### PR TITLE
add ranked FTS5 recall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,12 @@ integration.
 
 `core/` decomposes into `wiki.py` (the `Wiki` engine class), `format.py`
 (functions over the on-disk page format), `event.py` (the payload-only `Event`
-base), and `_obsidian.py` (the internal Obsidian integration). Engine
-diagnostics are typed notice events: each kind has an `on_<kind>` hook
-delegating to the `on_notice` funnel, which logs `event.description` through the
-stdlib `Wiki.logger`; hosts intercept by overriding hooks (the CLI swaps
-`on_notice` per instance to capture and condense narration).
+base), `_obsidian.py` (the internal Obsidian integration), and `_recall.py` (the
+internal SQLite FTS5 index). Engine diagnostics are typed notice events: each
+kind has an `on_<kind>` hook delegating to the `on_notice` funnel, which logs
+`event.description` through the stdlib `Wiki.logger`; hosts intercept by
+overriding hooks (the CLI swaps `on_notice` per instance to capture and condense
+narration).
 
 ## Build & Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Ranked full-text recall through `wiki recall`. A zero-dependency SQLite FTS5
+  index under `.wiki/cache/` refreshes incrementally before each query, weights
+  titles, headings, and tags above body prose, and supports subtree, tag,
+  prefix, raw-FTS5, limit, and JSON controls.
+
 ## [1.2.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ their work in project-specific knowledge.
 
 Every wiki root carries a `.wiki/` directory — the tool's namespace, holding
 `settings.json` (the file that declares the root; `wiki init` writes it and
-`wiki update` restores a missing one), the derived word counts cache, and the
-staged Obsidian config. Page, folder, and wiki names are lenient by default:
-spaces, dashes, mixed case, and unicode are all fine. Only characters that would
-break the wiki's structure — its path, link, and index syntax — are rejected,
-along with leading dots (hidden files) and the reserved `_index` name. A wiki
-can opt into stricter rules, such as ASCII-only or identifier-style names,
-through the `naming` block in `.wiki/settings.json`; `wiki lint` flags any name
-that violates the policy. Whole subtrees can be excluded from indexing with
-gitignore-style globs in `exclude.patterns` — excluded paths are never walked or
-linted, though `wiki read` still serves them.
+`wiki update` restores a missing one), the derived word counts and ranked
+full-text recall caches, and the staged Obsidian config. Page, folder, and wiki
+names are lenient by default: spaces, dashes, mixed case, and unicode are all
+fine. Only characters that would break the wiki's structure — its path, link,
+and index syntax — are rejected, along with leading dots (hidden files) and the
+reserved `_index` name. A wiki can opt into stricter rules, such as ASCII-only
+or identifier-style names, through the `naming` block in `.wiki/settings.json`;
+`wiki lint` flags any name that violates the policy. Whole subtrees can be
+excluded from indexing with gitignore-style globs in `exclude.patterns` —
+excluded paths are never walked or linted, though `wiki read` still serves them.
 
 Frontmatter timestamps default to UTC in ISO-8601. To change them, set a
 timezone (any IANA name) and format (a strftime string) under `timestamp` in
@@ -119,6 +119,13 @@ past a thousand. Descriptions print in full by default — `--desc-limit` (or th
 truncation — while `wiki map --stat` sizes the dump (lines, chars, words)
 without printing it. The map's indent unit and truncation marker are
 configurable via `map.indent` and `map.ellipsis` in `.wiki/settings.json`.
+
+Ranked recall uses the same self-ignored cache directory. `wiki recall` builds
+an SQLite FTS5 index on first use and refreshes added, changed, and removed
+Markdown pages before each query. BM25 ranking weights titles, headings, and
+frontmatter tags above body prose; the default query form safely combines terms
+with AND, while `--prefix`, `--tag`, `--raw`, and `--json` cover agent
+workflows.
 
 ### CLI
 
@@ -161,6 +168,7 @@ the positional rules, notes included, for just that span.
 Browse structure, search across content, and read entries:
 
 - `wiki map` — print an indented tree overview
+- `wiki recall` — rank relevant pages with SQLite FTS5
 - `wiki search` — search content with regex
 - `wiki read` — read a named entry
 
@@ -169,8 +177,8 @@ one (the root is the ancestor declaring itself with `.wiki/settings.json`; an
 undeclared index tree resolves to its outermost `_index.md`, unless the tree
 encloses a declared root — then resolution refuses and directs you to that
 root), or else on the `wiki/` folder under the current directory; pass `--path`
-to target another wiki. `map`, `search`, `update`, and `lint` accept an optional
-name argument to restrict scope to a subtree. Run `wiki --help` and
+to target another wiki. `map`, `recall`, `search`, `update`, and `lint` accept
+an optional name argument to restrict scope to a subtree. Run `wiki --help` and
 `wiki <command> --help` for full option descriptions.
 
 ### Formatters

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -40,9 +40,9 @@ run and points at ``wiki trust``. There is no silent fallback.
 Subtree scope
 ~~~~~~~~~~~~~
 
-``map``, ``recall``, ``search``, ``update``, and ``lint`` take an optional positional
-``name`` argument restricting the operation to a subtree. The scope must
-resolve to a directory relative to the wiki root — a page name fails with
+``map``, ``recall``, ``search``, ``update``, and ``lint`` take an optional
+positional ``name`` argument restricting the operation to a subtree. The scope
+must resolve to a directory relative to the wiki root — a page name fails with
 ``Wiki folder not found: '<name>'``. A scope outside the root is refused, as
 is one inside an excluded directory — dot-prefixed (``.wiki``, ``.git``,
 ``.obsidian``), symlinked, or matched by ``exclude.patterns``, the last
@@ -57,8 +57,8 @@ slice/``--depth``/``--desc-limit`` value, or malformed ``--settings`` JSON —
 prints a usage message and exits 2 instead; a closed downstream pipe exits 0
 silently. Some commands carry their own exit-code conventions, documented in
 their sections: ``search`` and ``recall`` follow the grep convention (0 match,
-1 no match, 2 error), ``update --check`` exits 1 when changes are pending, and ``lint``
-exits 1 when issues are found.
+1 no match, 2 error), ``update --check`` exits 1 when changes are pending, and
+``lint`` exits 1 when issues are found.
 
 ``wiki install``
 ----------------

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -420,7 +420,7 @@ FTS5 support, or unresolved wiki exits 2.
    [
      {
        "path": "topics/parser.md",
-       "snippet": "The «parser» follows the project «architecture»...",
+       "snippet": "The >>parser<< follows the project >>architecture<<...",
        "score": 2.417
      }
    ]

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -40,7 +40,7 @@ run and points at ``wiki trust``. There is no silent fallback.
 Subtree scope
 ~~~~~~~~~~~~~
 
-``map``, ``search``, ``update``, and ``lint`` take an optional positional
+``map``, ``recall``, ``search``, ``update``, and ``lint`` take an optional positional
 ``name`` argument restricting the operation to a subtree. The scope must
 resolve to a directory relative to the wiki root — a page name fails with
 ``Wiki folder not found: '<name>'``. A scope outside the root is refused, as
@@ -56,8 +56,8 @@ exits 1; invalid option usage — mutually exclusive flags, a bad
 slice/``--depth``/``--desc-limit`` value, or malformed ``--settings`` JSON —
 prints a usage message and exits 2 instead; a closed downstream pipe exits 0
 silently. Some commands carry their own exit-code conventions, documented in
-their sections: ``search`` follows the grep convention (0 match, 1 no match,
-2 error), ``update --check`` exits 1 when changes are pending, and ``lint``
+their sections: ``search`` and ``recall`` follow the grep convention (0 match,
+1 no match, 2 error), ``update --check`` exits 1 when changes are pending, and ``lint``
 exits 1 when issues are found.
 
 ``wiki install``
@@ -356,6 +356,74 @@ body search.
    $ wiki search -i 'parser' topics
    topics/example.md
    topics/parser.md
+
+``wiki recall``
+---------------
+
+.. code-block:: text
+
+   wiki recall <query> [name] [--path <dir>] [--limit <n>] [--prefix]
+               [--tag <tag>] [--raw] [--json]
+
+Returns relevant Markdown pages from a local SQLite FTS5 index. The index lives
+at ``.wiki/cache/recall.db``, where the cache's own ``.gitignore`` keeps all
+derived state out of commits. Every query first compares path, mtime, and size,
+then updates only added, changed, or removed pages. No explicit build command
+is required.
+
+Ordinary queries quote each whitespace-separated term and combine the terms
+with AND, so FTS5 operators in user text are not executed. ``--prefix`` turns
+the final term into a prefix query. ``--raw`` opts into the full FTS5 query
+grammar instead. BM25 ranks title, heading, and frontmatter-tag matches above
+body prose. Default output prints score, path, and a highlighted body snippet;
+``--json`` emits objects with ``path``, ``snippet``, and ``score`` keys.
+
+The exit code follows the grep convention: matches exit 0; no match prints
+``No matches found.`` on stderr and exits 1; an invalid FTS5 query, unavailable
+FTS5 support, or unresolved wiki exits 2.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 18 56
+
+   * - Argument / option
+     - Default
+     - Behavior
+   * - ``query`` (positional, required)
+     - —
+     - Terms to recall, or raw FTS5 syntax with ``--raw``.
+   * - ``name`` (positional)
+     - the whole wiki
+     - Restrict scope to a subtree (must be a folder).
+   * - ``--path``
+     - the enclosing wiki root
+     - Wiki root directory (see `Wiki root resolution`_).
+   * - ``--limit``
+     - ``10``
+     - Maximum number of ranked pages to return (at least 1).
+   * - ``--prefix``
+     - off
+     - Treat the final ordinary-query term as a prefix.
+   * - ``--tag``
+     - none
+     - Require a matching frontmatter tag token.
+   * - ``--raw``
+     - off
+     - Interpret ``query`` as raw FTS5 syntax.
+   * - ``--json``
+     - off
+     - Emit structured results for agents and scripts.
+
+.. code-block:: console
+
+   $ wiki recall 'parser architecture' topics --json
+   [
+     {
+       "path": "topics/parser.md",
+       "snippet": "The «parser» follows the project «architecture»...",
+       "score": 2.417
+     }
+   ]
 
 ``wiki update``
 ---------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -260,8 +260,8 @@ default: ``wiki update`` warns per row, naming the matching pattern, and
 ``wiki update --prune`` removes the row with the normal prune notice. Prose
 wikilinks into excluded-but-present files stay live — the generated index
 link block is the hard surface, body prose is not. Scoping ``update``,
-``lint``, ``map``, or ``search`` at or under an excluded directory is
-refused with an error naming the pattern.
+``lint``, ``map``, ``recall``, or ``search`` at or under an excluded
+directory is refused with an error naming the pattern.
 
 Any ``_index.md`` files already inside an excluded subtree become inert
 unmanaged bytes — never rewritten, never deleted. A nested wiki (a

--- a/docs/guide/structure.rst
+++ b/docs/guide/structure.rst
@@ -40,9 +40,9 @@ excluded from the tree entirely:
 - **Paths matching ``exclude.patterns``** — opt-in gitignore-style globs in
   ``.wiki/settings.json`` (see :doc:`/configuration`).
 
-``wiki map``, ``wiki search``, ``wiki update``, and ``wiki lint`` all accept
-an optional positional argument naming a subtree to work on. It must be a
-folder, not a page:
+``wiki map``, ``wiki recall``, ``wiki search``, ``wiki update``, and
+``wiki lint`` all accept an optional positional argument naming a subtree
+to work on. It must be a folder, not a page:
 
 .. code-block:: console
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -377,7 +377,7 @@ refresh changed, added, and removed Markdown pages before querying it:
    [
      {
        "path": "topics/parser.md",
-       "snippet": "The «parser» follows the project «architecture»...",
+       "snippet": "The >>parser<< follows the project >>architecture<<...",
        "score": 2.417
      }
    ]

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -367,6 +367,25 @@ Search follows the grep convention — a match exits 0, no match prints ``No
 matches found.`` on stderr and exits 1, and an error (bad regex, no resolvable
 wiki) exits 2 — so scripts branch on the exit code rather than parse output.
 
+Use ranked recall when relevance matters more than exact matching lines. The
+first call builds a self-ignored SQLite FTS5 index; later calls incrementally
+refresh changed, added, and removed Markdown pages before querying it:
+
+.. code-block:: console
+
+   $ wiki recall 'parser architecture' topics --json
+   [
+     {
+       "path": "topics/parser.md",
+       "snippet": "The «parser» follows the project «architecture»...",
+       "score": 2.417
+     }
+   ]
+
+Safe queries combine whitespace-separated terms with AND. Add ``--prefix``
+for partial final terms, ``--tag <tag>`` for a frontmatter-tag filter, or
+``--raw`` when the caller intentionally supplies FTS5 syntax.
+
 Read entries
 ~~~~~~~~~~~~
 

--- a/docs/skill.rst
+++ b/docs/skill.rst
@@ -115,13 +115,15 @@ guesses they might.
 The workflow it drives
 ----------------------
 
-Navigating: map, search, read
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Navigating: map, recall, search, read
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For consuming a wiki, the skill directs the agent to the read commands:
 
 - ``wiki map`` for an indented tree overview — the agent's first move when
   orienting in an unfamiliar wiki, scoped and filtered as needed.
+- ``wiki recall`` for ranked lexical retrieval when the agent needs the most
+  relevant pages and snippets rather than exact matching lines.
 - ``wiki search`` for regex search over page content (or frontmatter fields
   with ``--field``).
 - ``wiki read`` to print a named entry, optionally sliced by lines, words, or

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -1128,7 +1128,7 @@ def test_recall_ranked_and_json_output(wiki: pathlib.Path) -> None:
     rendered = _wiki(wiki, 'recall', 'widget', '--path', str(wiki))
     assert rendered.returncode == 0, rendered.stdout + rendered.stderr
     assert 'core/design.md' in rendered.stdout
-    assert '«widget»' in rendered.stdout
+    assert '>>widget<<' in rendered.stdout
 
     structured = _wiki(
         wiki,

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -1156,6 +1156,32 @@ def test_recall_exit_codes(wiki: pathlib.Path) -> None:
     assert invalid.returncode == 2
     assert 'Error:' in invalid.stderr
 
+    conflict = _wiki(
+        wiki,
+        'recall',
+        'widget',
+        '--prefix',
+        '--raw',
+        '--path',
+        str(wiki),
+    )
+    assert conflict.returncode == 2
+    assert 'Usage:' in (conflict.stdout + conflict.stderr)
+    assert 'mutually exclusive' in (conflict.stdout + conflict.stderr).lower()
+
+    invalid_limit = _wiki(
+        wiki,
+        'recall',
+        'widget',
+        '--limit',
+        '0',
+        '--path',
+        str(wiki),
+    )
+    assert invalid_limit.returncode == 2
+    assert 'Usage:' in (invalid_limit.stdout + invalid_limit.stderr)
+    assert '--limit must be >= 1' in (invalid_limit.stdout + invalid_limit.stderr)
+
 
 # ------ read
 

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -63,6 +63,8 @@ __all__ = [
     'test_search_invalid_regex_reports_error',
     'test_search_resolution_failure_exits_two',
     'test_search_all_skips_undecodable_files',
+    'test_recall_ranked_and_json_output',
+    'test_recall_exit_codes',
     'test_read_slice_forms',
     'test_read_resolves_dotted_page_name',
     'test_read_errors',
@@ -1116,6 +1118,43 @@ def test_search_all_skips_undecodable_files(wiki: pathlib.Path) -> None:
         assert 'snippet.txt' in result.stdout
     finally:
         binary.unlink()
+
+
+# ------ recall
+
+
+def test_recall_ranked_and_json_output(wiki: pathlib.Path) -> None:
+    """Recall returns ranked snippets and structured output for agents."""
+    rendered = _wiki(wiki, 'recall', 'widget', '--path', str(wiki))
+    assert rendered.returncode == 0, rendered.stdout + rendered.stderr
+    assert 'core/design.md' in rendered.stdout
+    assert '«widget»' in rendered.stdout
+
+    structured = _wiki(
+        wiki,
+        'recall',
+        'widg',
+        '--prefix',
+        '--json',
+        '--path',
+        str(wiki),
+    )
+    assert structured.returncode == 0, structured.stdout + structured.stderr
+    results = json.loads(structured.stdout)
+    assert results[0]['path'] == 'core/design.md'
+    assert set(results[0]) == {'path', 'snippet', 'score'}
+
+
+def test_recall_exit_codes(wiki: pathlib.Path) -> None:
+    """Recall distinguishes a clean miss from invalid FTS input."""
+    missing = _wiki(wiki, 'recall', 'zzz_no_such_token', '--path', str(wiki))
+    assert missing.returncode == 1
+    assert 'No matches' in missing.stderr
+    assert missing.stdout == ''
+
+    invalid = _wiki(wiki, 'recall', '[', '--raw', '--path', str(wiki))
+    assert invalid.returncode == 2
+    assert 'Error:' in invalid.stderr
 
 
 # ------ read

--- a/tests/test_core/test_recall.py
+++ b/tests/test_core/test_recall.py
@@ -1,0 +1,78 @@
+"""Behavioral tests for ranked FTS5 wiki recall."""
+
+from __future__ import annotations
+
+import pathlib
+
+from ._helpers import _make_wiki
+
+__all__ = [
+    'test_recall_ranks_metadata_and_refreshes_incrementally',
+    'test_recall_supports_scope_tags_prefixes_and_raw_queries',
+]
+
+
+def test_recall_ranks_metadata_and_refreshes_incrementally(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Recall ranks metadata first and never serves stale derived rows.
+
+    The first query creates the ignored cache. Later queries detect a new page
+    and a removed page directly from filesystem signatures, without requiring
+    ``wiki update`` or an explicit index command.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': []})
+    title_hit = tmp_path / 'core' / 'title-hit.md'
+    title_hit.write_text(
+        '---\nname: core/title-hit\ntitle: Mnemosyne\ndesc: A page.\n'
+        'tags: [memory]\n---\n\n# title-hit\n\nShort body.\n',
+        encoding='utf-8',
+    )
+    body_hit = tmp_path / 'core' / 'body-hit.md'
+    body_hit.write_text(
+        '---\nname: core/body-hit\ndesc: A page.\ntags: []\n---\n\n'
+        '# body-hit\n\nMnemosyne appears in ordinary prose.\n',
+        encoding='utf-8',
+    )
+
+    matches = wiki.recall('mnemosyne')
+    assert matches[0][0] == 'core/title-hit.md'
+    assert (tmp_path / '.wiki' / 'cache' / 'recall.db').is_file()
+    assert (tmp_path / '.wiki' / 'cache' / '.gitignore').read_text(
+        encoding='utf-8'
+    ).strip() == '*'
+
+    fresh = tmp_path / 'core' / 'fresh.md'
+    fresh.write_text('# fresh\n\nA newly authored quasarlex page.\n', encoding='utf-8')
+    assert wiki.recall('quasarlex')[0][0] == 'core/fresh.md'
+
+    title_hit.unlink()
+    assert all(path != 'core/title-hit.md' for path, _, _ in wiki.recall('mnemosyne'))
+
+
+def test_recall_supports_scope_tags_prefixes_and_raw_queries(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Safe queries compose with tag and subtree filters; raw FTS stays opt-in."""
+    wiki = _make_wiki(tmp_path, folders={'core': [], 'guides': []})
+    (tmp_path / 'core' / 'agents.md').write_text(
+        '---\nname: core/agents\ndesc: A page.\ntags: [agents]\n---\n\n'
+        '# agents\n\nZettelkasten context for autonomous work.\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'guides' / 'notes.md').write_text(
+        '---\nname: guides/notes\ndesc: A page.\ntags: [writing]\n---\n\n'
+        '# notes\n\nZettelkasten context for authors.\n',
+        encoding='utf-8',
+    )
+
+    tagged = wiki.recall('zettel', prefix=True, tag='agents')
+    assert [path for path, _, _ in tagged] == ['core/agents.md']
+    scoped = wiki.recall('zettelkasten', name='guides')
+    assert [path for path, _, _ in scoped] == ['guides/notes.md']
+    raw = wiki.recall('zettel* OR autonomous', raw=True)
+    assert {path for path, _, _ in raw} == {
+        'core/agents.md',
+        'guides/notes.md',
+    }
+    assert wiki.recall('zettelkasten" OR title:escape AND (') == []

--- a/tests/test_core/test_recall.py
+++ b/tests/test_core/test_recall.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import shutil
 
 import pytest
 
@@ -13,6 +14,8 @@ __all__ = [
     'test_recall_supports_scope_tags_prefixes_and_raw_queries',
     'test_recall_scopes_to_exact_subtree',
     'test_recall_does_not_reread_unchanged_unreadable_pages',
+    'test_recall_retries_indexed_pages_after_a_transient_read_failure',
+    'test_recall_rebuilds_a_corrupt_index',
 ]
 
 
@@ -38,6 +41,9 @@ def test_recall_ranks_metadata_and_refreshes_incrementally(
         '# body-hit\n\nMnemosyne appears in ordinary prose.\n',
         encoding='utf-8',
     )
+    # drop the cache update() seeded, so the first query's own cache write
+    # is what the assertions below see
+    shutil.rmtree(tmp_path / '.wiki' / 'cache')
 
     matches = wiki.recall('mnemosyne')
     assert matches[0][0] == 'core/title-hit.md'
@@ -129,3 +135,47 @@ def test_recall_does_not_reread_unchanged_unreadable_pages(
     assert wiki.recall('hidden') == []
     assert wiki.recall('hidden') == []
     assert attempts == 1
+
+
+def test_recall_retries_indexed_pages_after_a_transient_read_failure(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed re-read keeps serving the stale row and retries next query."""
+    wiki = _make_wiki(tmp_path, folders={'core': []})
+    page = tmp_path / 'core' / 'page.md'
+    page.write_text('# page\n\nFirsttoken draft.\n', encoding='utf-8')
+    assert wiki.recall('firsttoken')[0][0] == 'core/page.md'
+
+    page.write_text('# page\n\nSecondtoken revision.\n', encoding='utf-8')
+    original_read_text = pathlib.Path.read_text
+
+    def read_text(
+        path: pathlib.Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> str:
+        if path == page:
+            raise OSError('transient')
+        return original_read_text(path, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(pathlib.Path, 'read_text', read_text)
+    assert wiki.recall('firsttoken')[0][0] == 'core/page.md'
+    assert wiki.recall('secondtoken') == []
+
+    monkeypatch.undo()
+    assert wiki.recall('secondtoken')[0][0] == 'core/page.md'
+
+
+def test_recall_rebuilds_a_corrupt_index(tmp_path: pathlib.Path) -> None:
+    """A corrupt index file is discarded and rebuilt, never fatal."""
+    wiki = _make_wiki(tmp_path, folders={'core': []})
+    (tmp_path / 'core' / 'page.md').write_text(
+        '# page\n\nCorrupttoken prose.\n',
+        encoding='utf-8',
+    )
+    assert wiki.recall('corrupttoken')[0][0] == 'core/page.md'
+
+    cache = tmp_path / '.wiki' / 'cache' / 'recall.db'
+    cache.write_bytes(b'junk')
+    assert wiki.recall('corrupttoken')[0][0] == 'core/page.md'

--- a/tests/test_core/test_recall.py
+++ b/tests/test_core/test_recall.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import pathlib
 
+import pytest
+
 from ._helpers import _make_wiki
 
 __all__ = [
     'test_recall_ranks_metadata_and_refreshes_incrementally',
     'test_recall_supports_scope_tags_prefixes_and_raw_queries',
+    'test_recall_scopes_to_exact_subtree',
+    'test_recall_does_not_reread_unchanged_unreadable_pages',
 ]
 
 
@@ -76,3 +80,52 @@ def test_recall_supports_scope_tags_prefixes_and_raw_queries(
         'guides/notes.md',
     }
     assert wiki.recall('zettelkasten" OR title:escape AND (') == []
+    with pytest.raises(ValueError, match='fts5'):
+        wiki.recall('[', raw=True)
+
+
+def test_recall_scopes_to_exact_subtree(tmp_path: pathlib.Path) -> None:
+    """Subtree names treat SQL wildcard characters as literal path text."""
+    wiki = _make_wiki(
+        tmp_path,
+        folders={'my_notes': [], 'myxnotes': [], 'myxnotes/sub': []},
+    )
+    (tmp_path / 'my_notes' / 'inside.md').write_text(
+        '# inside\n\nSharedtoken belongs here.\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'myxnotes' / 'sub' / 'outside.md').write_text(
+        '# outside\n\nSharedtoken belongs elsewhere.\n',
+        encoding='utf-8',
+    )
+
+    matches = wiki.recall('sharedtoken', name='my_notes')
+    assert [path for path, _, _ in matches] == ['my_notes/inside.md']
+
+
+def test_recall_does_not_reread_unchanged_unreadable_pages(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unchanged read failure stays off the incremental refresh path."""
+    wiki = _make_wiki(tmp_path, folders={'core': []})
+    unreadable = tmp_path / 'core' / 'unreadable.md'
+    unreadable.write_text('# unreadable\n\nHidden token.\n', encoding='utf-8')
+    original_read_text = pathlib.Path.read_text
+    attempts = 0
+
+    def read_text(
+        path: pathlib.Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+    ) -> str:
+        nonlocal attempts
+        if path == unreadable:
+            attempts += 1
+            raise OSError('unreadable')
+        return original_read_text(path, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(pathlib.Path, 'read_text', read_text)
+    assert wiki.recall('hidden') == []
+    assert wiki.recall('hidden') == []
+    assert attempts == 1

--- a/wiki/cli/cmd/wiki.py
+++ b/wiki/cli/cmd/wiki.py
@@ -610,6 +610,14 @@ def recall(
         A match exits 0, no match exits 1, and an invalid query or unresolved
         wiki exits 2.
         """
+        if prefix and raw:
+            raise typer.BadParameter('--prefix and --raw are mutually exclusive.')
+        if limit < 1:
+            raise typer.BadParameter('--limit must be >= 1.')
+        # every failure here -- invalid FTS input, an unresolvable wiki or
+        # subtree, a refused or broken hook -- is the triple's error leg,
+        # so the catch is total: a per-type list would leak new failure
+        # modes to the wrapper's exit 1, aliasing them with a no-match
         try:
             wiki = resolve(path)
             matches = wiki.recall(
@@ -621,8 +629,12 @@ def recall(
                 raw=raw,
             )
         except Exception as e:
+            # grep triple: runtime errors exit 2 (the wrapper's exception
+            # path exits 1), so the body renders in the wrapper's grammar
             typer.echo(f'Error: {e}', err=True)
             raise typer.Exit(code=2) from e
+        # grep convention: no-match exits 1 with the notice on stderr, so
+        # scripts can distinguish no-match from match by exit code alone
         if not matches:
             typer.echo('No matches found.', err=True)
             raise SystemExit(1)

--- a/wiki/cli/cmd/wiki.py
+++ b/wiki/cli/cmd/wiki.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.resources
+import json
 import pathlib
 import shutil
 import subprocess
@@ -48,6 +49,7 @@ __all__ = [
     'trust',
     'read',
     'search',
+    'recall',
     'update',
     'lint',
     'map',
@@ -552,6 +554,88 @@ def search(
                 if relpath not in seen:
                     seen.add(relpath)
                     typer.echo(relpath)
+
+    return app
+
+
+def recall(
+    app: typer.Typer,
+    *,
+    resolve: Callable[[Optional[str]], Wiki] = resolve_wiki,
+) -> typer.Typer:
+    """Register the ``recall`` command."""
+    # search query argument
+    query_help = 'Terms to recall, combined with AND by default.'
+    query = typer.Argument(..., help=query_help)
+    # folder name argument
+    name_help = 'Restrict scope to named subtree (relative path).'
+    name = typer.Argument(None, help=name_help)
+    # wiki root option
+    path_help = (
+        'Wiki root directory. Defaults to the enclosing wiki root (the'
+        ' ancestor declaring .wiki/settings.json, else the outermost'
+        ' _index.md chain), else {cwd}/wiki/.'
+    )
+    path = typer.Option(None, '--path', help=path_help)
+    # result limit option
+    limit_help = 'Maximum number of ranked pages to return.'
+    limit = typer.Option(10, '--limit', help=limit_help)
+    # prefix flag
+    prefix_help = 'Treat the final query term as a prefix.'
+    prefix = typer.Option(False, '--prefix', help=prefix_help)
+    # tag filter option
+    tag_help = 'Require a frontmatter tag token.'
+    tag = typer.Option('', '--tag', help=tag_help)
+    # raw query flag
+    raw_help = 'Interpret the query as raw FTS5 syntax.'
+    raw = typer.Option(False, '--raw', help=raw_help)
+    # JSON output flag
+    json_help = 'Emit structured JSON results.'
+    as_json = typer.Option(False, '--json', help=json_help)
+
+    @command(app, 'recall')
+    def _recall(
+        query: str = query,
+        name: Optional[str] = name,
+        path: Optional[str] = path,
+        limit: int = limit,
+        prefix: bool = prefix,
+        tag: str = tag,
+        raw: bool = raw,
+        as_json: bool = as_json,
+    ) -> None:
+        """Recall relevant wiki pages through ranked full-text search.
+
+        The derived FTS5 index refreshes incrementally before each query.
+        A match exits 0, no match exits 1, and an invalid query or unresolved
+        wiki exits 2.
+        """
+        try:
+            wiki = resolve(path)
+            matches = wiki.recall(
+                query,
+                name=name,
+                limit=limit,
+                prefix=prefix,
+                tag=tag,
+                raw=raw,
+            )
+        except Exception as e:
+            typer.echo(f'Error: {e}', err=True)
+            raise typer.Exit(code=2) from e
+        if not matches:
+            typer.echo('No matches found.', err=True)
+            raise SystemExit(1)
+        elif as_json:
+            results = [
+                {'path': path, 'snippet': snippet, 'score': score}
+                for path, snippet, score in matches
+            ]
+            output = json.dumps(results, ensure_ascii=False, indent=2)
+            typer.echo(output)
+        else:
+            for path, snippet, score in matches:
+                typer.echo(f'{score:>7.3f}  {path}\n         {snippet}')
 
     return app
 

--- a/wiki/cli/main.py
+++ b/wiki/cli/main.py
@@ -25,6 +25,7 @@ def cli(**kwargs: Any) -> None:
     cmd.trust(app)
     cmd.read(app)
     cmd.search(app)
+    cmd.recall(app)
     cmd.update(app)
     cmd.lint(app)
     cmd.map(app)

--- a/wiki/core/_memory.py
+++ b/wiki/core/_memory.py
@@ -1,0 +1,243 @@
+"""SQLite FTS5 index for ranked wiki recall."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sqlite3
+import unicodedata
+from collections.abc import Iterable
+
+from wiki.constants import WIKI_CACHE
+from wiki.util.filesystem import write_atomic
+
+from . import format
+
+__all__ = []
+
+_CACHE_NAME = 'recall.db'
+_SCHEMA_VERSION = '1'
+_HEADING = re.compile(r'^#{1,6}\s+(.*)$', re.MULTILINE)
+
+
+def fts5_available() -> bool:
+    """Return whether the running Python's SQLite exposes FTS5."""
+    try:
+        connection = sqlite3.connect(':memory:')
+        connection.execute('CREATE VIRTUAL TABLE probe USING fts5(text)')
+        connection.close()
+        return True
+    except sqlite3.OperationalError:
+        return False
+
+
+def recall(
+    root: pathlib.Path,
+    files: Iterable[pathlib.Path],
+    query: str,
+    *,
+    folder: pathlib.Path,
+    limit: int = 10,
+    prefix: bool = False,
+    tag: str = '',
+    raw: bool = False,
+) -> list[tuple[str, str, float]]:
+    """Refresh the derived index and return ranked full-text matches.
+
+    Args:
+        root: Wiki root.
+        files: Markdown files visible to the wiki walk.
+        query: Search terms, or an FTS5 expression when ``raw`` is set.
+        folder: Resolved subtree scope.
+        limit: Maximum number of matches.
+        prefix: Treat the final safe-query term as a prefix.
+        tag: Require this frontmatter tag token.
+        raw: Pass ``query`` through as FTS5 syntax.
+
+    Returns:
+        ``(relative_path, snippet, score)`` tuples ordered by relevance.
+
+    Raises:
+        RuntimeError: If SQLite was built without FTS5.
+        ValueError: If the query or limit is invalid.
+
+    """
+    if not fts5_available():
+        raise RuntimeError("This Python's sqlite3 module lacks FTS5 support.")
+    if limit < 1:
+        raise ValueError('limit must be at least 1')
+    expression = _match_expression(query, prefix=prefix, tag=tag, raw=raw)
+
+    connection = _open(root)
+    try:
+        _refresh(connection, root, files)
+        sql = (
+            'SELECT path, '
+            "snippet(notes_fts, 3, '«', '»', '…', 12), "
+            'bm25(notes_fts, 10.0, 4.0, 6.0, 1.0) '
+            'FROM notes_fts WHERE notes_fts MATCH ?'
+        )
+        parameters: list[object] = [expression]
+        if folder != root:
+            relative = _relative(folder, root)
+            sql += ' AND (folder = ? OR folder LIKE ?)'
+            parameters.extend((relative, relative.rstrip('/') + '/%'))
+        sql += ' ORDER BY bm25(notes_fts, 10.0, 4.0, 6.0, 1.0) LIMIT ?'
+        parameters.append(limit)
+        rows = connection.execute(sql, parameters).fetchall()
+    finally:
+        connection.close()
+
+    return [
+        (path, ' '.join(snippet.split()), round(-rank, 3))
+        for path, snippet, rank in rows
+    ]
+
+
+def _open(root: pathlib.Path) -> sqlite3.Connection:
+    """Open the self-ignored derived index under ``.wiki/cache``."""
+    cache = root / WIKI_CACHE
+    cache.mkdir(parents=True, exist_ok=True)
+    gitignore = cache / '.gitignore'
+    if not gitignore.exists():
+        write_atomic(gitignore, '*\n')
+    connection = sqlite3.connect(cache / _CACHE_NAME)
+    connection.execute('PRAGMA journal_mode=WAL')
+    connection.execute('PRAGMA busy_timeout=5000')
+    return connection
+
+
+def _refresh(
+    connection: sqlite3.Connection,
+    root: pathlib.Path,
+    files: Iterable[pathlib.Path],
+) -> None:
+    """Incrementally refresh rows whose mtime or size changed."""
+    _ensure_schema(connection)
+    present = {}
+    for path in sorted(set(files)):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        relative = _relative(path, root)
+        present[relative] = (path, stat.st_mtime_ns, stat.st_size)
+
+    indexed = {
+        path: (mtime_ns, size)
+        for path, mtime_ns, size in connection.execute(
+            'SELECT path, mtime_ns, size FROM files'
+        )
+    }
+    removed = set(indexed) - set(present)
+    changed = {
+        path
+        for path, (_, mtime_ns, size) in present.items()
+        if indexed.get(path) != (mtime_ns, size)
+    }
+
+    with connection:
+        for relative in removed:
+            connection.execute('DELETE FROM notes_fts WHERE path = ?', (relative,))
+            connection.execute('DELETE FROM files WHERE path = ?', (relative,))
+        for relative in changed:
+            path, mtime_ns, size = present[relative]
+            try:
+                text = path.read_text(encoding='utf-8')
+            except (OSError, UnicodeDecodeError):
+                connection.execute('DELETE FROM notes_fts WHERE path = ?', (relative,))
+                connection.execute('DELETE FROM files WHERE path = ?', (relative,))
+                continue
+            title, headings, tags, body = _fields(path, text)
+            folder = str(pathlib.PurePath(relative).parent)
+            connection.execute('DELETE FROM notes_fts WHERE path = ?', (relative,))
+            connection.execute(
+                'INSERT INTO notes_fts(title, headings, tags, body, path, folder) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                (title, headings, tags, body, relative, folder),
+            )
+            connection.execute(
+                'INSERT INTO files(path, mtime_ns, size) VALUES (?, ?, ?) '
+                'ON CONFLICT(path) DO UPDATE SET '
+                'mtime_ns=excluded.mtime_ns, size=excluded.size',
+                (relative, mtime_ns, size),
+            )
+
+
+def _ensure_schema(connection: sqlite3.Connection) -> None:
+    """Create the FTS schema, rebuilding derived rows after a version change."""
+    connection.execute(
+        'CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)'
+    )
+    version = connection.execute(
+        "SELECT value FROM meta WHERE key = 'schema_version'"
+    ).fetchone()
+    if version and version[0] != _SCHEMA_VERSION:
+        connection.execute('DROP TABLE IF EXISTS notes_fts')
+        connection.execute('DROP TABLE IF EXISTS files')
+    connection.execute(
+        'CREATE TABLE IF NOT EXISTS files ('
+        'path TEXT PRIMARY KEY, mtime_ns INTEGER NOT NULL, size INTEGER NOT NULL)'
+    )
+    connection.execute(
+        'CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5('
+        'title, headings, tags, body, path UNINDEXED, folder UNINDEXED, '
+        'tokenize="unicode61 remove_diacritics 2", prefix="2 3")'
+    )
+    connection.execute(
+        "INSERT INTO meta(key, value) VALUES('schema_version', ?) "
+        'ON CONFLICT(key) DO UPDATE SET value=excluded.value',
+        (_SCHEMA_VERSION,),
+    )
+    connection.commit()
+
+
+def _fields(path: pathlib.Path, text: str) -> tuple[str, str, str, str]:
+    """Extract weighted fields from one Markdown page."""
+    frontmatter, body = format.parse_page(text)
+    values = [path.stem]
+    if frontmatter:
+        name = format.read_frontmatter_name(frontmatter)
+        title = format.read_frontmatter_title(frontmatter)
+        for value in (name, title):
+            if value and value not in values:
+                values.append(value)
+        tags = format.read_frontmatter_field(frontmatter, 'tags') or ''
+    else:
+        tags = ''
+    headings = ' '.join(_HEADING.findall(body))
+    return ' '.join(values), headings, tags, body
+
+
+def _match_expression(
+    query: str,
+    *,
+    prefix: bool,
+    tag: str,
+    raw: bool,
+) -> str:
+    """Build an FTS5 expression, quoting ordinary user terms."""
+    if raw:
+        if prefix:
+            raise ValueError('prefix cannot be combined with a raw query')
+        expression = query.strip()
+        if not expression:
+            raise ValueError('empty query')
+    else:
+        terms = query.split()
+        if not terms:
+            raise ValueError('empty query')
+        quoted = ['"' + term.replace('"', '""') + '"' for term in terms]
+        if prefix:
+            quoted[-1] += '*'
+        expression = ' '.join(quoted)
+    if tag:
+        value = tag.replace('"', '""')
+        expression = f'({expression}) AND tags:"{value}"'
+    return expression
+
+
+def _relative(path: pathlib.Path, root: pathlib.Path) -> str:
+    """Return an NFC-normalized POSIX path relative to the wiki root."""
+    relative = path.relative_to(root).as_posix()
+    return unicodedata.normalize('NFC', relative)

--- a/wiki/core/_recall.py
+++ b/wiki/core/_recall.py
@@ -73,7 +73,7 @@ def recall(
         _refresh(connection, root, files)
         sql = (
             'SELECT path, '
-            "snippet(notes_fts, 3, '«', '»', '…', 12), "
+            "snippet(notes_fts, 3, '>>', '<<', '...', 12), "
             'bm25(notes_fts, 10.0, 4.0, 6.0, 1.0) '
             'FROM notes_fts WHERE notes_fts MATCH ?'
         )
@@ -105,7 +105,19 @@ def _open(root: pathlib.Path) -> sqlite3.Connection:
     gitignore = cache / '.gitignore'
     if not gitignore.exists():
         wiki.util.fs.write_atomic(gitignore, '*\n')
-    connection = sqlite3.connect(cache / _CACHE_NAME)
+    try:
+        return _connect(cache / _CACHE_NAME)
+    except sqlite3.DatabaseError:
+        # a corrupt index is derived state: discard it and rebuild once,
+        # the same contract the word-counts cache honors
+        for suffix in ('', '-wal', '-shm'):
+            (cache / (_CACHE_NAME + suffix)).unlink(missing_ok=True)
+        return _connect(cache / _CACHE_NAME)
+
+
+def _connect(path: pathlib.Path) -> sqlite3.Connection:
+    """Open the index database and apply its connection pragmas."""
+    connection = sqlite3.connect(path)
     connection.execute('PRAGMA journal_mode=WAL')
     connection.execute('PRAGMA busy_timeout=5000')
     return connection
@@ -146,6 +158,21 @@ def _refresh(
             connection.execute('DELETE FROM files WHERE path = ?', (relative,))
         for relative in changed:
             path, mtime_ns, size = present[relative]
+            # read before mutating: a failed read leaves an indexed page
+            # serving its stale row, to be retried on the next refresh
+            try:
+                text = path.read_text(encoding='utf-8')
+            except (OSError, UnicodeDecodeError):
+                # only a never-indexed page earns a tombstone signature, so
+                # the unreadable file is not re-read on every query
+                if relative not in indexed:
+                    connection.execute(
+                        'INSERT INTO files(path, mtime_ns, size) VALUES (?, ?, ?)',
+                        (relative, mtime_ns, size),
+                    )
+                continue
+            title, headings, tags, body = _fields(path, text)
+            folder = str(pathlib.PurePath(relative).parent)
             connection.execute('DELETE FROM notes_fts WHERE path = ?', (relative,))
             connection.execute(
                 'INSERT INTO files(path, mtime_ns, size) VALUES (?, ?, ?) '
@@ -153,12 +180,6 @@ def _refresh(
                 'mtime_ns=excluded.mtime_ns, size=excluded.size',
                 (relative, mtime_ns, size),
             )
-            try:
-                text = path.read_text(encoding='utf-8')
-            except (OSError, UnicodeDecodeError):
-                continue
-            title, headings, tags, body = _fields(path, text)
-            folder = str(pathlib.PurePath(relative).parent)
             connection.execute(
                 'INSERT INTO notes_fts(title, headings, tags, body, path, folder) '
                 'VALUES (?, ?, ?, ?, ?, ?)',

--- a/wiki/core/_recall.py
+++ b/wiki/core/_recall.py
@@ -8,8 +8,8 @@ import sqlite3
 import unicodedata
 from collections.abc import Iterable
 
+import wiki.util
 from wiki.constants import WIKI_CACHE
-from wiki.util.filesystem import write_atomic
 
 from . import format
 
@@ -80,11 +80,15 @@ def recall(
         parameters: list[object] = [expression]
         if folder != root:
             relative = _relative(folder, root)
-            sql += ' AND (folder = ? OR folder LIKE ?)'
-            parameters.extend((relative, relative.rstrip('/') + '/%'))
+            prefix_path = relative.rstrip('/') + '/'
+            sql += ' AND (folder = ? OR substr(folder, 1, ?) = ?)'
+            parameters.extend((relative, len(prefix_path), prefix_path))
         sql += ' ORDER BY bm25(notes_fts, 10.0, 4.0, 6.0, 1.0) LIMIT ?'
         parameters.append(limit)
-        rows = connection.execute(sql, parameters).fetchall()
+        try:
+            rows = connection.execute(sql, parameters).fetchall()
+        except sqlite3.OperationalError as e:
+            raise ValueError(str(e)) from e
     finally:
         connection.close()
 
@@ -100,7 +104,7 @@ def _open(root: pathlib.Path) -> sqlite3.Connection:
     cache.mkdir(parents=True, exist_ok=True)
     gitignore = cache / '.gitignore'
     if not gitignore.exists():
-        write_atomic(gitignore, '*\n')
+        wiki.util.fs.write_atomic(gitignore, '*\n')
     connection = sqlite3.connect(cache / _CACHE_NAME)
     connection.execute('PRAGMA journal_mode=WAL')
     connection.execute('PRAGMA busy_timeout=5000')
@@ -142,25 +146,23 @@ def _refresh(
             connection.execute('DELETE FROM files WHERE path = ?', (relative,))
         for relative in changed:
             path, mtime_ns, size = present[relative]
-            try:
-                text = path.read_text(encoding='utf-8')
-            except (OSError, UnicodeDecodeError):
-                connection.execute('DELETE FROM notes_fts WHERE path = ?', (relative,))
-                connection.execute('DELETE FROM files WHERE path = ?', (relative,))
-                continue
-            title, headings, tags, body = _fields(path, text)
-            folder = str(pathlib.PurePath(relative).parent)
             connection.execute('DELETE FROM notes_fts WHERE path = ?', (relative,))
-            connection.execute(
-                'INSERT INTO notes_fts(title, headings, tags, body, path, folder) '
-                'VALUES (?, ?, ?, ?, ?, ?)',
-                (title, headings, tags, body, relative, folder),
-            )
             connection.execute(
                 'INSERT INTO files(path, mtime_ns, size) VALUES (?, ?, ?) '
                 'ON CONFLICT(path) DO UPDATE SET '
                 'mtime_ns=excluded.mtime_ns, size=excluded.size',
                 (relative, mtime_ns, size),
+            )
+            try:
+                text = path.read_text(encoding='utf-8')
+            except (OSError, UnicodeDecodeError):
+                continue
+            title, headings, tags, body = _fields(path, text)
+            folder = str(pathlib.PurePath(relative).parent)
+            connection.execute(
+                'INSERT INTO notes_fts(title, headings, tags, body, path, folder) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                (title, headings, tags, body, relative, folder),
             )
 
 

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -29,7 +29,7 @@ from wiki.constants import (
 )
 from wiki.typing import Link, PathLike
 
-from . import _obsidian, format
+from . import _memory, _obsidian, format
 from .event import Event
 
 __all__ = ['Wiki']
@@ -1311,6 +1311,51 @@ class Wiki:
                     if regex.search(line):
                         result.append((relpath, lineno, line))
         return result
+
+    def recall(
+        self: Wiki,
+        query: str,
+        *,
+        name: Optional[str] = None,
+        limit: int = 10,
+        prefix: bool = False,
+        tag: str = '',
+        raw: bool = False,
+    ) -> list[tuple[str, str, float]]:
+        """Return ranked full-text matches from an incremental FTS5 index.
+
+        The derived index lives under ``.wiki/cache`` and refreshes changed,
+        added, and removed Markdown pages before each query. Title, headings,
+        and frontmatter tags receive more BM25 weight than body prose.
+
+        Args:
+            query: Search terms, or an FTS5 expression when ``raw`` is set.
+            name: Restrict scope to a named subtree. ``None`` means the whole
+                wiki.
+            limit: Maximum number of matching pages.
+            prefix: Treat the final safe-query term as a prefix.
+            tag: Require this frontmatter tag token.
+            raw: Pass ``query`` through as FTS5 syntax.
+
+        Returns:
+            ``(relative_path, snippet, score)`` tuples ordered by relevance.
+
+        """
+        if name:
+            folder = self._resolve_folder(name)
+        else:
+            folder = self._root
+        files = self._search_files(self._root)
+        return _memory.recall(
+            self._root,
+            files,
+            query,
+            folder=folder,
+            limit=limit,
+            prefix=prefix,
+            tag=tag,
+            raw=raw,
+        )
 
     def map(
         self: Wiki,

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -29,7 +29,7 @@ from wiki.constants import (
 )
 from wiki.typing import Link, PathLike
 
-from . import _memory, _obsidian, format
+from . import _obsidian, _recall, format
 from .event import Event
 
 __all__ = ['Wiki']
@@ -1346,7 +1346,7 @@ class Wiki:
         else:
             folder = self._root
         files = self._search_files(self._root)
-        return _memory.recall(
+        return _recall.recall(
             self._root,
             files,
             query,

--- a/wiki/skills/wiki/SKILL.md
+++ b/wiki/skills/wiki/SKILL.md
@@ -25,6 +25,7 @@ Maintain indexes as files are added and removed:
 Browse structure, search across content, and read entries:
 
 - `wiki map` — print an indented tree overview
+- `wiki recall` — rank relevant pages with SQLite FTS5
 - `wiki search` — search content with regex
 - `wiki read` — read a named entry
 
@@ -68,8 +69,8 @@ rather than authoring or auditing page by page yourself:
 - **`.wiki/` is the tool's namespace.** Every root carries a `.wiki/` directory
   holding `settings.json` — the file that declares the wiki root; `wiki init`
   writes it and `wiki update` restores a missing one — plus the derived
-  word-counts cache and the staged Obsidian config. Never author content there;
-  the walk skips dot-directories by construction.
+  word-counts and ranked-recall caches and the staged Obsidian config. Never
+  author content there; the walk skips dot-directories by construction.
 - **Exclusions are configurable.** Beyond the built-ins (dot-paths, symlinks,
   `_index.md`), gitignore-style globs in `exclude.patterns` in
   `.wiki/settings.json` exclude whole subtrees from indexing — never walked,


### PR DESCRIPTION
## Summary

- add `wiki recall` as a ranked full-text retrieval command alongside the existing regex-based `wiki search`
- maintain a zero-dependency SQLite FTS5 index in the self-ignored `.wiki/cache/` directory
- refresh added, changed, and removed Markdown pages incrementally before every query
- weight titles, headings, and frontmatter tags above body prose with BM25 ranking
- support subtree scope, tag filters, final-term prefixes, raw FTS5 expressions, result limits, and JSON output
- document the command in the README, bundled agent skill, CLI reference, recipes, and changelog

## Why

`wiki search` intentionally provides grep-like regex matching and line-oriented output. Agents navigating a larger wiki also need a relevance-ranked recall path that returns the best pages and compact snippets without changing that established search contract.

This adapts the zero-dependency FTS5 memory pattern from [howdeploy/ObsidianDataWeave](https://github.com/howdeploy/ObsidianDataWeave) to `plasma-wiki`'s authoring model. Because wiki pages can be edited outside the CLI, `recall` validates filesystem signatures and refreshes the index at query time instead of depending on a writer hook.

The index is derived, root-relative state under `.wiki/cache/recall.db`; no absolute paths or new runtime dependencies are introduced. A Python build without SQLite FTS5 receives an actionable error through the command's grep-style error leg.

## Validation

- `635 passed` with the full pytest suite
- `pre-commit run --all-files`
- `sphinx-build -W docs docs/_build`
