### PR TITLE
Read frontmatter through PyYAML compose; pin the repair with an oracle suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,15 @@ edits conflict only on authored prose; `wiki config` installs the Obsidian
 integration.
 
 `core/` decomposes into `wiki.py` (the `Wiki` engine class), `format.py`
-(functions over the on-disk page format), `event.py` (the payload-only `Event`
-base), `_obsidian.py` (the internal Obsidian integration), and `_search.py` (the
-internal SQLite FTS5 index). Engine diagnostics are typed notice events: each
-kind has an `on_<kind>` hook delegating to the `on_notice` funnel, which logs
-`event.description` through the stdlib `Wiki.logger`; hosts intercept by
-overriding hooks (the CLI swaps `on_notice` per instance to capture and condense
-narration).
+(functions over the on-disk page format; frontmatter values come from PyYAML's
+composed node graph, with the line grammar as the fallback for a block a strict
+reader rejects, and every write stays byte-level), `event.py` (the payload-only
+`Event` base), `_obsidian.py` (the internal Obsidian integration), and
+`_search.py` (the internal SQLite FTS5 index). Engine diagnostics are typed
+notice events: each kind has an `on_<kind>` hook delegating to the `on_notice`
+funnel, which logs `event.description` through the stdlib `Wiki.logger`; hosts
+intercept by overriding hooks (the CLI swaps `on_notice` per instance to capture
+and condense narration).
 
 ## Build & Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,49 @@ may include breaking changes, each listed under a Breaking heading.
 ### Breaking
 
 - `wiki lint` reports frontmatter a strict YAML reader rejects as a new hard
-  issue, `invalid_yaml` (with `line` and `reason` payload fields): an unquoted
-  `: ` inside a one-line value, a value ending in `:`, a duplicate key, a
-  control character, a key that is not a scalar, or a body that is not
+  issue, `invalid_yaml` (with `line` and `reason` payload fields) — for example
+  an unquoted `: ` inside a one-line value, a value ending in `:`, a value
+  opening with an indicator character (`- % @ * | >` and the like), a duplicate
+  key, a control character, a key that is not a scalar, or a body that is not
   `key: value` pairs. A wiki that linted clean may lint red until the offending
   values are quoted; the fix is the author's — `wiki update` never rewrites an
-  authored value.
+  authored value. The verdict is the installed PyYAML build's: a wheel without
+  libyaml runs the pure-Python loader, which words its errors differently and
+  rejects a tab inside a plain value the C loader accepts (such a block then
+  reads through the line grammar). A tag no reader constructs (`!custom`,
+  `!!int` over text) is not checked: the block composes, so it lints clean and
+  reads as its text.
 - Frontmatter values are read the way a strict YAML reader reads them: a value
   continued on indented lines folds into one, a quoted value decodes, an
   indented `# comment` under a bare key is a comment, a bare key with trailing
   spaces reads its body, a space followed by `#` starts a comment, and `null`
   followed by a comment unsets like `null`. The first `wiki update` after
-  upgrading may rewrite a parent row, a `[category]` label, or an H1 once on
-  pages carrying such shapes — run `wiki update --check` after upgrading to list
-  them — and the search index rebuilds on the next `wiki search`. A block a
-  strict reader rejects still reads as before, through the line grammar.
+  upgrading may rewrite a `name:` line, a parent row, a `[category]` label, or
+  an H1 once on pages carrying such shapes — run `wiki update --check` after
+  upgrading to list them — and the search index rebuilds on the next
+  `wiki search`. A clone still on an earlier version reverts those rewrites on
+  its next `wiki update` (re-stamping `updated:`) and reads a comment-carrying
+  placeholder (`desc: ... # note`) as an authored description, so upgrade every
+  clone of a shared wiki together. A block a strict reader rejects still reads
+  through the line grammar. A UTF-8 BOM opening a page or index file is removed
+  on that first update, as one opening the block's body is.
 - PyYAML (`pyyaml>=6,<7`) is a runtime dependency; environments synced before
   this release need a `uv sync` (or a reinstall).
 
 ### Changed
 
-- A frontmatter key outside the `[\w-]+` grammar (a dotted `com.example:`) sorts
-  as a custom field, below the known fields and above the timestamps, instead of
-  riding along under the field before it.
-- The `wiki update` narration counts pages with malformed frontmatter without
+- The fields of a block a strict reader accepts are bounded by the parser's own
+  key positions, so a quoted key (`"desc": x`) is the field it names, and a
+  quoted scalar or flow collection continued at column 0 moves as one field
+  under `wiki update` and matches as one under `wiki match --field`. A block the
+  parser rejects keeps one line grammar for the repair, the field order, and
+  `match --field` alike: a column-0 `[\w.-]+` key whose colon is followed by a
+  space or the line end — so a dotted key (`com.example:`) sorts as a custom
+  field below the known fields and above the timestamps instead of riding along
+  under the field before it, and a `key:value` line with no space after the
+  colon is text to the wiki as it is to YAML (`wiki lint` names it; the fix is
+  one space).
+- The `wiki update` narration counts files with malformed frontmatter without
   the `(no closing ---)` suffix; each per-file notice names its reason.
 
 ### Fixed
@@ -41,39 +60,209 @@ may include breaking changes, each listed under a Breaking heading.
 - A stamp written as a bare `created:`/`updated:` key over an indented line is a
   value: `wiki update` no longer stamps the run's clock onto the key line and
   strands the authored stamp below it, and the `updated:` re-stamp replaces the
-  whole value.
-- Refreshing a bare-key `name:` keeps an indented `# comment` under it.
+  whole value. A quoted-empty stamp (`created: ''`) is stamped like a blank one;
+  a stamp written as a sequence is an unparseable stamp to `wiki lint`.
+- Refreshing a `name:` keeps the comment on its key line and an indented
+  `# comment` under a bare key, and reads past a UTF-8 BOM opening the body
+  instead of hiding the `name:` line behind it and drawing a duplicate.
 - `title: null # comment` and `desc: | # comment` are unset like `title: null`
   and `desc: |`: update removes the title line and restores the desc
-  placeholder.
+  placeholder. A block the parser rejects reads its fields the same way:
+  `null # comment`, a bare key over an indented `null`, and a comment-only value
+  are unset there too, so the reader and the repair agree and update converges
+  in one run.
 - Filling or removing a valueless field keeps its comments: `desc: # note`
-  becomes `desc: ... # note`, the comment on an unset `title:` stays behind as a
-  comment line, and a comment line indented under a stamp stays under the fresh
-  stamp.
+  becomes `desc: ... # note`, the comment on an unset `title:` or `category:`
+  stays behind as a column-0 comment line (never indented into a block-scalar
+  neighbor as its content), and the comment lines under a stamp stay under the
+  fresh stamp, the `updated:` re-stamp's tail comment included. Every leading
+  valueless copy of `title:`/`category:` goes in one run.
 - A sequence written at column 0 under `desc:`, `category:`, or a timestamp key
-  is that field's value: update no longer restores the placeholder or stamps the
-  key line and strands the items under the field before it.
+  is that field's value, and so is a column-0 `# comment` between a key and its
+  indented body: update no longer restores the placeholder or stamps the key
+  line and strands the lines under the field before it.
 - A frontmatter block that is valid YAML but not `key: value` pairs is left
-  untouched with a notice instead of gaining fields appended under the text.
+  untouched with a notice instead of gaining fields appended under the text; so
+  is a mapping whose keys the byte-level repair cannot place (a flow mapping, an
+  indented one, an explicit `? key`, an alias used as a key, a `<<` merge key,
+  two keys on one line broken by a NEL), which `wiki lint` reports as malformed
+  frontmatter. A block carrying an alias is never reordered, since the anchor
+  must stay above it; a re-stamped or filled stamp keeps the anchor on its key
+  line, so an alias of it keeps resolving; and a repair that would leave an
+  accepted block rejected is refused with the same notice, which `wiki lint`
+  reports too. A trailing `...` document-end marker stays the block's last line.
+- A stamp written as a flow sequence or mapping on its key line
+  (`created: [2025-01-01]`, `created: {}`) is an unparseable stamp to
+  `wiki lint`, as one written under the key is; a duplicate key inside a nested
+  mapping is an `invalid_yaml` issue on its own line; an unclosed flow
+  collection is reported on the line holding it; and a `#` inside a quoted stamp
+  is text, never a comment for the re-stamp to re-attach.
+- A block scalar opened by a sequence item or a nested key (`- k: |+`,
+  `meta:\n  inner: |+`), or behind a node property (`key: &a |+`), keeps its
+  trailing blank line, and a quoted scalar continued at column 0 keeps the blank
+  lines inside it; a double-quoted escape naming no character (past U+10FFFF, or
+  a lone surrogate) reads verbatim instead of crashing the run.
+- A node property over nothing (`created: !!str`, `desc: &d`) is a blank the
+  repair fills behind the property, and `wiki match --field` matches the value
+  past a property rather than the property itself; a `... # end` marker, or
+  comment lines after the marker, stay the block's last lines; a body that is
+  not a mapping reads no fields at all, so a `key:` spelled inside a list draws
+  no other finding and matches no field.
+- A parent index row reads its child's repaired frontmatter in the same run
+  (pages are planned before their indexes, so `wiki update` narrates page
+  notices — and their condensed count lines — before index notices), so a repair
+  that changes what the reader returns no longer leaves the row a run behind; a
+  block whose only alias sat on `updated:` is ordered by the write that replaces
+  the alias, and a UTF-8 BOM at column 0 of any block line (which the C loader
+  skips, so a `# comment` behind one is a comment) is dropped by the repair, so
+  neither takes a second run.
+- A self-referential or shared alias graph (`tags: &a [*a]`) composes in bounded
+  time instead of hanging every command on the wiki, and collections nested past
+  100 levels are an `invalid_yaml` finding on the line that passes the bound
+  instead of a recursion the C loader runs off its stack.
+- A repair that would close a quote the line grammar cannot see around the lines
+  it writes (`tags: "open` above a `name: "x` line, a stamp continued at column
+  0 above an open quote) is refused with the malformed notice — `wiki lint`
+  reports it too — instead of crashing `wiki update` or re-inserting the
+  swallowed stamps on every run.
+- Under the line grammar an unclosed `[` or `{` reads to the next key line
+  instead of through the stamps and the closing fence into the H1 and the parent
+  row; a quote left open inside a flow collection carries to the next line, so a
+  stray blank after the collection is stripped; a block scalar behind a node
+  property (`desc: &a |`) reads its body, and a collection's node property
+  (`tags: &t [a]`) is not its text; node properties separated by more than one
+  space strip as one does; and a `desc: |` or stamp header over column-0 comment
+  lines alone is an empty value the repair fills, the comments kept under it.
+- `wiki match --field` composes a block over 64 KB once per file rather than
+  once per matched line, strips a quoted key whose quotes escape or double a
+  quote from its line, keeps a flow collection whole past a `#` inside its
+  quotes (`tags: ['alpha #note', beta]`), and leaves a quoted scalar's
+  continuation line (`two: three"`) unstripped, since the composed block says it
+  opens no key.
+- The H1 and the parent row are read from the block as the write leaves it: a
+  block the parser rejects only until the `updated:` re-stamp closes its quote
+  or drops its bracket reads through the parser in the same run, so the update
+  converges in one run instead of rewriting the H1 and the row on the next.
+- A double-quoted `\0` escape in a title or desc is dropped on read instead of
+  landing as a raw NUL byte in the H1 and the parent row, which made both files
+  binary to git and aborted the merge driver.
+- A collection's `' #'` tails (`tags: [a, b] # note`, `- alpha # note`) are not
+  its text, so `wiki search --tag` no longer sees comment words as tags; under
+  the line grammar a bare key over column-0 items reads the items (as the
+  composed block does), a block scalar ends at the first line indented less than
+  its body (`title: |4` over a two-space `# note`), and a column-0 item after a
+  value on the key line (`name: x` over `- draft`) is text outside the field,
+  kept in place rather than deleted with the refreshed name.
+- A value a strict reader resolves as a number and cannot construct (`0x_`,
+  `0b_`) is written quoted, as a date no calendar has is; `strip_blank_lines`
+  reads a block header behind a quoted key spelled with a space before its colon
+  (`"desc" : |+`), so its trailing blank survives; and a tab on a trailing
+  whitespace-only line of the block is reported on that line.
+- `wiki update` and `wiki lint` recognize conflict markers of any length git's
+  `conflict-marker-size` attribute lengthens them to, not only the
+  seven-character default the driver forwards.
+- The `_index.md` merge driver normalizes `created:` whenever the base index
+  lacks the stamp (a hand-written or imported index, not only an empty add/add
+  base) and gives a side lacking a regenerated key the current branch's copy of
+  it where `wiki update` places the key, so two branches that each ran
+  `wiki update` over such an index merge clean; and a link row both sides carry
+  takes the other side's text when only that side changed it against the base
+  (however the rows are spaced on each side), so an authored desc on an asset
+  row or a placeholder-desc child is no longer lost to the current branch's
+  copy. An add/add merge of two indexes keeps both sides' rows, the H1, and the
+  `***` line.
+- Under the line grammar a quoted value closing on a later line folds its lines
+  up to the closing quote (a hand-wrapped `title: "..."` reads whole instead of
+  as its first line with a stray quote), a flow collection's `' #'` tail is not
+  its text, a node property over nothing is an absent value, and a `: ` on the
+  third or later line of a plain value is reported on its own line. The nesting
+  bound counts a bracket only where a value opens with one — a block scalar's
+  body, a plain value's text (`rock 'n roll`, `a [b`), and its continuation
+  lines are never collections — so a valid block never lints red for its
+  brackets.
+- Under the line grammar a quote mid-text is content: `title: 'Bob's Page'`
+  reads whole instead of truncating at the apostrophe and rewriting the H1 and
+  the parent row to `Bob` (the close is the quote nothing but whitespace or a
+  comment follows), and `wiki match --field` sees the same value. A quoted item
+  or scalar wrapped across lines keeps a `#` inside its span
+  (`tags: ['a wrapped\n  item #x', beta]` reads whole, so `search --tag` sees
+  every item), and a comment line after a quoted stamp's closing quote
+  (`updated: "..."` over `# todo: verify`) no longer refuses the repair. The
+  `_index.md` merge driver's row rule compares rows without their trailing blank
+  lines under CRLF and whitespace-only separators too, so such an index does not
+  lose the other side's row edit to a re-spaced current branch.
+- Under `titles.required`, a page or index with a duplicated `name:` line
+  converges in one run: the plan orders the block after seeding `title: null`,
+  as the write does. Under the line grammar a bare `desc:`/`title:` over an
+  indented quoted body reads the quoted scalar (`desc:` over `'A: colon here.'`
+  reads `A: colon here.`), a quoted item keeps its `#` (`- 'notes #draft'`), and
+  `wiki match --field` matches a quoted value continued on the next line from
+  its first character. The `_index.md` merge driver treats a bare or
+  quoted-empty `created:` in the base as no stamp, so two branches that each
+  filled it merge clean.
+- A repair that would fold an authored key line into a quoted value it closes
+  (`zebra: 27"` moved under `desc: "open`, or a `desc: D.` line inside a quoted
+  `name:` the refresh rewrites) is refused with the malformed notice instead of
+  written; a `[category]` label reads the block as the write leaves it, like the
+  H1 and the row; and a blank line an unclosed quote or bracket in `updated:`
+  kept as content goes with the re-stamp that closes it, so neither takes a
+  second run.
+- A sequence or mapping value reads as its source lines joined (comment lines
+  dropped), so `wiki search --tag` sees a tag written at column 0 or on the
+  second line of a flow sequence, and a `' #'` inside a quoted item stays; under
+  the line grammar a plain value folds its indented continuation lines, node
+  properties before a key or value are not the value, and `wiki match --field`
+  strips a key spelled with spaces from its line. A date-shaped value no
+  calendar has (`2024-02-30`) is written quoted, since a strict reader cannot
+  construct it plain.
+- The `_index.md` merge driver treats every comment under a regenerated key as
+  authored: a deletion or rewording on one side lands through the ordinary
+  three-way merge instead of ours' copy resurrecting it or a conflict. A comment
+  between the key and its indented value belongs to the value's extent, so it
+  moves with the value rather than stranding the value lines under the other
+  side's one-liner.
+- `wiki new` (`NAME`, `--desc`, `--content`) and `wiki init` (`NAME`) refuse an
+  argument holding a byte no UTF-8 decodes, before anything lands on disk; the
+  `_index.md` merge driver merges such a byte verbatim instead of aborting.
+- Under the line grammar a quoted value ends at its closing quote, a `null` on
+  the key line over an indented `null` is the text `null null`, and a
+  `key:value` typo is reported on its own line rather than the line after it (a
+  blank line between them included), while a `: ` on a key line after a
+  multi-line field is reported on the key line; a duplicate anchor names the
+  first occurrence, and nested duplicate keys are listed in line order. The tool
+  writes `<<` and `=` quoted, as a strict reader constructs them as merge and
+  value indicators otherwise.
 - A double-quoted carriage-return escape in a value reads as a line break
   instead of carrying a bare carriage return into the H1 and the parent row.
-- Values the tool writes — an adopted heading seeded as `title:`, a `wiki new`
-  desc, a timestamp — are quoted whenever a plain scalar would misread them: a
-  leading indicator character, a ` #` comment start, leading or trailing
-  whitespace; a value holding a control or line-separator character is
-  double-quoted with the character escaped.
+- Values the tool writes — a `name:`, an adopted heading seeded as `title:`, a
+  `wiki new` desc, a timestamp — are quoted whenever a plain scalar would
+  misread them: a leading indicator character, a ` #` comment start, leading or
+  trailing whitespace; a value holding a control, C1, line-separator, or
+  noncharacter code point is double-quoted with it escaped, a multi-line
+  `wiki new` desc included, and `wiki match --field` decodes every double-quoted
+  escape a strict reader decodes.
 - The `_index.md` merge driver moves a regenerated key with its indented
   continuation lines, so a block-scalar `name:` on one side no longer strands
-  its body under the other side's one-liner, leaves a blank line separating the
-  key from the next field in place on every side, and matches a key spelled with
-  a space before its colon.
+  its body under the other side's one-liner; leaves a blank line separating the
+  key from the next field in place on every side, byte for byte (a CRLF or
+  whitespace-only separator no longer conflicts); keeps a `# comment` the other
+  side wrote under the key; matches a key spelled with a space before its colon;
+  and handles an extent of any size.
 - `wiki lint`'s "Missing period in desc" names a ` #` comment as the likely
-  cause when the value's line carries one outside a block-scalar header.
+  cause when a plain value's lines carry one, the key line or a continuation
+  line, in a block the parser accepts.
+- `wiki lint`'s `invalid_yaml` line is the offending line whatever precedes it:
+  a NEL, LS, or PS the parser counts as a line break no longer shifts it, an
+  unterminated quote or a stray line is reported where it starts rather than
+  where the parser gave up, and a second document's reason reads as a sentence.
 - `wiki match --field` sees a sequence item written at column 0 whose text holds
-  a colon (`- https://doi.org/...`) and a flow-sequence continuation line
-  (`https://b]`) as part of its field, and a key written with a space before its
-  colon (`desc : x`) as the field it names, so `wiki update` no longer inserts a
-  duplicate `desc:` beside one.
+  a colon (`- https://doi.org/...`) and, in a block the parser accepts, a
+  flow-sequence continuation line (`https://b]`) as part of its field, and a key
+  written with a space before its colon (`desc : x`) as the field it names, so
+  `wiki update` no longer inserts a duplicate `desc:` beside one.
+- `wiki update` keeps a whitespace-only line indented past a block scalar's body
+  and the trailing blank of a keep-chomping block inside a column-0 sequence
+  item, both of which are content.
 
 ## [1.3.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ may include breaking changes, each listed under a Breaking heading.
 - PyYAML (`pyyaml>=6,<7`) is a runtime dependency; environments synced before
   this release need a `uv sync` (or a reinstall).
 
+### Changed
+
+- A frontmatter key outside the `[\w-]+` grammar (a dotted `com.example:`) sorts
+  as a custom field, below the known fields and above the timestamps, instead of
+  riding along under the field before it.
+- The `wiki update` narration counts pages with malformed frontmatter without
+  the `(no closing ---)` suffix; each per-file notice names its reason.
+
 ### Fixed
 
 - A stamp written as a bare `created:`/`updated:` key over an indented line is a
@@ -46,9 +54,7 @@ may include breaking changes, each listed under a Breaking heading.
   is that field's value: update no longer restores the placeholder or stamps the
   key line and strands the items under the field before it.
 - A frontmatter block that is valid YAML but not `key: value` pairs is left
-  untouched with a notice instead of gaining fields appended under the text; a
-  key missing the space after its colon (`name:core/design`) is repaired rather
-  than reported as such a block.
+  untouched with a notice instead of gaining fields appended under the text.
 - A double-quoted carriage-return escape in a value reads as a line break
   instead of carrying a bare carriage return into the H1 and the parent row.
 - Values the tool writes — an adopted heading seeded as `title:`, a `wiki new`
@@ -68,14 +74,6 @@ may include breaking changes, each listed under a Breaking heading.
   (`https://b]`) as part of its field, and a key written with a space before its
   colon (`desc : x`) as the field it names, so `wiki update` no longer inserts a
   duplicate `desc:` beside one.
-
-### Changed
-
-- A frontmatter key outside the `[\w-]+` grammar (a dotted `com.example:`) sorts
-  as a custom field, below the known fields and above the timestamps, instead of
-  riding along under the field before it.
-- The `wiki update` narration counts pages with malformed frontmatter without
-  the `(no closing ---)` suffix; each per-file notice names its reason.
 
 ## [1.3.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,16 @@ may include breaking changes, each listed under a Breaking heading.
   its body under the other side's one-liner.
 - `wiki lint`'s "Missing period in desc" names a ` #` comment as the likely
   cause when the value's line carries one.
+- `wiki match --field` sees a sequence item written at column 0 whose text holds
+  a colon (`- https://doi.org/...`) as part of its field, and a key written with
+  a space before its colon (`desc : x`) as the field it names, so `wiki update`
+  no longer inserts a duplicate `desc:` beside one.
 
 ### Changed
 
+- A frontmatter key outside the `[\w-]+` grammar (a dotted `com.example:`) sorts
+  as a custom field, below the known fields and above the timestamps, instead of
+  riding along under the field before it.
 - The `wiki update` narration counts pages with malformed frontmatter without
   the `(no closing ---)` suffix; each per-file notice names its reason.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ may include breaking changes, each listed under a Breaking heading.
 
 ## [Unreleased]
 
+### Breaking
+
+- `wiki lint` reports frontmatter a strict YAML reader rejects as a new hard
+  issue, `invalid_yaml` (with `line` and `reason` payload fields): an unquoted
+  `: ` inside a one-line value, a value ending in `:`, a duplicate key, a
+  control character, a key that is not a scalar, or a body that is not
+  `key: value` pairs. A wiki that linted clean may lint red until the offending
+  values are quoted; the fix is the author's — `wiki update` never rewrites an
+  authored value.
+- Frontmatter values are read the way a strict YAML reader reads them: a value
+  continued on indented lines folds into one, a quoted value decodes, an
+  indented `# comment` under a bare key is a comment, a bare key with trailing
+  spaces reads its body, a space followed by `#` starts a comment, and `null`
+  followed by a comment unsets like `null`. The first `wiki update` after
+  upgrading may rewrite a parent row, a `[category]` label, or an H1 once on
+  pages carrying such shapes — run `wiki update --check` after upgrading to list
+  them — and the search index rebuilds on the next `wiki search`. A block a
+  strict reader rejects still reads as before, through the line grammar.
+- PyYAML (`pyyaml>=6,<7`) is a runtime dependency; environments synced before
+  this release need a `uv sync` (or a reinstall).
+
+### Fixed
+
+- A stamp written as a bare `created:`/`updated:` key over an indented line is a
+  value: `wiki update` no longer stamps the run's clock onto the key line and
+  strands the authored stamp below it, and the `updated:` re-stamp replaces the
+  whole value.
+- Refreshing a bare-key `name:` keeps an indented `# comment` under it.
+- `title: null # comment` and `desc: | # comment` are unset like `title: null`
+  and `desc: |`: update removes the title line and restores the desc
+  placeholder.
+- A frontmatter block that is valid YAML but not `key: value` pairs is left
+  untouched with a notice instead of gaining fields appended under the text.
+- Values the tool writes — an adopted heading seeded as `title:`, a `wiki new`
+  desc — are quoted whenever a plain scalar would misread them: a leading
+  indicator character, a ` #` comment start, leading or trailing whitespace.
+- The `_index.md` merge driver moves a regenerated key with its indented
+  continuation lines, so a block-scalar `name:` on one side no longer strands
+  its body under the other side's one-liner.
+- `wiki lint`'s "Missing period in desc" names a ` #` comment as the likely
+  cause when the value's line carries one.
+
+### Changed
+
+- The `wiki update` narration counts pages with malformed frontmatter without
+  the `(no closing ---)` suffix; each per-file notice names its reason.
+
 ## [1.3.1] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,10 @@ may include breaking changes, each listed under a Breaking heading.
 - `wiki update` keeps a whitespace-only line indented past a block scalar's body
   and the trailing blank of a keep-chomping block inside a column-0 sequence
   item, both of which are content.
+- A multi-line desc whose first content line opens with a space or a tab writes
+  its block scalar with an explicit indentation indicator (`desc: |2`), so a
+  strict reader takes the leading whitespace as content instead of mis-detecting
+  the block's indentation and rejecting it.
 
 ## [1.3.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,20 +38,36 @@ may include breaking changes, each listed under a Breaking heading.
 - `title: null # comment` and `desc: | # comment` are unset like `title: null`
   and `desc: |`: update removes the title line and restores the desc
   placeholder.
+- Filling or removing a valueless field keeps its comments: `desc: # note`
+  becomes `desc: ... # note`, the comment on an unset `title:` stays behind as a
+  comment line, and a comment line indented under a stamp stays under the fresh
+  stamp.
+- A sequence written at column 0 under `desc:`, `category:`, or a timestamp key
+  is that field's value: update no longer restores the placeholder or stamps the
+  key line and strands the items under the field before it.
 - A frontmatter block that is valid YAML but not `key: value` pairs is left
-  untouched with a notice instead of gaining fields appended under the text.
+  untouched with a notice instead of gaining fields appended under the text; a
+  key missing the space after its colon (`name:core/design`) is repaired rather
+  than reported as such a block.
+- A double-quoted carriage-return escape in a value reads as a line break
+  instead of carrying a bare carriage return into the H1 and the parent row.
 - Values the tool writes — an adopted heading seeded as `title:`, a `wiki new`
-  desc — are quoted whenever a plain scalar would misread them: a leading
-  indicator character, a ` #` comment start, leading or trailing whitespace.
+  desc, a timestamp — are quoted whenever a plain scalar would misread them: a
+  leading indicator character, a ` #` comment start, leading or trailing
+  whitespace; a value holding a control or line-separator character is
+  double-quoted with the character escaped.
 - The `_index.md` merge driver moves a regenerated key with its indented
   continuation lines, so a block-scalar `name:` on one side no longer strands
-  its body under the other side's one-liner.
+  its body under the other side's one-liner, leaves a blank line separating the
+  key from the next field in place on every side, and matches a key spelled with
+  a space before its colon.
 - `wiki lint`'s "Missing period in desc" names a ` #` comment as the likely
-  cause when the value's line carries one.
+  cause when the value's line carries one outside a block-scalar header.
 - `wiki match --field` sees a sequence item written at column 0 whose text holds
-  a colon (`- https://doi.org/...`) as part of its field, and a key written with
-  a space before its colon (`desc : x`) as the field it names, so `wiki update`
-  no longer inserts a duplicate `desc:` beside one.
+  a colon (`- https://doi.org/...`) and a flow-sequence continuation line
+  (`https://b]`) as part of its field, and a key written with a space before its
+  colon (`desc : x`) as the field it names, so `wiki update` no longer inserts a
+  duplicate `desc:` beside one.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ Maintain indexes as files are added and removed:
 
 `wiki lint` exits 1 on issues and 0 on a clean wiki (soft notes go to stderr and
 never affect the exit code — a stale wikilink in prose is a note, while a broken
-link in a generated index block, or a prose link naming a folder rather than its
-`_index` page, is an issue). Scripts should read `wiki lint --json` — one JSON
-document on stdout listing every issue and note with a `severity` and `kind` —
-rather than parse the prose; the exit code is unchanged. A page that must
-display otherwise-flagged content — sample conflict markers, stale link examples
-— wraps those lines in a `<!-- start: no-lint -->` ... `<!-- end: no-lint -->`
-region, which suppresses the positional rules, notes included, for just that
-span.
+link in a generated index block, a prose link naming a folder rather than its
+`_index` page, or frontmatter a strict YAML reader rejects, is an issue).
+Scripts should read `wiki lint --json` — one JSON document on stdout listing
+every issue and note with a `severity` and `kind` — rather than parse the prose;
+the exit code is unchanged. A page that must display otherwise-flagged content —
+sample conflict markers, stale link examples — wraps those lines in a
+`<!-- start: no-lint -->` ... `<!-- end: no-lint -->` region, which suppresses
+the positional rules, notes included, for just that span.
 
 Browse structure, search across content, and read entries:
 

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -485,9 +485,10 @@ keeps the tool-owned surfaces in sync with the filesystem (see
 
 ``updated:`` is re-stamped only on files whose content actually changed.
 Files the sweep cannot safely fix are left alone with a notice: pages whose
-frontmatter never closes, emptied or truncated indexes (restore from git or
-delete to rebuild), entries with policy-invalid names, symlinks, and files
-edited concurrently during the run (re-run to converge).
+frontmatter never closes or is valid YAML but not ``key: value`` pairs,
+emptied or truncated indexes (restore from git or delete to rebuild), entries
+with policy-invalid names, symlinks, and files edited concurrently during the
+run (re-run to converge).
 
 Narration goes to stderr — condensed to one count line per category by
 default (e.g. ``Created 1 new index (fill in its desc)``, ``Added 2 new
@@ -615,9 +616,8 @@ payload fields (``path`` on every issue and on most notes — the
 ``resolver_notice``, ``merge_driver_unconfigured``, and
 ``git_fence_unavailable`` notes carry none — plus e.g. ``target``/``label``
 on a broken link, ``line`` on a wrap mangle, or ``line``/``reason`` on
-invalid YAML frontmatter), the rendered prose under
-``text``, and a ``summary`` with both counts; the exit-code contract is
-unchanged.
+invalid YAML frontmatter), the rendered prose under ``text``, and a
+``summary`` with both counts; the exit-code contract is unchanged.
 
 **Issues** (hard, exit 1) cover everything ``wiki update`` would rewrite —
 each shown as ``<path>: Requires update`` with an indented unified diff — plus
@@ -626,13 +626,12 @@ shadowed by same-named folders, merge conflict markers, leftover merge repair
 hints, malformed frontmatter (no closing ``---``, or a body that is not a
 ``key: value`` mapping), frontmatter a strict YAML reader rejects (an unquoted
 ``': '`` inside a value, a duplicate key), empty or truncated indexes, nested
-wiki roots,
-formatter-damage signatures (escaped wikilinks, a missing ``***`` delimiter),
-hand-wrap mangles, authored descriptions missing their trailing period,
-unparseable ``created:``/``updated:`` stamps, broken links in the generated
-index block, prose wikilinks naming a folder rather than its ``_index`` page,
-dangling or nested region markers, and — when the ``titles.required`` setting
-is on — missing titles.
+wiki roots, formatter-damage signatures (escaped wikilinks, a missing ``***``
+delimiter), hand-wrap mangles, authored descriptions missing their trailing
+period, unparseable ``created:``/``updated:`` stamps, broken links in the
+generated index block, prose wikilinks naming a folder rather than its
+``_index`` page, dangling or nested region markers, and — when the
+``titles.required`` setting is on — missing titles.
 
 **Notes** (soft, stderr) flag placeholder (``...``) descriptions, descriptions
 over 500 characters, empty index content sections, CRLF line endings, stale

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -404,9 +404,11 @@ frontmatter, which includes the H1 and an index's generated link block — and
 the default output is the matching file paths, deduplicated, in match order.
 ``--field`` switches to frontmatter matching: the pattern runs against each
 named field's value (the ``key:`` prefix and YAML quotes are stripped;
-block-scalar continuation lines are included). An empty ``--field ""`` is an
-explicit empty field set that matches nothing — it does not fall back to a
-body match.
+block-scalar continuation lines are included). A flow mapping, or a mapping
+indented as a whole, has no field lines to match; other mappings the repair
+refuses still match through the line grammar. An empty
+``--field ""`` is an explicit empty field set that matches nothing — it does
+not fall back to a body match.
 
 .. list-table::
    :header-rows: 1
@@ -485,10 +487,11 @@ keeps the tool-owned surfaces in sync with the filesystem (see
 
 ``updated:`` is re-stamped only on files whose content actually changed.
 Files the sweep cannot safely fix are left alone with a notice: pages whose
-frontmatter never closes or is valid YAML but not ``key: value`` pairs,
-emptied or truncated indexes (restore from git or delete to rebuild), entries
-with policy-invalid names, symlinks, and files edited concurrently during the
-run (re-run to converge).
+frontmatter never closes, is valid YAML but not ``key: value`` pairs, is a
+mapping with no column-0 ``key:`` lines, or would be left rejected by its own
+repair; emptied or truncated indexes (restore from git or delete to rebuild);
+entries with policy-invalid names; symlinks; and files edited concurrently
+during the run (re-run to converge).
 
 Narration goes to stderr — condensed to one count line per category by
 default (e.g. ``Created 1 new index (fill in its desc)``, ``Added 2 new
@@ -579,7 +582,8 @@ nothing on disk.
    * - ``--desc``
      - required
      - Authored frontmatter description (multi-line values write as a block
-       scalar).
+       scalar, or double-quoted with escapes when a line holds a character no
+       block may carry).
    * - ``--content``
      - required
      - Authored content for the section below the ``***`` delimiter.
@@ -623,9 +627,11 @@ invalid YAML frontmatter), the rendered prose under ``text``, and a
 each shown as ``<path>: Requires update`` with an indented unified diff — plus
 problems update cannot fix: missing indexes, invalid page/folder names, pages
 shadowed by same-named folders, merge conflict markers, leftover merge repair
-hints, malformed frontmatter (no closing ``---``, or a body that is not a
-``key: value`` mapping), frontmatter a strict YAML reader rejects (an unquoted
-``': '`` inside a value, a duplicate key), empty or truncated indexes, nested
+hints, malformed frontmatter (no closing ``---``, a mapping with no column-0
+``key:`` lines, or a block its own repair would leave rejected), frontmatter a
+strict YAML reader rejects (an unquoted ``': '``
+inside a value, a duplicate key, a body that is not ``key: value`` pairs),
+empty or truncated indexes, nested
 wiki roots, formatter-damage signatures (escaped wikilinks, a missing ``***``
 delimiter), hand-wrap mangles, authored descriptions missing their trailing
 period, unparseable ``created:``/``updated:`` stamps, broken links in the

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -406,9 +406,9 @@ the default output is the matching file paths, deduplicated, in match order.
 named field's value (the ``key:`` prefix and YAML quotes are stripped;
 block-scalar continuation lines are included). A flow mapping, or a mapping
 indented as a whole, has no field lines to match; other mappings the repair
-refuses still match through the line grammar. An empty
-``--field ""`` is an explicit empty field set that matches nothing — it does
-not fall back to a body match.
+refuses still match through the line grammar. An empty ``--field ""`` is an
+explicit empty field set that matches nothing — it does not fall back to a
+body match.
 
 .. list-table::
    :header-rows: 1
@@ -629,10 +629,10 @@ problems update cannot fix: missing indexes, invalid page/folder names, pages
 shadowed by same-named folders, merge conflict markers, leftover merge repair
 hints, malformed frontmatter (no closing ``---``, a mapping with no column-0
 ``key:`` lines, or a block its own repair would leave rejected), frontmatter a
-strict YAML reader rejects (an unquoted ``': '``
-inside a value, a duplicate key, a body that is not ``key: value`` pairs),
-empty or truncated indexes, nested
-wiki roots, formatter-damage signatures (escaped wikilinks, a missing ``***``
+strict YAML reader rejects (an unquoted ``': '`` inside a value, a duplicate
+key, a body that is not ``key: value`` pairs), empty or truncated indexes,
+nested wiki roots, formatter-damage signatures (escaped wikilinks, a missing
+``***``
 delimiter), hand-wrap mangles, authored descriptions missing their trailing
 period, unparseable ``created:``/``updated:`` stamps, broken links in the
 generated index block, prose wikilinks naming a folder rather than its

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -614,7 +614,8 @@ with one JSON document on stdout carrying every finding under an explicit
 payload fields (``path`` on every issue and on most notes — the
 ``resolver_notice``, ``merge_driver_unconfigured``, and
 ``git_fence_unavailable`` notes carry none — plus e.g. ``target``/``label``
-on a broken link or ``line`` on a wrap mangle), the rendered prose under
+on a broken link, ``line`` on a wrap mangle, or ``line``/``reason`` on
+invalid YAML frontmatter), the rendered prose under
 ``text``, and a ``summary`` with both counts; the exit-code contract is
 unchanged.
 
@@ -622,8 +623,10 @@ unchanged.
 each shown as ``<path>: Requires update`` with an indented unified diff — plus
 problems update cannot fix: missing indexes, invalid page/folder names, pages
 shadowed by same-named folders, merge conflict markers, leftover merge repair
-hints, malformed frontmatter
-(no closing ``---``), empty or truncated indexes, nested wiki roots,
+hints, malformed frontmatter (no closing ``---``, or a body that is not a
+``key: value`` mapping), frontmatter a strict YAML reader rejects (an unquoted
+``': '`` inside a value, a duplicate key), empty or truncated indexes, nested
+wiki roots,
 formatter-damage signatures (escaped wikilinks, a missing ``***`` delimiter),
 hand-wrap mangles, authored descriptions missing their trailing period,
 unparseable ``created:``/``updated:`` stamps, broken links in the generated

--- a/docs/guide/generation.rst
+++ b/docs/guide/generation.rst
@@ -54,10 +54,12 @@ rewrites only the files that differ. It owns:
    an unset ``title:`` or ``category:`` line (blank or plain ``null``), drops
    stray blank lines, and enforces the canonical field order. Authored values
    — ``title:``, ``desc:``, ``category:``, ``tags:``, ``sources:``, and any
-   custom keys — are preserved. Values are read the way a strict YAML reader
-   reads them (a value continued on indented lines folds, a quoted value
-   decodes, ``null # comment`` unsets like ``null``); a block a strict reader
-   rejects still reads through the line grammar, as authored.
+   custom keys — are preserved, and so are the comments on a field the
+   repair fills or removes (``desc: # note`` becomes ``desc: ... # note``).
+   Values are read the way a strict YAML reader reads them (a value continued
+   on indented lines folds, a quoted value decodes, ``null # comment`` unsets
+   like ``null``); a block a strict reader rejects still reads through the
+   line grammar, as authored.
 
 **Headings.**
    The H1 of every page and index is rewritten to the authored ``title:`` when

--- a/docs/guide/generation.rst
+++ b/docs/guide/generation.rst
@@ -345,14 +345,19 @@ its meaning:
    A page's frontmatter block never closes; update leaves the file untouched.
    Close the block by hand.
 
-``Invalid YAML frontmatter (line N): <reason>; a strict reader drops the whole block, so quote or rewrite the value``
+``Invalid YAML frontmatter (line N): <reason>; <advice>``
    A strict YAML reader rejects the block — an unquoted ``': '`` inside a
    one-line value, a value ending in ``:``, a duplicate key, a control
    character, a key that is not a scalar, or a body that is not ``key: value``
    pairs — so Obsidian and any YAML library lose every field, while the wiki
    still reads the block through its line grammar (or, for a body that is not
-   a mapping, leaves it untouched). Quote the value, drop the duplicate, or
-   rewrite the block.
+   a mapping, leaves it untouched). The advice names the cause: a parse error
+   (``a strict reader drops the whole block, so quote or rewrite the value``),
+   a duplicate key (``a strict reader rejects the block or keeps the last
+   copy, the wiki reads the first``), a key that is not a scalar (``the wiki
+   reads the block by its line grammar alone``), or a body that is not a
+   mapping (``no strict reader finds key: value pairs in it``). Quote the
+   value, drop the duplicate, or rewrite the block.
 
 ``Empty or truncated index (no frontmatter); restore it from git or delete it to rebuild``
    An emptied or truncated ``_index.md``; update keeps it as-is. Restore or

--- a/docs/guide/generation.rst
+++ b/docs/guide/generation.rst
@@ -54,7 +54,10 @@ rewrites only the files that differ. It owns:
    an unset ``title:`` or ``category:`` line (blank or plain ``null``), drops
    stray blank lines, and enforces the canonical field order. Authored values
    — ``title:``, ``desc:``, ``category:``, ``tags:``, ``sources:``, and any
-   custom keys — are preserved.
+   custom keys — are preserved. Values are read the way a strict YAML reader
+   reads them (a value continued on indented lines folds, a quoted value
+   decodes, ``null # comment`` unsets like ``null``); a block a strict reader
+   rejects still reads through the line grammar, as authored.
 
 **Headings.**
    The H1 of every page and index is rewritten to the authored ``title:`` when
@@ -186,6 +189,10 @@ would destroy authored content or race a concurrent editor:
 
 - **A page whose frontmatter never closes** (opening ``---`` with no closing
   ``---``) is left untouched — update cannot tell frontmatter from body.
+- **A frontmatter block that is not a mapping** (valid YAML, but a bare
+  sentence or a list between the fences) is left untouched — it has no fields
+  to repair, and appending fields under the text would leave a block no
+  reader accepts.
 - **An emptied or truncated index** (an ``_index.md`` with no closed
   frontmatter) is kept as-is rather than rebuilt; rebuilding would discard
   whatever authored content survives. Restore it from git, or delete it so
@@ -335,6 +342,15 @@ its meaning:
 ``Malformed frontmatter (no closing ---)``
    A page's frontmatter block never closes; update leaves the file untouched.
    Close the block by hand.
+
+``Invalid YAML frontmatter (line N): <reason>; a strict reader drops the whole block, so quote or rewrite the value``
+   A strict YAML reader rejects the block — an unquoted ``': '`` inside a
+   one-line value, a value ending in ``:``, a duplicate key, a control
+   character, a key that is not a scalar, or a body that is not ``key: value``
+   pairs — so Obsidian and any YAML library lose every field, while the wiki
+   still reads the block through its line grammar (or, for a body that is not
+   a mapping, leaves it untouched). Quote the value, drop the duplicate, or
+   rewrite the block.
 
 ``Empty or truncated index (no frontmatter); restore it from git or delete it to rebuild``
    An emptied or truncated ``_index.md``; update keeps it as-is. Restore or
@@ -511,8 +527,10 @@ topics/_index.md``). The condensed lines and what they mean:
      - Entries violating the naming policy were left unlinked.
    * - ``Skipped N concurrently-edited files (re-run `wiki update`)``
      - Files changed while update was planning; re-run to converge.
-   * - ``N pages with malformed frontmatter (no closing ---)``
-     - Left untouched; close the block by hand.
+   * - ``N pages with malformed frontmatter``
+     - Left untouched; the per-file notice names the reason — close an
+       unclosed block by hand, or rewrite a body that is not ``key: value``
+       pairs.
    * - ``N empty or truncated indexes (restore from git or delete to rebuild)``
      - Left untouched; restore or delete.
 

--- a/docs/guide/generation.rst
+++ b/docs/guide/generation.rst
@@ -195,6 +195,12 @@ would destroy authored content or race a concurrent editor:
   sentence or a list between the fences) is left untouched — it has no fields
   to repair, and appending fields under the text would leave a block no
   reader accepts.
+- **A mapping whose keys are not column-0** ``key:`` **lines** (a flow mapping
+  such as ``{name: x}``, a mapping indented as a whole, an explicit ``? key``)
+  is left untouched the same way — the repair edits column-0 key lines, and
+  has none to edit — as is a block whose repair would leave it rejected by a
+  strict reader; ``wiki lint`` reports both as malformed frontmatter, and
+  their fields still read through the parser.
 - **An emptied or truncated index** (an ``_index.md`` with no closed
   frontmatter) is kept as-is rather than rebuilt; rebuilding would discard
   whatever authored content survives. Restore it from git, or delete it so
@@ -344,6 +350,20 @@ its meaning:
 ``Malformed frontmatter (no closing ---)``
    A page's frontmatter block never closes; update leaves the file untouched.
    Close the block by hand.
+
+``Malformed frontmatter (keys are not column-0 key: value lines)`` / ``Malformed frontmatter (its repair would break the YAML)``
+   A mapping the byte-level repair cannot edit — a flow mapping, a mapping
+   indented as a whole, an explicit ``? key``, an alias used as a key, a
+   merge key, two keys on one line — or a block whose repair (the
+   ``updated:`` re-stamp included) would leave a strict reader rejecting it
+   or would land its fields inside a quoted value, such as an anchored
+   ``name:`` with an alias of it below or a ``name:`` line inside a quote
+   left open above it and closed below; update leaves the file untouched and
+   the parser still reads the fields it can. Rewrite the block as plain
+   ``key: value`` lines. (A block that is valid YAML but not ``key: value``
+   pairs — a bare sentence, a list — draws update's ``Malformed frontmatter
+   (not a key: value mapping)`` notice and lint's ``Invalid YAML
+   frontmatter`` issue below.)
 
 ``Invalid YAML frontmatter (line N): <reason>; <advice>``
    A strict YAML reader rejects the block — an unquoted ``': '`` inside a
@@ -534,10 +554,11 @@ topics/_index.md``). The condensed lines and what they mean:
      - Entries violating the naming policy were left unlinked.
    * - ``Skipped N concurrently-edited files (re-run `wiki update`)``
      - Files changed while update was planning; re-run to converge.
-   * - ``N pages with malformed frontmatter``
+   * - ``N files with malformed frontmatter``
      - Left untouched; the per-file notice names the reason — close an
-       unclosed block by hand, or rewrite a body that is not ``key: value``
-       pairs.
+       unclosed block by hand, rewrite a body that is not ``key: value``
+       pairs or a flow or indented mapping as column-0 ``key: value`` lines,
+       or remove the alias the repair would break.
    * - ``N empty or truncated indexes (restore from git or delete to rebuild)``
      - Left untouched; restore or delete.
 

--- a/docs/guide/merge-driver.rst
+++ b/docs/guide/merge-driver.rst
@@ -52,13 +52,16 @@ The driver splits each side of the merge — ours, base, and theirs — at the
 
 Frontmatter
    The tool-owned keys ``name:`` and ``updated:`` are normalized to the
-   current branch's lines before merging, so their churn never conflicts. On
-   an add/add merge (both branches created the index independently),
-   ``created:`` joins the normalized keys — both sides seeded the stamp from
-   their own ``wiki update`` runs, so it is churn, not authorship. The
-   remaining, authored keys — ``title:``, ``desc:``, ``category:``,
-   ``tags:``, ``sources:``, ``created:`` (ordinarily), and any custom keys —
-   get a normal three-way merge that can conflict.
+   current branch's lines before merging, so their churn never conflicts; a
+   side that lacks one of them gains the current branch's copy, so the other
+   side adding the key is no change to merge. When the base index carries no
+   ``created:`` — an add/add merge (both branches created the index
+   independently), a hand-written or imported index — ``created:`` joins the
+   normalized keys: both sides seeded the stamp from their own ``wiki update``
+   runs, so it is churn, not authorship. The remaining, authored keys —
+   ``title:``, ``desc:``, ``category:``, ``tags:``, ``sources:``,
+   ``created:`` (ordinarily), and any custom keys — get a normal three-way
+   merge that can conflict.
 
    A side whose frontmatter block cannot be detected at all — a formatter
    mangled or left unclosed the ``---`` delimiters of a block the base had —
@@ -75,7 +78,12 @@ Link block
    ``***`` line, resolve to the union of both sides' rows: the current
    branch's layout wins, and each row present only on the other side rides
    over — desc continuations included — appended above the closing ``***``.
-   No row is silently dropped; ``wiki update`` owns this region, and the
+   A row both sides carry keeps the current branch's text, unless only the
+   other side changed it against the base — an authored desc on a row
+   ``wiki update`` does not regenerate, such as an asset's — in which case
+   the other side's text lands. No row is silently dropped, and an edit only
+   one side made is never lost; when both sides edit the same row, the
+   current branch's text wins. ``wiki update`` owns this region, and the
    post-merge run re-sorts the block and prunes whatever carried rows have
    no target on the merged filesystem.
 
@@ -142,7 +150,9 @@ Lost delimiter
    edits are indistinguishable. The driver refuses to guess and emits a
    whole-file conflict, with a hint to restore the ``***`` line
    (``wiki update`` repairs it), redo the merge, and delete the hint when
-   resolving.
+   resolving. A side whose authored prose holds its own ``***`` thematic
+   break cannot be told apart this way: the driver takes the first ``***``
+   as the delimiter, so restore the delimiter line before merging.
 
 After the merge
 ---------------

--- a/docs/guide/obsidian.rst
+++ b/docs/guide/obsidian.rst
@@ -100,7 +100,11 @@ throughout Obsidian: the file explorer (including sorting), the graph,
 bookmarks, search, link suggestions, tab titles, the inline title, and the
 window frame. A ``replace`` processor strips any path prefix from the
 displayed name, so a page named ``topics/example`` displays as ``example``
-and each ``_index.md`` displays as its folder's name.
+and each ``_index.md`` displays as its folder's name. The plugin reads
+``name:`` with Obsidian's own YAML parser, so a page whose frontmatter a
+strict reader rejects (an unquoted ``': '`` inside a value, say) displays its
+raw filename instead; ``wiki lint`` reports such a block as an
+``invalid_yaml`` issue.
 
 The plugin's settings are copied from the staged configuration, but its code
 is downloaded from the pinned upstream GitHub release at setup time — the

--- a/docs/guide/pages.rst
+++ b/docs/guide/pages.rst
@@ -90,7 +90,9 @@ Frontmatter fields
      - Free-form list, seeded ``[]``.
    * - custom keys
      - author
-     - Preserved verbatim between the known fields and the timestamps.
+     - Preserved verbatim between the known fields and the timestamps, when
+       named with word characters, dots, and dashes (``com.example``); a key
+       spelled any other way (one with spaces) stays with the field above it.
    * - ``created``
      - tool
      - Stamped when the file gains frontmatter, kept from then on.
@@ -160,8 +162,11 @@ Authored descriptions must end in a period (``wiki lint`` fails one that does
 not); the seeded ``...`` placeholder only draws a soft note until it is filled
 in. A description containing a colon followed by a space, or a space followed
 by ``#`` (the start of a YAML comment), must be YAML-quoted: ``wiki lint``
-reports the unquoted colon as invalid YAML, and names the comment as the
-likely cause when a description it truncated fails the period check. Do not
+reports the unquoted colon on a one-line description, or on a continuation
+line of one, as invalid YAML — though under a bare ``desc:`` key an indented
+``Key: value`` line nests a mapping instead, which no strict reader shows as
+text and lint does not report — and names the comment as the likely cause
+when a description it truncated fails the period check. Do not
 hand-wrap a description mid-word — let the YAML block scalar carry any line
 breaks.
 
@@ -274,7 +279,11 @@ a warning rather than risk consuming the body. Likewise an index emptied of
 its frontmatter is preserved as-is — restore it from git, or delete it and let
 ``wiki update`` rebuild it. A block that is valid YAML but not ``key: value``
 pairs — a bare sentence, a list — has no fields: ``wiki update`` leaves it
-untouched with a notice and ``wiki lint`` reports it.
+untouched with a notice and ``wiki lint`` reports it. A mapping whose keys are
+not column-0 ``key:`` lines (a flow mapping, an indented one) is read but left
+untouched the same way, as is a block whose repair would leave a strict reader
+worse off — an accepted block rejected, or authored lines folded into a quoted
+value the repair closes.
 
 Region directives
 -----------------

--- a/docs/guide/pages.rst
+++ b/docs/guide/pages.rst
@@ -35,8 +35,14 @@ A page looks like this:
 
    Authored body content.
 
-Frontmatter is YAML between two ``---`` lines, and the opening ``---`` must be
-the first line of the file. Fresh frontmatter — written when a bare page is
+Frontmatter is a YAML mapping between two ``---`` lines, and the opening
+``---`` must be the first line of the file. Field values are read the way a
+strict YAML reader (Obsidian's included) reads them — a value continued on
+indented lines folds into one, a quoted value decodes, a space followed by
+``#`` starts a comment — and ``wiki lint`` reports a block a strict reader
+rejects (an unquoted ``': '`` inside a value, a duplicate key, a body that is
+not ``key: value`` pairs) as an ``invalid_yaml`` issue. Fresh frontmatter —
+written when a bare page is
 adopted or when ``wiki init`` or ``wiki update`` creates an index — contains
 exactly ``name``, a ``desc: ...`` placeholder, ``tags: []``, ``sources: []``,
 ``created``, and ``updated``, plus a ``title:`` seeded from the authored H1
@@ -153,9 +159,12 @@ propagates nothing at all: its row keeps what it has until the page's own
 
 Authored descriptions must end in a period (``wiki lint`` fails one that does
 not); the seeded ``...`` placeholder only draws a soft note until it is filled
-in. A description containing a colon followed by a space must be YAML-quoted.
-Do not hand-wrap a description mid-word — let the YAML block scalar carry any
-line breaks.
+in. A description containing a colon followed by a space, or a space followed
+by ``#`` (the start of a YAML comment), must be YAML-quoted: ``wiki lint``
+reports the unquoted colon as invalid YAML, and names the comment as the
+likely cause when a description it truncated fails the period check. Do not
+hand-wrap a description mid-word — let the YAML block scalar carry any line
+breaks.
 
 Categories
 ~~~~~~~~~~
@@ -264,7 +273,9 @@ Frontmatter that opens with ``---`` but never closes is malformed: the file
 parses as having no frontmatter, and ``wiki update`` leaves it untouched with
 a warning rather than risk consuming the body. Likewise an index emptied of
 its frontmatter is preserved as-is — restore it from git, or delete it and let
-``wiki update`` rebuild it.
+``wiki update`` rebuild it. A block that is valid YAML but not ``key: value``
+pairs — a bare sentence, a list — has no fields: ``wiki update`` leaves it
+untouched with a notice and ``wiki lint`` reports it.
 
 Region directives
 -----------------

--- a/docs/guide/pages.rst
+++ b/docs/guide/pages.rst
@@ -42,16 +42,15 @@ indented lines folds into one, a quoted value decodes, a space followed by
 ``#`` starts a comment — and ``wiki lint`` reports a block a strict reader
 rejects (an unquoted ``': '`` inside a value, a duplicate key, a body that is
 not ``key: value`` pairs) as an ``invalid_yaml`` issue. Fresh frontmatter —
-written when a bare page is
-adopted or when ``wiki init`` or ``wiki update`` creates an index — contains
-exactly ``name``, a ``desc: ...`` placeholder, ``tags: []``, ``sources: []``,
-``created``, and ``updated``, plus a ``title:`` seeded from the authored H1
-when an adopted bare page carries one (and, when ``titles.required`` is set,
-a ``title: null`` placeholder); no ``category:`` line is ever seeded. An
-index created with ``wiki new`` has the same shape but carries its authored
-``--desc`` in place of the placeholder (``wiki new`` refuses a blank or
-``...`` desc). Everything below the frontmatter is the page body, and apart
-from the H1 heading it is entirely yours.
+written when a bare page is adopted or when ``wiki init`` or ``wiki update``
+creates an index — contains exactly ``name``, a ``desc: ...`` placeholder,
+``tags: []``, ``sources: []``, ``created``, and ``updated``, plus a ``title:``
+seeded from the authored H1 when an adopted bare page carries one (and, when
+``titles.required`` is set, a ``title: null`` placeholder); no ``category:``
+line is ever seeded. An index created with ``wiki new`` has the same shape but
+carries its authored ``--desc`` in place of the placeholder (``wiki new``
+refuses a blank or ``...`` desc). Everything below the frontmatter is the page
+body, and apart from the H1 heading it is entirely yours.
 
 ``wiki update`` keeps fields in canonical order: ``name``, ``title``,
 ``desc``, ``category``, ``tags``, ``sources``, then any custom authored keys

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -301,8 +301,9 @@ indexes (fill in each new ``desc:``), prunes index rows whose target is gone
 or unindexable (excluded, gitignored, or symlinked), and repairs a mangled
 ``***`` delimiter. Everything else needs a human: names that violate the
 naming policy, pages shadowed by a same-named folder, merge conflict markers
-and leftover merge-repair hint comments, malformed frontmatter, truncated
-indexes, escaped wikilinks in page prose and hyphen dangles or wrapped list
+and leftover merge-repair hint comments, malformed frontmatter, frontmatter a
+strict YAML reader rejects, truncated indexes, escaped wikilinks in page prose
+and hyphen dangles or wrapped list
 markers (formatter and line-wrap damage), descriptions missing their trailing
 period, prose wikilinks naming a folder rather than its ``_index`` page,
 unparseable ``created:``/``updated:`` stamps, a nested ``.wiki/settings.json``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ maintainers = [
 ]
 dynamic = ["classifiers"]
 dependencies = [
+    "pyyaml>=6,<7",
     "typer>=0.24,<1",
 ]
 
@@ -55,7 +56,6 @@ security = [
 test = [
     "pytest-cov",
     "pytest-xdist",
-    "pyyaml",
 ]
 type = [
     "pyright",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,11 @@ import sys
 from collections.abc import Iterator
 
 import pytest
+import yaml
 
 import wiki
 from wiki.constants import OFFLINE_MODE
+from wiki.core import format
 
 # the CLI suite drives the installed wiki console script as a subprocess,
 # which coverage's in-process tracer cannot see; under --cov, point both the
@@ -44,6 +46,34 @@ def _isolate_trust_store(
     """
     home = tmp_path_factory.mktemp('wiki_config')
     monkeypatch.setenv('WIKI_CONFIG_DIR', str(home))
+
+
+@pytest.fixture(params=['c', 'pure'])
+def _loader(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[str]:
+    """Run the test under the C loader and again under the pure-Python loader.
+
+    The C loader is a build-time option of the PyYAML wheel, so the reader
+    falls back to the pure loader where it is missing; the ``pure`` axis
+    removes it the same way. The compose memo is keyed by block text alone,
+    so it is cleared on both axes -- before, so this loader recomposes, and
+    after, so the next test's loader does.
+    """
+    format._compose_cached.cache_clear()
+    if request.param == 'pure':
+        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    yield request.param
+    format._compose_cached.cache_clear()
+
+
+@pytest.fixture
+def _pure_loader(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Run the test under the pure-Python loader alone (see ``_loader``)."""
+    format._compose_cached.cache_clear()
+    monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    yield
+    format._compose_cached.cache_clear()
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,9 @@ import sys
 from collections.abc import Iterator
 
 import pytest
-import yaml
 
 import wiki
 from wiki.constants import OFFLINE_MODE
-from wiki.core import format
 
 # the CLI suite drives the installed wiki console script as a subprocess,
 # which coverage's in-process tracer cannot see; under --cov, point both the
@@ -46,34 +44,6 @@ def _isolate_trust_store(
     """
     home = tmp_path_factory.mktemp('wiki_config')
     monkeypatch.setenv('WIKI_CONFIG_DIR', str(home))
-
-
-@pytest.fixture(params=['c', 'pure'])
-def _loader(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[str]:
-    """Run the test under the C loader and again under the pure-Python loader.
-
-    The C loader is a build-time option of the PyYAML wheel, so the reader
-    falls back to the pure loader where it is missing; the ``pure`` axis
-    removes it the same way. The compose memo is keyed by block text alone,
-    so it is cleared on both axes -- before, so this loader recomposes, and
-    after, so the next test's loader does.
-    """
-    format._compose_cached.cache_clear()
-    if request.param == 'pure':
-        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
-    yield request.param
-    format._compose_cached.cache_clear()
-
-
-@pytest.fixture
-def _pure_loader(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Run the test under the pure-Python loader alone (see ``_loader``)."""
-    format._compose_cached.cache_clear()
-    monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
-    yield
-    format._compose_cached.cache_clear()
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/test_cli/test_utils.py
+++ b/tests/test_cli/test_utils.py
@@ -411,8 +411,9 @@ def test_trust_root_concurrent_writes_keep_every_entry(
     barrier = threading.Barrier(workers)
 
     def trust(root: pathlib.Path) -> None:
-        # release all workers into the critical section together
-        barrier.wait()
+        # release all workers into the critical section together; the bound
+        # turns a worker dying before the barrier into a failure, not a hang
+        barrier.wait(timeout=60)
         trust_root(root)
 
     with cf.ThreadPoolExecutor(max_workers=workers) as pool:

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -95,6 +95,7 @@ __all__ = [
     'test_init_writes_gitattributes_without_committing',
     'test_merge_driver_merges_authored_frontmatter',
     'test_merge_driver_moves_regenerated_keys_with_their_bodies',
+    'test_merge_driver_leaves_a_shared_blank_line_alone',
     'test_merge_unions_link_rows',
     'test_merge_keeps_frontmatter_when_side_is_mangled',
     'test_merge_dispatches_on_pathname',
@@ -2116,6 +2117,60 @@ def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     assert frontmatter.startswith('name: core\n')
     assert '\n  core\n' not in frontmatter
     assert _wiki(tmp_path, 'update', '--path', str(root), '--check').returncode == 0
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+def test_merge_driver_leaves_a_shared_blank_line_alone(tmp_path: pathlib.Path) -> None:
+    """A blank line every side shares under ``name:`` never becomes a conflict.
+
+    The normalization moves a regenerated key with the indented lines under
+    it; a blank line that separates the key from the next field is not
+    part of the value, so it must stay on every input -- dropping it from
+    base and theirs alone would make a shared line look like ours' edit.
+    """
+    root = tmp_path / 'wiki'
+    # a real repo whose wiki has the driver registered by init
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    base = (
+        '---\n'
+        'name: core\n'
+        '\n'
+        'desc: Original section.\n'
+        'created: 2026-01-01T00:00:00Z\n'
+        'updated: 2026-01-01T00:00:00Z\n'
+        '---\n'
+        '\n'
+        '# core\n'
+        '\n'
+        '***\n'
+        '\n'
+        'Body prose.\n'
+    )
+    _write(index, base)
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # theirs edits the desc, ours carries regenerated churn only
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    _write(index, base.replace('desc: Original section.', 'desc: Edited by theirs.'))
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    _write(
+        index,
+        base.replace('updated: 2026-01-01T00:00:00Z', 'updated: 2026-01-03T12:00:00Z'),
+    )
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean, theirs' desc lands, and the blank line is still one
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
+    assert frontmatter.startswith('name: core\n\ndesc: Edited by theirs.\n')
+    assert 'updated: 2026-01-03T12:00:00Z' in frontmatter
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -43,6 +43,8 @@ __all__ = [
     'test_update_narrations_condense_by_default',
     'test_update_condenses_batch_adoption',
     'test_new_requires_authored_desc_and_content',
+    'test_new_refuses_an_argument_that_is_not_utf8',
+    'test_update_counts_files_with_malformed_frontmatter',
     'test_new_refuses_interior_path',
     'test_read_only_commands_are_deterministic',
     'test_path_inside_wiki_resolves_upward',
@@ -103,8 +105,6 @@ __all__ = [
     'test_merge_driver_carries_separators_and_comments_verbatim',
     'test_merge_driver_merges_comments_as_authored_lines',
     'test_merge_driver_replaces_a_block_body_whole',
-    'test_update_counts_files_with_malformed_frontmatter',
-    'test_new_refuses_an_argument_that_is_not_utf8',
     'test_merge_unions_link_rows',
     'test_merge_keeps_frontmatter_when_side_is_mangled',
     'test_merge_dispatches_on_pathname',
@@ -694,6 +694,67 @@ def test_new_requires_authored_desc_and_content(tmp_path: pathlib.Path) -> None:
     )
     assert again.returncode == 2
     assert 'Index already exists' in again.stderr
+
+
+@pytest.mark.parametrize(
+    argnames=('command', 'option'),
+    argvalues=[
+        ('new', 'NAME'),
+        ('new', '--desc'),
+        ('new', '--content'),
+        ('init', 'NAME'),
+    ],
+    ids=['new-name', 'new-desc', 'new-content', 'init-name'],
+)
+def test_new_refuses_an_argument_that_is_not_utf8(
+    tmp_path: pathlib.Path,
+    command: str,
+    option: str,
+) -> None:
+    """An argv byte no UTF-8 decodes is refused, by option name, before anything lands on disk."""
+    root = tmp_path / 'wiki'
+    bad = 'Caf' + chr(0xDCE9) + ' au lait.'
+    if command == 'init':
+        args = ['init', bad, '--path', str(root)]
+    else:
+        assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+        values = {'NAME': 'latin', '--desc': 'A desc.', '--content': 'Body.'}
+        values[option] = bad
+        args = ['new', values['NAME'], '--desc', values['--desc']]
+        args += ['--content', values['--content'], '--path', str(root)]
+
+    # the refusal names the option and creates nothing
+    result = _wiki(tmp_path, *args)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert f'{option} is not valid UTF-8' in result.stderr
+    assert not (root / 'latin').exists()
+    if command == 'init':
+        assert not root.exists()
+
+
+def test_update_counts_files_with_malformed_frontmatter(tmp_path: pathlib.Path) -> None:
+    """Pages and indexes update cannot repair are counted as files, each reason under ``--full``."""
+    root = tmp_path / 'wiki'
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    (root / 'core').mkdir()
+    (root / 'core' / 'unclosed.md').write_text(
+        '---\nname: core/unclosed\ndesc: Never closes.\n\nBody.\n', encoding='utf-8'
+    )
+    (root / 'core' / 'listed.md').write_text(
+        '---\n- a\n- b\n---\n\n# listed\n\nBody.\n', encoding='utf-8'
+    )
+
+    # the condensed run counts both; the full run names each reason
+    condensed = _wiki(root, 'update', '--path', str(root))
+    assert condensed.returncode == 0, condensed.stdout + condensed.stderr
+    assert '2 files with malformed frontmatter' in condensed.stderr
+    full = _wiki(root, 'update', '--path', str(root), '--full')
+    assert full.returncode == 0, full.stdout + full.stderr
+    assert 'Malformed frontmatter (no closing ---) in core/unclosed.md' in full.stderr
+    assert (
+        'Malformed frontmatter (not a key: value mapping) in core/listed.md'
+        in full.stderr
+    )
 
 
 def test_new_refuses_interior_path(tmp_path: pathlib.Path) -> None:
@@ -2623,67 +2684,6 @@ def test_merge_driver_replaces_a_block_body_whole(tmp_path: pathlib.Path) -> Non
     frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
     assert frontmatter.startswith('name: core\ndesc: Edited by theirs.\n')
     assert '# note' not in frontmatter
-
-
-@pytest.mark.parametrize(
-    argnames=('command', 'option'),
-    argvalues=[
-        ('new', 'NAME'),
-        ('new', '--desc'),
-        ('new', '--content'),
-        ('init', 'NAME'),
-    ],
-    ids=['new-name', 'new-desc', 'new-content', 'init-name'],
-)
-def test_new_refuses_an_argument_that_is_not_utf8(
-    tmp_path: pathlib.Path,
-    command: str,
-    option: str,
-) -> None:
-    """An argv byte no UTF-8 decodes is refused, by option name, before anything lands on disk."""
-    root = tmp_path / 'wiki'
-    bad = 'Caf' + chr(0xDCE9) + ' au lait.'
-    if command == 'init':
-        args = ['init', bad, '--path', str(root)]
-    else:
-        assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
-        values = {'NAME': 'latin', '--desc': 'A desc.', '--content': 'Body.'}
-        values[option] = bad
-        args = ['new', values['NAME'], '--desc', values['--desc']]
-        args += ['--content', values['--content'], '--path', str(root)]
-
-    # the refusal names the option and creates nothing
-    result = _wiki(tmp_path, *args)
-    assert result.returncode == 2, result.stdout + result.stderr
-    assert f'{option} is not valid UTF-8' in result.stderr
-    assert not (root / 'latin').exists()
-    if command == 'init':
-        assert not root.exists()
-
-
-def test_update_counts_files_with_malformed_frontmatter(tmp_path: pathlib.Path) -> None:
-    """Pages and indexes update cannot repair are counted as files, each reason under ``--full``."""
-    root = tmp_path / 'wiki'
-    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
-    (root / 'core').mkdir()
-    (root / 'core' / 'unclosed.md').write_text(
-        '---\nname: core/unclosed\ndesc: Never closes.\n\nBody.\n', encoding='utf-8'
-    )
-    (root / 'core' / 'listed.md').write_text(
-        '---\n- a\n- b\n---\n\n# listed\n\nBody.\n', encoding='utf-8'
-    )
-
-    # the condensed run counts both; the full run names each reason
-    condensed = _wiki(root, 'update', '--path', str(root))
-    assert condensed.returncode == 0, condensed.stdout + condensed.stderr
-    assert '2 files with malformed frontmatter' in condensed.stderr
-    full = _wiki(root, 'update', '--path', str(root), '--full')
-    assert full.returncode == 0, full.stdout + full.stderr
-    assert 'Malformed frontmatter (no closing ---) in core/unclosed.md' in full.stderr
-    assert (
-        'Malformed frontmatter (not a key: value mapping) in core/listed.md'
-        in full.stderr
-    )
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -95,7 +95,16 @@ __all__ = [
     'test_init_writes_gitattributes_without_committing',
     'test_merge_driver_merges_authored_frontmatter',
     'test_merge_driver_moves_regenerated_keys_with_their_bodies',
+    'test_merge_driver_takes_the_other_sides_row_edit',
+    'test_merge_driver_normalizes_created_over_a_stampless_base',
+    'test_merge_driver_keeps_a_row_edit_on_a_crlf_index',
+    'test_merge_driver_unions_rows_of_an_add_add_merge',
     'test_merge_driver_leaves_a_shared_blank_line_alone',
+    'test_merge_driver_carries_separators_and_comments_verbatim',
+    'test_merge_driver_merges_comments_as_authored_lines',
+    'test_merge_driver_replaces_a_block_body_whole',
+    'test_update_counts_files_with_malformed_frontmatter',
+    'test_new_refuses_an_argument_that_is_not_utf8',
     'test_merge_unions_link_rows',
     'test_merge_keeps_frontmatter_when_side_is_mangled',
     'test_merge_dispatches_on_pathname',
@@ -2045,8 +2054,16 @@ def test_merge_driver_merges_authored_frontmatter(tmp_path: pathlib.Path) -> Non
         ('theirs', 'name: |\n  core\n'),
         ('ours', 'name: |\n  core\n'),
         ('theirs', 'name : core\n'),
+        ('theirs', 'name:\n  # which name\n  core\n'),
+        ('ours', 'name:\n  # which name\n  core\n'),
     ],
-    ids=['theirs-block', 'ours-block', 'theirs-spaced-colon'],
+    ids=[
+        'theirs-block',
+        'ours-block',
+        'theirs-spaced-colon',
+        'theirs-comment-then-body',
+        'ours-comment-then-body',
+    ],
 )
 def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     tmp_path: pathlib.Path,
@@ -2131,6 +2148,231 @@ def test_merge_driver_moves_regenerated_keys_with_their_bodies(
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')
+def test_merge_driver_takes_the_other_sides_row_edit(tmp_path: pathlib.Path) -> None:
+    """A row both sides carry takes theirs' text when only theirs changed it against the base.
+
+    An asset row's desc is authored in the index alone -- ``wiki update``
+    regenerates no desc for it -- so ours' unchanged copy must not win over
+    theirs' edit, or the edit is lost with a clean merge.
+    """
+    root = tmp_path / 'wiki'
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    (root / 'core').mkdir()
+    (root / 'core' / 'diagram.png').write_bytes(b'\x89PNG\r\n')
+    assert _wiki(root, 'update', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    base = index.read_text(encoding='utf-8')
+    row = '[[core/diagram.png|diagram.png]]: ...'
+    assert row in base
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # theirs authors the asset row's desc; ours adds a row directly under it
+    # (no blank between the rows) and edits the prose below ***
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    _write(index, base.replace(row, '[[core/diagram.png|diagram.png]]: The diagram.'))
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    (root / 'core' / 'zeta.png').write_bytes(b'\x89PNG\r\n')
+    ours = base.replace(f'{row}\n\n', f'{row}\n[[core/zeta.png|zeta.png]]: Zeta.\n\n')
+    _write(index, ours + '\nOurs wrote prose.\n')
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'ours')
+
+    # the merge is clean and carries theirs' desc on the shared row, in
+    # ours' layout
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    merged = index.read_text(encoding='utf-8')
+    assert (
+        '[[core/diagram.png|diagram.png]]: The diagram.\n[[core/zeta.png|zeta.png]]: Zeta.\n\n'
+        in merged
+    )
+    assert 'Ours wrote prose.' in merged
+    # update re-spaces the rows and keeps the authored asset desc
+    update = _wiki(root, 'update', '--path', str(root))
+    assert update.returncode == 0, update.stdout + update.stderr
+    assert '[[core/diagram.png|diagram.png]]: The diagram.' in index.read_text(
+        encoding='utf-8'
+    )
+    check = _wiki(root, 'update', '--path', str(root), '--check')
+    assert check.returncode == 0, check.stdout + check.stderr
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+@pytest.mark.parametrize(
+    argnames=('base_block', 'crlf'),
+    argvalues=[
+        ('name: core\ndesc: Original section.', False),
+        ('desc: Original section.', False),
+        ('name: core\ndesc: Original section.\ncreated:\nupdated:', False),
+        ('name: core\ndesc: Original section.\ncreated:\nupdated:', True),
+    ],
+    ids=['stampless', 'nameless', 'valueless-stamps', 'valueless-stamps-crlf'],
+)
+def test_merge_driver_normalizes_created_over_a_stampless_base(
+    tmp_path: pathlib.Path,
+    base_block: str,
+    crlf: bool,
+) -> None:
+    """A base index without stamps (or a name) gets them from each side's own update: churn, not a conflict.
+
+    A side lacking a regenerated key gains ours' copy where ``wiki
+    update`` puts it -- ``name:`` under the opening fence, the stamps
+    above the closing one -- so the other side adding the key is no
+    change beside its authored edit.
+    """
+    root = tmp_path / 'wiki'
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    base = f'---\n{base_block}\n---\n\n# core\n\n***\n\nBody prose.\n'
+    if crlf:
+        index.parent.mkdir(parents=True, exist_ok=True)
+        index.write_bytes(base.replace('\n', '\r\n').encode('utf-8'))
+    else:
+        _write(index, base)
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # each side's wiki update names and stamps the block on its own clock
+    def updated(text: str, clock: str) -> str:
+        stamps = f'created: {clock}\nupdated: {clock}\n'
+        if 'created:' in text:
+            text = text.replace('created:\nupdated:\n', stamps)
+        else:
+            text = text.replace('---\n\n# core', f'{stamps}---\n\n# core')
+        if 'name:' not in text:
+            text = text.replace('---\n', '---\nname: core\n', 1)
+        return text
+
+    # a CRLF base is normalized to LF by both sides' updates identically, so
+    # only the stamps differ there (an authored edit beside re-ended lines is
+    # an ordinary three-way conflict); an LF base carries authored edits too
+    edit = 'Original section.' if crlf else 'Edited by theirs.'
+    prose = '' if crlf else 'Ours wrote prose.\n'
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    theirs = updated(base.replace('Original section.', edit), '2026-01-01T00:00:07Z')
+    _write(index, theirs)
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    _write(index, updated(base, '2026-01-01T00:00:00Z') + prose)
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean: ours' name and stamps, theirs' desc, both bodies
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    merged = index.read_text(encoding='utf-8')
+    assert merged.startswith('---\nname: core\n')
+    assert 'created: 2026-01-01T00:00:00Z\n' in merged
+    assert merged.count('created:') == 1
+    assert merged.count('name:') == 1
+    assert f'desc: {edit}' in merged
+    if prose:
+        assert prose in merged
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+@pytest.mark.parametrize(
+    argnames=('endings', 'blank'),
+    argvalues=[('\r\n', '\r\n'), ('\n', ' \n')],
+    ids=['crlf', 'whitespace-separator'],
+)
+def test_merge_driver_keeps_a_row_edit_on_a_crlf_index(
+    tmp_path: pathlib.Path,
+    endings: str,
+    blank: str,
+) -> None:
+    r"""The row rule compares rows without their trailing blanks, CRLF and whitespace-only ones too.
+
+    A CRLF blank line is ``\r\n`` and a whitespace-only separator holds
+    spaces: a strip that only knows ``\n`` leaves ours' re-spaced block
+    unequal to base's, and theirs' authored row edit silently loses to
+    ours' unchanged text.
+    """
+    root = tmp_path / 'wiki'
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    (root / 'core').mkdir()
+    index = root / 'core' / '_index.md'
+    row = '[[core/diagram.png|diagram.png]]: Base diagram.'
+    base = (
+        '---\nname: core\ndesc: Core.\ncreated: 2026-01-01T00:00:00Z\n'
+        f'updated: 2026-01-01T00:00:00Z\n---\n\n# core\n\n{row}\n***\n'
+    ).replace('\n', endings)
+    index.write_bytes(base.encode('utf-8'))
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # theirs edits the row's desc; ours only re-spaces the block
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    index.write_bytes(base.replace('Base diagram.', 'Theirs diagram.').encode('utf-8'))
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    index.write_bytes(
+        base.replace(f'{row}{endings}', f'{row}{endings}{blank}').encode('utf-8')
+    )
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean and theirs' edit lands in ours' spacing
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    merged = index.read_bytes().decode('utf-8')
+    assert (
+        f'[[core/diagram.png|diagram.png]]: Theirs diagram.{endings}{blank}' in merged
+    )
+    assert 'Base diagram.' not in merged
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+def test_merge_driver_unions_rows_of_an_add_add_merge(tmp_path: pathlib.Path) -> None:
+    """Two indexes created independently merge to both sides' rows, the H1, and the ``***`` line kept.
+
+    With no base file the driver's first input is empty; the parts must
+    still be told apart, or ours' link block is read as a side to
+    collect and never printed.
+    """
+    root = tmp_path / 'wiki'
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+    index = root / 'core' / '_index.md'
+    frontmatter = (
+        '---\nname: core\ndesc: Core section.\ntags: []\nsources: []\n'
+        'created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n\n# core\n\n'
+    )
+
+    # each side creates the index with its own child row
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    _write(index, frontmatter + '[[core/beta|beta]]: Beta page.\n\n***\n')
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    _write(index, frontmatter + '[[core/alpha|alpha]]: Alpha page.\n\n***\n')
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'ours')
+
+    # the merge keeps the H1, both rows, and the delimiter
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    merged = index.read_text(encoding='utf-8')
+    assert '\n# core\n' in merged
+    assert '[[core/alpha|alpha]]: Alpha page.' in merged
+    assert '[[core/beta|beta]]: Beta page.' in merged
+    assert merged.rstrip().endswith('***')
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
 def test_merge_driver_leaves_a_shared_blank_line_alone(tmp_path: pathlib.Path) -> None:
     """A blank line every side shares under ``name:`` never becomes a conflict.
 
@@ -2182,6 +2424,266 @@ def test_merge_driver_leaves_a_shared_blank_line_alone(tmp_path: pathlib.Path) -
     frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
     assert frontmatter.startswith('name: core\n\ndesc: Edited by theirs.\n')
     assert 'updated: 2026-01-03T12:00:00Z' in frontmatter
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+@pytest.mark.parametrize(
+    argnames=('separator', 'theirs_extra', 'ours_name', 'survives'),
+    argvalues=[
+        ('\r\n', '', 'name: core\r\n', 'name: core\r\n\r\ndesc: Edited by theirs.\r\n'),
+        (
+            '\n',
+            '  # note\n',
+            'name: core\n',
+            'name: core\n  # note\n\ndesc: Edited by theirs.\n',
+        ),
+        ('\n', '', 'name: |\n' + '  core\n' * 40_000, 'name: |\n  core\n  core\n'),
+        (
+            '\n',
+            '# section\n',
+            'name: core\n# section\n',
+            'name: core\n# section\n\ndesc: Edited by theirs.\n',
+        ),
+    ],
+    ids=['crlf-separator', 'theirs-comment', 'huge-extent', 'shared-comment'],
+)
+def test_merge_driver_carries_separators_and_comments_verbatim(
+    tmp_path: pathlib.Path,
+    separator: str,
+    theirs_extra: str,
+    ours_name: str,
+    survives: str,
+) -> None:
+    """The normalization moves bytes verbatim and keeps what is authored.
+
+    A shared separator line keeps its CRLF ending on every side, so it
+    never reads as ours' edit; a comment theirs wrote under a regenerated
+    key is authored and reaches the merge; and an extent of any size
+    travels through a file, not the environment.
+    """
+    root = tmp_path / 'wiki'
+    # a real repo whose wiki has the driver registered by init
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    index.parent.mkdir()
+    base = separator.join(
+        [
+            '---',
+            'name: core',
+            '',
+            'desc: Original section.',
+            'created: 2026-01-01T00:00:00Z',
+            'updated: 2026-01-01T00:00:00Z',
+            '---',
+            '',
+            '# core',
+            '',
+            '***',
+            '',
+            'Body prose.',
+            '',
+        ]
+    )
+    index.write_bytes(base.encode('utf-8'))
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # theirs edits the desc (and may annotate the name); ours regenerates
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    theirs = base.replace('desc: Original section.', 'desc: Edited by theirs.')
+    theirs = theirs.replace(
+        f'name: core{separator}', f'name: core{separator}{theirs_extra}'
+    )
+    index.write_bytes(theirs.encode('utf-8'))
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    ours = base.replace(
+        'updated: 2026-01-01T00:00:00Z', 'updated: 2026-01-03T12:00:00Z'
+    )
+    ours = ours.replace(f'name: core{separator}', ours_name)
+    index.write_bytes(ours.encode('utf-8'))
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean and the bytes that must survive do
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    merged = index.read_bytes().decode('utf-8')
+    assert survives in merged
+    assert 'desc: Edited by theirs.' in merged
+    assert 'updated: 2026-01-03T12:00:00Z' in merged
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+@pytest.mark.parametrize(
+    argnames=('theirs_comment', 'present', 'absent'),
+    argvalues=[
+        ('', 'name: core\ndesc: Edited by theirs.\n', '# section slug'),
+        (
+            '# section renamed\n',
+            'name: core\n# section renamed\ndesc:',
+            '# section slug',
+        ),
+        ('  # section slug\n', 'name: core\n  # section slug\ndesc:', '\n\n'),
+    ],
+    ids=['deleted', 'reworded', 'indented-shared'],
+)
+def test_merge_driver_merges_comments_as_authored_lines(
+    tmp_path: pathlib.Path,
+    theirs_comment: str,
+    present: str,
+    absent: str,
+) -> None:
+    """A comment under a regenerated key is authored: a deletion or rewording on one side lands.
+
+    The driver normalizes the key's value lines alone; a comment line
+    (indented or not) is outside the extent, so a side that deletes or
+    rewords it wins the ordinary three-way merge instead of having ours'
+    copy resurrect it or a spurious conflict raised.
+    """
+    root = tmp_path / 'wiki'
+    # a real repo whose wiki has the driver registered by init
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    index.parent.mkdir()
+    base_comment = (
+        '  # section slug\n' if theirs_comment.startswith('  ') else '# section slug\n'
+    )
+    base = (
+        f'---\nname: core\n{base_comment}desc: Original section.\n'
+        'created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n\n'
+        '# core\n\n***\n\nBody prose.\n'
+    )
+    _write(index, base)
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # theirs edits the comment and the desc; ours regenerates the stamp
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    theirs = base.replace(base_comment, theirs_comment)
+    theirs = theirs.replace('desc: Original section.', 'desc: Edited by theirs.')
+    _write(index, theirs)
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    _write(
+        index,
+        base.replace('updated: 2026-01-01T00:00:00Z', 'updated: 2026-01-03T12:00:00Z'),
+    )
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean and theirs' comment edit lands beside ours' stamp
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    merged = index.read_text(encoding='utf-8')
+    assert present in merged
+    assert absent not in merged.split('---\n')[1]
+    assert 'updated: 2026-01-03T12:00:00Z' in merged
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+def test_merge_driver_replaces_a_block_body_whole(tmp_path: pathlib.Path) -> None:
+    """An indented comment inside a block-scalar name is value, replaced with the rest of the body."""
+    root = tmp_path / 'wiki'
+    # a real repo whose wiki has the driver registered by init
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    index.parent.mkdir()
+    base = (
+        '---\nname: core\ndesc: Original section.\n'
+        'created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n\n'
+        '# core\n\n***\n\nBody prose.\n'
+    )
+    _write(index, base)
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # theirs writes the name as a block whose body holds a hash line
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    theirs = base.replace('name: core\n', 'name: |\n  core\n  # note\n')
+    _write(index, theirs.replace('desc: Original section.', 'desc: Edited by theirs.'))
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    _write(
+        index,
+        base.replace('updated: 2026-01-01T00:00:00Z', 'updated: 2026-01-03T12:00:00Z'),
+    )
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean; ours' one-line name replaces theirs' whole block
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
+    assert frontmatter.startswith('name: core\ndesc: Edited by theirs.\n')
+    assert '# note' not in frontmatter
+
+
+@pytest.mark.parametrize(
+    argnames=('command', 'option'),
+    argvalues=[
+        ('new', 'NAME'),
+        ('new', '--desc'),
+        ('new', '--content'),
+        ('init', 'NAME'),
+    ],
+    ids=['new-name', 'new-desc', 'new-content', 'init-name'],
+)
+def test_new_refuses_an_argument_that_is_not_utf8(
+    tmp_path: pathlib.Path,
+    command: str,
+    option: str,
+) -> None:
+    """An argv byte no UTF-8 decodes is refused, by option name, before anything lands on disk."""
+    root = tmp_path / 'wiki'
+    bad = 'Caf' + chr(0xDCE9) + ' au lait.'
+    if command == 'init':
+        args = ['init', bad, '--path', str(root)]
+    else:
+        assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+        values = {'NAME': 'latin', '--desc': 'A desc.', '--content': 'Body.'}
+        values[option] = bad
+        args = ['new', values['NAME'], '--desc', values['--desc']]
+        args += ['--content', values['--content'], '--path', str(root)]
+
+    # the refusal names the option and creates nothing
+    result = _wiki(tmp_path, *args)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert f'{option} is not valid UTF-8' in result.stderr
+    assert not (root / 'latin').exists()
+    if command == 'init':
+        assert not root.exists()
+
+
+def test_update_counts_files_with_malformed_frontmatter(tmp_path: pathlib.Path) -> None:
+    """Pages and indexes update cannot repair are counted as files, each reason under ``--full``."""
+    root = tmp_path / 'wiki'
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    (root / 'core').mkdir()
+    (root / 'core' / 'unclosed.md').write_text(
+        '---\nname: core/unclosed\ndesc: Never closes.\n\nBody.\n', encoding='utf-8'
+    )
+    (root / 'core' / 'listed.md').write_text(
+        '---\n- a\n- b\n---\n\n# listed\n\nBody.\n', encoding='utf-8'
+    )
+
+    # the condensed run counts both; the full run names each reason
+    condensed = _wiki(root, 'update', '--path', str(root))
+    assert condensed.returncode == 0, condensed.stdout + condensed.stderr
+    assert '2 files with malformed frontmatter' in condensed.stderr
+    full = _wiki(root, 'update', '--path', str(root), '--full')
+    assert full.returncode == 0, full.stdout + full.stderr
+    assert 'Malformed frontmatter (no closing ---) in core/unclosed.md' in full.stderr
+    assert (
+        'Malformed frontmatter (not a key: value mapping) in core/listed.md'
+        in full.stderr
+    )
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -94,6 +94,7 @@ __all__ = [
     'test_merge_driver_no_op_without_git',
     'test_init_writes_gitattributes_without_committing',
     'test_merge_driver_merges_authored_frontmatter',
+    'test_merge_driver_moves_regenerated_keys_with_their_bodies',
     'test_merge_unions_link_rows',
     'test_merge_keeps_frontmatter_when_side_is_mangled',
     'test_merge_dispatches_on_pathname',
@@ -2034,6 +2035,87 @@ def test_merge_driver_merges_authored_frontmatter(tmp_path: pathlib.Path) -> Non
     assert 'desc: Theirs again.' in text
     assert 'title: Ours retitled' in text
     assert 'title: Theirs retitled' in text
+
+
+@pytest.mark.skipif(GIT is None, reason='git not on PATH')
+@pytest.mark.parametrize('side', ['theirs', 'ours'])
+def test_merge_driver_moves_regenerated_keys_with_their_bodies(
+    tmp_path: pathlib.Path,
+    side: str,
+) -> None:
+    """A regenerated key is normalized as a whole extent, indented body included.
+
+    The driver normalizes ``name:`` to ours on every input; a value
+    written as a block scalar spans two lines, and swapping the key line
+    alone would strand the other side's body under ours' one-liner,
+    where a strict reader folds it into the name. Ours' whole extent
+    replaces theirs' whole extent -- whichever side wrote the block --
+    and ``wiki update`` then joins a surviving block onto one line.
+    """
+    root = tmp_path / 'wiki'
+    # a real repo whose wiki has the driver registered by init
+    assert _git(tmp_path, 'init', '-q', '-b', 'main').returncode == 0
+    _git(tmp_path, 'config', 'user.email', 't@t')
+    _git(tmp_path, 'config', 'user.name', 't')
+    assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
+    index = root / 'core' / '_index.md'
+    base = (
+        '---\n'
+        'name: core\n'
+        'desc: Original section.\n'
+        'tags: []\n'
+        'sources: []\n'
+        'created: 2026-01-01T00:00:00Z\n'
+        'updated: 2026-01-01T00:00:00Z\n'
+        '---\n'
+        '\n'
+        '# core\n'
+        '\n'
+        '***\n'
+        '\n'
+        'Body prose.\n'
+    )
+    _write(index, base)
+    _git(tmp_path, 'add', '-A')
+    _git(tmp_path, 'commit', '-q', '-m', 'base')
+
+    # one side writes the name as a block scalar; each side edits something
+    # of its own so the merge reaches the driver
+    block = 'name: |\n  core\n'
+    _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
+    theirs = base.replace('desc: Original section.', 'desc: Edited by theirs.')
+    if side == 'theirs':
+        theirs = theirs.replace('name: core\n', block)
+    _write(index, theirs)
+    _git(tmp_path, 'commit', '-q', '-am', 'theirs')
+    _git(tmp_path, 'checkout', '-q', 'main')
+    ours = base.replace(
+        'updated: 2026-01-01T00:00:00Z',
+        'updated: 2026-01-03T12:00:00Z',
+    )
+    if side == 'ours':
+        ours = ours.replace('name: core\n', block)
+    _write(index, ours)
+    _git(tmp_path, 'commit', '-q', '-am', 'ours')
+
+    # the merge is clean and carries exactly ours' name extent
+    merge = _git(tmp_path, 'merge', 'theirs')
+    assert merge.returncode == 0, merge.stdout + merge.stderr
+    frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
+    assert frontmatter.count('name:') == 1
+    if side == 'ours':
+        assert block in frontmatter
+    else:
+        assert frontmatter.startswith('name: core\n')
+        assert '\n  core\n' not in frontmatter
+    assert 'desc: Edited by theirs.' in frontmatter
+
+    # update joins a surviving block onto one line and converges
+    assert _wiki(tmp_path, 'update', '--path', str(root)).returncode == 0
+    frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
+    assert frontmatter.startswith('name: core\n')
+    assert '\n  core\n' not in frontmatter
+    assert _wiki(tmp_path, 'update', '--path', str(root), '--check').returncode == 0
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -1362,25 +1362,26 @@ def test_lint_details_issues_and_count_condenses(
     root = tmp_path / 'wiki'
     assert _wiki(tmp_path, 'init', '--path', str(root)).returncode == 0
     _write(root / 'core' / '_index.md', _index('Core', 'Core concepts.', 'Text.'))
-    pages = [f'page{i}' for i in range(8)]
+    page_count = 8  # one dangling row per deleted page
+    pages = [f'page{i}' for i in range(page_count)]
     for page in pages:
         _write(root / 'core' / f'{page}.md', _page(page, f'The {page} page.', 'Body.'))
     assert _wiki(root, 'update', '--path', str(root)).returncode == 0
-    # delete every page: eight dangling rows plus the pending prune diff
+    # delete every page: one dangling row each plus the pending prune diff
     for page in pages:
         (root / 'core' / f'{page}.md').unlink()
 
     # the default (detailed) view lists every broken link plus the summary
     default = _wiki(root, 'lint', '--path', str(root))
     assert default.returncode == 1
-    assert default.stdout.count('Broken link [[') == 8
-    assert '9 issues' in default.stdout
+    assert default.stdout.count('Broken link [[') == page_count
+    assert f'{page_count + 1} issues' in default.stdout
 
     # --count condenses to the summary; the notes leave stderr too
     count = _wiki(root, 'lint', '--path', str(root), '--count')
     assert count.returncode == 1
     assert count.stdout.count('Broken link [[') == 0
-    assert '9 issues' in count.stdout
+    assert f'{page_count + 1} issues' in count.stdout
     assert 'Needs desc' not in count.stderr
 
     # --full is the explicit default; combining the modes is a usage error

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -2039,10 +2039,19 @@ def test_merge_driver_merges_authored_frontmatter(tmp_path: pathlib.Path) -> Non
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')
-@pytest.mark.parametrize('side', ['theirs', 'ours'])
+@pytest.mark.parametrize(
+    argnames=('side', 'block'),
+    argvalues=[
+        ('theirs', 'name: |\n  core\n'),
+        ('ours', 'name: |\n  core\n'),
+        ('theirs', 'name : core\n'),
+    ],
+    ids=['theirs-block', 'ours-block', 'theirs-spaced-colon'],
+)
 def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     tmp_path: pathlib.Path,
     side: str,
+    block: str,
 ) -> None:
     """A regenerated key is normalized as a whole extent, indented body included.
 
@@ -2050,8 +2059,9 @@ def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     written as a block scalar spans two lines, and swapping the key line
     alone would strand the other side's body under ours' one-liner,
     where a strict reader folds it into the name. Ours' whole extent
-    replaces theirs' whole extent -- whichever side wrote the block --
-    and ``wiki update`` then joins a surviving block onto one line.
+    replaces theirs' whole extent -- whichever side wrote the block, and
+    whether theirs spells the key ``name:`` or ``name :`` -- and
+    ``wiki update`` then joins a surviving block onto one line.
     """
     root = tmp_path / 'wiki'
     # a real repo whose wiki has the driver registered by init
@@ -2080,9 +2090,8 @@ def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     _git(tmp_path, 'add', '-A')
     _git(tmp_path, 'commit', '-q', '-m', 'base')
 
-    # one side writes the name as a block scalar; each side edits something
+    # one side writes the name in its own shape; each side edits something
     # of its own so the merge reaches the driver
-    block = 'name: |\n  core\n'
     _git(tmp_path, 'checkout', '-q', '-b', 'theirs')
     theirs = base.replace('desc: Original section.', 'desc: Edited by theirs.')
     if side == 'theirs':
@@ -2103,7 +2112,7 @@ def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     merge = _git(tmp_path, 'merge', 'theirs')
     assert merge.returncode == 0, merge.stdout + merge.stderr
     frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
-    assert frontmatter.count('name:') == 1
+    assert len(re.findall(r'^name[ \t]*:', frontmatter, re.M)) == 1
     if side == 'ours':
         assert block in frontmatter
     else:
@@ -2112,11 +2121,13 @@ def test_merge_driver_moves_regenerated_keys_with_their_bodies(
     assert 'desc: Edited by theirs.' in frontmatter
 
     # update joins a surviving block onto one line and converges
-    assert _wiki(tmp_path, 'update', '--path', str(root)).returncode == 0
+    update = _wiki(root, 'update', '--path', str(root))
+    assert update.returncode == 0, update.stdout + update.stderr
     frontmatter = index.read_text(encoding='utf-8').split('---\n')[1]
     assert frontmatter.startswith('name: core\n')
     assert '\n  core\n' not in frontmatter
-    assert _wiki(tmp_path, 'update', '--path', str(root), '--check').returncode == 0
+    check = _wiki(root, 'update', '--path', str(root), '--check')
+    assert check.returncode == 0, check.stdout + check.stderr
 
 
 @pytest.mark.skipif(GIT is None, reason='git not on PATH')

--- a/tests/test_core/_oracle.py
+++ b/tests/test_core/_oracle.py
@@ -23,6 +23,7 @@ __all__ = [
     'BODIES',
     'DECOS',
     'EXTRAS',
+    'SEQUENCES',
     'NAME',
     'NOW',
     'block',
@@ -33,6 +34,7 @@ __all__ = [
     'oracle_scalar',
     'oracle_mapping',
     'oracle_valid',
+    'oracle_extent',
     'normalize',
 ]
 
@@ -127,6 +129,12 @@ EXTRAS = [
     ('local-tag', 'desc', ['desc: !bang Alpha beta.']),
     ('bool-like', 'title', ['title: yes']),
     ('sexagesimal', 'title', ['title: 1:20']),
+]
+#: sequence-valued shapes, which the reader never resolves but whose line
+#: extents must still scope right, as ``(id, key, field lines)``
+SEQUENCES = [
+    ('column0-url-items', 'sources', ['sources:', '- https://doi.org/x', '- b']),
+    ('indented-items', 'tags', ['tags:', '  - a', '  - b']),
 ]
 #: the repair's path-derived name and clock
 NAME = 'fixed/page'
@@ -271,6 +279,28 @@ def oracle_valid(body: str) -> bool:
         return False
     keys = [key_node.value for key_node, _ in node.value]
     return len(keys) == len(set(keys))
+
+
+def oracle_extent(body: str, key: str) -> set[int]:
+    """Return the 1-based file lines a strict reader's key marks give ``key``.
+
+    The top-level keys' start marks partition the body: every line from
+    a key's line up to the line before the next key's belongs to that
+    key -- comments, blanks, and sequence items included -- and the last
+    key runs to the end of the body. Body line 0 is file line 2, after
+    the opening fence.
+    """
+    node = yaml.compose(body, Loader=_LOADER)
+    starts = sorted(key_node.start_mark.line for key_node, _ in node.value)
+    last = len(body.rstrip('\n').split('\n'))
+    for key_node, _ in node.value:
+        if key_node.value != key:
+            continue
+        start = key_node.start_mark.line
+        following = [line for line in starts if line > start]
+        end = following[0] if following else last
+        return set(range(start + 2, end + 2))
+    return set()
 
 
 def normalize(text: Optional[str]) -> str:

--- a/tests/test_core/_oracle.py
+++ b/tests/test_core/_oracle.py
@@ -1,0 +1,283 @@
+"""Frontmatter grammar and strict-YAML oracle for the ``wiki.core.format`` tests.
+
+The grammar enumerates one field under test in every scalar style the
+on-disk format admits, over a set of body shapes and decorations, inside
+a closed block with fixed neighbors; PyYAML's ``compose`` supplies the
+value a strict reader sees (scalar text with folding, chomping, and
+escapes applied, no type coercion) and ``safe_load`` the whole mapping.
+The extras table adds the valid shapes the grammar's axes do not reach
+-- comments on the key line, quoted and block openers under a bare key,
+end-of-line comments, escaped line breaks, a space before the colon,
+node properties -- which hand-derived reading rules miss first.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import yaml
+
+__all__ = [
+    'KEYS',
+    'STYLES',
+    'BODIES',
+    'DECOS',
+    'EXTRAS',
+    'NAME',
+    'NOW',
+    'block',
+    'field_lines',
+    'frontmatter',
+    'grammar',
+    'yaml_body',
+    'oracle_scalar',
+    'oracle_mapping',
+    'oracle_valid',
+    'normalize',
+]
+
+#: keys under test: the six schema keys, the optional pair, a custom key and
+#: a dotted key outside the ``[\w-]+`` field grammar
+KEYS = [
+    'name',
+    'title',
+    'desc',
+    'category',
+    'tags',
+    'sources',
+    'created',
+    'updated',
+    'custom_key',
+    'com.example',
+]
+#: scalar styles: one-line plain, plain continuing below the key line, plain
+#: under a bare key, the two quoted forms, and every block-scalar header
+STYLES = [
+    'plain',
+    'plain-inline-multi',
+    'bare-key-multi',
+    'single-quoted',
+    'double-quoted',
+    '|',
+    '|-',
+    '|+',
+    '>',
+    '>-',
+    '>+',
+    '|2',
+]
+#: body shapes a multi-line value can take
+BODIES = [
+    'one-line',
+    'two-lines',
+    'paragraph-break',
+    'trailing-blanks',
+    'more-indented',
+    'ws-only-over-indented',
+]
+#: decorations around the field: comments, stray blanks, trailing spaces
+DECOS = [
+    'none',
+    'comment-before',
+    'comment-after-indented',
+    'blank-before',
+    'blank-after',
+    'trailing-spaces',
+]
+#: valid shapes off the grammar's axes as ``(id, key, field lines)``
+EXTRAS = [
+    ('keyline-comment-body', 'desc', ['desc: # authored note', '  Alpha beta.']),
+    ('keyline-comment-no-body', 'title', ['title: # TODO']),
+    (
+        'keyline-comment-block-header',
+        'desc',
+        ['desc: | # header note', '  Alpha beta.'],
+    ),
+    ('bare-key-single-quoted', 'desc', ['desc:', "  'A: colon here.'"]),
+    ('bare-key-double-quoted', 'title', ['title:', '  "Draft: one"']),
+    ('bare-key-literal-own-line', 'desc', ['desc:', '  |', '    Alpha beta.']),
+    (
+        'bare-key-folded-own-line',
+        'desc',
+        ['desc:', '  >-', '    Alpha beta.', '    Gamma delta.'],
+    ),
+    ('quoted-eol-comment', 'desc', ["desc: 'Alpha beta.'  # trailing comment"]),
+    ('plain-eol-comment', 'desc', ['desc: Alpha beta.  # trailing comment']),
+    ('null-eol-comment', 'title', ['title: null # why']),
+    ('dq-escaped-linebreak', 'desc', ['desc: "Alpha \\', '  Gamma delta."']),
+    (
+        'dq-multiline-hash-line',
+        'desc',
+        ['desc: "Alpha beta.', '  # not a comment', '  Gamma delta."'],
+    ),
+    (
+        'sq-doubled-quote-multiline',
+        'desc',
+        ["desc: 'Alpha beta.", "  ''quoted'' gamma.'"],
+    ),
+    (
+        'plain-inline-multi-two-blanks',
+        'desc',
+        ['desc: Alpha beta.', '', '', '  Gamma delta.'],
+    ),
+    ('plain-inline-multi-hash-no-space', 'desc', ['desc: Alpha beta.', '  #tag line']),
+    ('plain-hash-in-value', 'desc', ['desc: Use #1 approach.']),
+    ('key-space-colon', 'desc', ['desc : Alpha beta.']),
+    ('anchor-alias', 'desc', ['custom_key: &note Alpha beta.', 'desc: *note']),
+    ('local-tag', 'desc', ['desc: !bang Alpha beta.']),
+    ('bool-like', 'title', ['title: yes']),
+    ('sexagesimal', 'title', ['title: 1:20']),
+]
+#: the repair's path-derived name and clock
+NAME = 'fixed/page'
+NOW = '2026-08-27T00:00:00Z'
+
+# the C loader is a build-time option of the PyYAML wheel; values and styles
+# are identical to the pure loader's
+_LOADER = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+_QUOTES = {'single-quoted': "'", 'double-quoted': '"'}
+_TEXT = ['Alpha beta.', 'Gamma delta.', 'Epsilon zeta.']
+_STAMPS = ['2026-07-10T02:36:41Z', '2026-07-11T00:00:00Z', '2026-07-12T00:00:00Z']
+
+
+def _body_lines(body: str, text: list[str]) -> list[str]:
+    """Return the unindented value lines for a body shape."""
+    first, second, third = text
+    return {
+        'one-line': [first],
+        'two-lines': [first, second],
+        'paragraph-break': [first, '', second],
+        'trailing-blanks': [first, second, '', ''],
+        'more-indented': [first, f'  {second}', third],
+        'ws-only-over-indented': [first, '  ', second],
+    }[body]
+
+
+def _indent(line: str) -> str:
+    """Indent a value line one level; a blank line stays blank."""
+    return f'  {line}' if line else ''
+
+
+def _field(key: str, style: str, body: str) -> Optional[list[str]]:
+    """Render the field under test, or ``None`` for a pruned combination."""
+    lines = _body_lines(body, _STAMPS if key in ('created', 'updated') else _TEXT)
+    if style == 'plain':
+        return [f'{key}: {lines[0]}'] if body == 'one-line' else None
+    if style == 'plain-inline-multi':
+        if body == 'one-line':
+            return None
+        return [f'{key}: {lines[0]}', *(_indent(line) for line in lines[1:])]
+    if style == 'bare-key-multi':
+        return [f'{key}:', *(_indent(line) for line in lines)]
+    if style in _QUOTES:
+        quote = _QUOTES[style]
+        if body == 'one-line':
+            return [f'{key}: {quote}{lines[0]}{quote}']
+        out = [f'{key}: {quote}{lines[0]}', *(_indent(line) for line in lines[1:])]
+        out[-1] = f'{out[-1]}{quote}' if out[-1] else f'  {quote}'
+        return out
+    return [f'{key}: {style}', *(_indent(line) for line in lines)]
+
+
+def _decorate(lines: list[str], deco: str) -> list[str]:
+    """Apply one decoration around the field lines."""
+    return {
+        'none': lines,
+        'comment-before': ['# authored note', *lines],
+        'comment-after-indented': [*lines, '  # trailing note'],
+        'blank-before': ['', *lines],
+        'blank-after': [*lines, ''],
+        'trailing-spaces': [f'{line}  ' if line.strip() else line for line in lines],
+    }[deco]
+
+
+def field_lines(key: str, style: str, body: str, deco: str) -> list[str]:
+    """Return the decorated lines of the field under test."""
+    return _decorate(_field(key, style, body), deco)
+
+
+def block(key: str, lines: list[str]) -> str:
+    """Close ``lines`` -- the field under test -- inside the fixed neighbors.
+
+    ``name``, ``desc``, ``created``, and ``updated`` surround the field so
+    the repair's tool-owned edits are known in advance; the neighbor
+    sharing ``key`` is omitted.
+    """
+    out = ['---']
+    if key != 'name':
+        out.append(f'name: {NAME}')
+    if key != 'desc':
+        out.append('desc: Fixed desc.')
+    out.extend(lines)
+    if key != 'created':
+        out.append('created: 2026-01-01T00:00:00Z')
+    if key != 'updated':
+        out.append('updated: 2026-01-02T00:00:00Z')
+    out.append('---')
+    return '\n'.join(out)
+
+
+def frontmatter(key: str, style: str, body: str, deco: str) -> str:
+    """Build the closed block carrying ``key`` in the given shape."""
+    return block(key, field_lines(key, style, body, deco))
+
+
+def grammar() -> list[tuple[str, str, str]]:
+    """Enumerate the pruned ``(style, body, deco)`` shapes."""
+    return [
+        (style, body, deco)
+        for style in STYLES
+        for body in BODIES
+        if _field('desc', style, body) is not None
+        for deco in DECOS
+    ]
+
+
+def yaml_body(text: str) -> str:
+    """Return the YAML document between the fences, newline-terminated."""
+    return '\n'.join(text.split('\n')[1:-1]) + '\n'
+
+
+def oracle_scalar(body: str, key: str) -> Optional[str]:
+    """Return the scalar text a strict reader gives ``key`` (first occurrence).
+
+    ``compose`` keeps the raw scalar text -- folding, chomping, and escapes
+    applied, but no type coercion -- so a timestamp compares as text.
+    """
+    node = yaml.compose(body, Loader=_LOADER)
+    for key_node, value_node in node.value:
+        if key_node.value == key and isinstance(value_node, yaml.ScalarNode):
+            return value_node.value
+    return None
+
+
+def oracle_mapping(body: str) -> dict[str, Any]:
+    """Return the whole mapping as a strict reader loads it."""
+    return yaml.safe_load(body)
+
+
+def oracle_valid(body: str) -> bool:
+    """Return whether a strict reader accepts ``body`` as a mapping with unique keys.
+
+    Lint's definition of valid frontmatter: the body composes, its root
+    is a mapping, and no top-level key repeats (a strict reader refuses
+    a duplicate or silently keeps one copy).
+    """
+    try:
+        node = yaml.compose(body, Loader=_LOADER)
+    except yaml.YAMLError:
+        return False
+    if not isinstance(node, yaml.MappingNode):
+        return False
+    keys = [key_node.value for key_node, _ in node.value]
+    return len(keys) == len(set(keys))
+
+
+def normalize(text: Optional[str]) -> str:
+    """Reduce a value to the content the wiki's contract compares.
+
+    A block scalar's final line breaks are chomping, not content, and an
+    absent field (``None``) compares like an empty value; everything
+    else -- interior line structure included -- must agree exactly.
+    """
+    return (text or '').rstrip('\n')

--- a/tests/test_core/_oracle.py
+++ b/tests/test_core/_oracle.py
@@ -135,6 +135,7 @@ EXTRAS = [
 SEQUENCES = [
     ('column0-url-items', 'sources', ['sources:', '- https://doi.org/x', '- b']),
     ('indented-items', 'tags', ['tags:', '  - a', '  - b']),
+    ('flow-continuation', 'sources', ['sources: [https://a,', 'https://b]']),
 ]
 #: the repair's path-derived name and clock
 NAME = 'fixed/page'

--- a/tests/test_core/_oracle.py
+++ b/tests/test_core/_oracle.py
@@ -26,8 +26,8 @@ __all__ = [
     'SEQUENCES',
     'NAME',
     'NOW',
-    'block',
     'field_lines',
+    'block',
     'frontmatter',
     'grammar',
     'yaml_body',
@@ -39,7 +39,7 @@ __all__ = [
 ]
 
 #: keys under test: the six schema keys, the optional pair, a custom key and
-#: a dotted key outside the ``[\w-]+`` field grammar
+#: a dotted key (the custom-field shapes the schema does not name)
 KEYS = [
     'name',
     'title',
@@ -152,14 +152,15 @@ _STAMPS = ['2026-07-10T02:36:41Z', '2026-07-11T00:00:00Z', '2026-07-12T00:00:00Z
 def _body_lines(body: str, text: list[str]) -> list[str]:
     """Return the unindented value lines for a body shape."""
     first, second, third = text
-    return {
+    shapes = {
         'one-line': [first],
         'two-lines': [first, second],
         'paragraph-break': [first, '', second],
         'trailing-blanks': [first, second, '', ''],
         'more-indented': [first, f'  {second}', third],
         'ws-only-over-indented': [first, '  ', second],
-    }[body]
+    }
+    return shapes[body]
 
 
 def _indent(line: str) -> str:
@@ -167,9 +168,15 @@ def _indent(line: str) -> str:
     return f'  {line}' if line else ''
 
 
+def _pad(line: str) -> str:
+    """Pad a value line with trailing spaces; a blank line stays blank."""
+    return f'{line}  ' if line.strip() else line
+
+
 def _field(key: str, style: str, body: str) -> Optional[list[str]]:
     """Render the field under test, or ``None`` for a pruned combination."""
-    lines = _body_lines(body, _STAMPS if key in ('created', 'updated') else _TEXT)
+    text = _STAMPS if key in ('created', 'updated') else _TEXT
+    lines = _body_lines(body, text)
     if style == 'plain':
         return [f'{key}: {lines[0]}'] if body == 'one-line' else None
     if style == 'plain-inline-multi':
@@ -190,14 +197,15 @@ def _field(key: str, style: str, body: str) -> Optional[list[str]]:
 
 def _decorate(lines: list[str], deco: str) -> list[str]:
     """Apply one decoration around the field lines."""
-    return {
+    decorations = {
         'none': lines,
         'comment-before': ['# authored note', *lines],
         'comment-after-indented': [*lines, '  # trailing note'],
         'blank-before': ['', *lines],
         'blank-after': [*lines, ''],
-        'trailing-spaces': [f'{line}  ' if line.strip() else line for line in lines],
-    }[deco]
+        'trailing-spaces': [_pad(line) for line in lines],
+    }
+    return decorations[deco]
 
 
 def field_lines(key: str, style: str, body: str, deco: str) -> list[str]:
@@ -244,7 +252,8 @@ def grammar() -> list[tuple[str, str, str]]:
 
 def yaml_body(text: str) -> str:
     """Return the YAML document between the fences, newline-terminated."""
-    return '\n'.join(text.split('\n')[1:-1]) + '\n'
+    lines = text.split('\n')[1:-1]
+    return '\n'.join(lines) + '\n'
 
 
 def oracle_scalar(body: str, key: str) -> Optional[str]:

--- a/tests/test_core/_oracle.py
+++ b/tests/test_core/_oracle.py
@@ -32,6 +32,7 @@ __all__ = [
     'grammar',
     'yaml_body',
     'oracle_scalar',
+    'oracle_scalars',
     'oracle_mapping',
     'oracle_valid',
     'oracle_extent',
@@ -76,6 +77,7 @@ BODIES = [
     'trailing-blanks',
     'more-indented',
     'ws-only-over-indented',
+    'trailing-ws-only-over-indented',
 ]
 #: decorations around the field: comments, stray blanks, trailing spaces
 DECOS = [
@@ -125,10 +127,15 @@ EXTRAS = [
     ('plain-inline-multi-hash-no-space', 'desc', ['desc: Alpha beta.', '  #tag line']),
     ('plain-hash-in-value', 'desc', ['desc: Use #1 approach.']),
     ('key-space-colon', 'desc', ['desc : Alpha beta.']),
+    ('quoted-key', 'desc', ['"desc": Alpha beta.']),
     ('anchor-alias', 'desc', ['custom_key: &note Alpha beta.', 'desc: *note']),
     ('local-tag', 'desc', ['desc: !bang Alpha beta.']),
     ('bool-like', 'title', ['title: yes']),
     ('sexagesimal', 'title', ['title: 1:20']),
+    ('dq-column0-continuation', 'desc', ['desc: "Alpha beta.', 'Gamma delta."']),
+    ('sq-column0-continuation', 'desc', ["desc: 'Alpha beta.", "Gamma delta.'"]),
+    ('column0-comment-mid-field', 'desc', ['desc:', '# a comment', '  Alpha beta.']),
+    ('null-null-title', 'title', ['title: null', '  null']),
 ]
 #: sequence-valued shapes, which the reader never resolves but whose line
 #: extents must still scope right, as ``(id, key, field lines)``
@@ -136,6 +143,7 @@ SEQUENCES = [
     ('column0-url-items', 'sources', ['sources:', '- https://doi.org/x', '- b']),
     ('indented-items', 'tags', ['tags:', '  - a', '  - b']),
     ('flow-continuation', 'sources', ['sources: [https://a,', 'https://b]']),
+    ('flow-seq-blank-inside', 'tags', ['tags: ["a', '', 'b"]']),
 ]
 #: the repair's path-derived name and clock
 NAME = 'fixed/page'
@@ -159,6 +167,7 @@ def _body_lines(body: str, text: list[str]) -> list[str]:
         'trailing-blanks': [first, second, '', ''],
         'more-indented': [first, f'  {second}', third],
         'ws-only-over-indented': [first, '  ', second],
+        'trailing-ws-only-over-indented': [first, second, '  '],
     }
     return shapes[body]
 
@@ -267,6 +276,22 @@ def oracle_scalar(body: str, key: str) -> Optional[str]:
         if key_node.value == key and isinstance(value_node, yaml.ScalarNode):
             return value_node.value
     return None
+
+
+def oracle_scalars(body: str) -> dict[str, Optional[str]]:
+    """Return every top-level key's scalar text (first occurrence), ``None`` for a collection.
+
+    Composed, not constructed, so a value carrying a local tag no
+    constructor knows still compares as its text.
+    """
+    node = yaml.compose(body, Loader=_LOADER)
+    result: dict[str, Optional[str]] = {}
+    for key_node, value_node in node.value:
+        if key_node.value in result:
+            continue
+        scalar = isinstance(value_node, yaml.ScalarNode)
+        result[key_node.value] = value_node.value if scalar else None
+    return result
 
 
 def oracle_mapping(body: str) -> dict[str, Any]:

--- a/tests/test_core/conftest.py
+++ b/tests/test_core/conftest.py
@@ -11,7 +11,7 @@ from wiki.core import format
 
 
 @pytest.fixture(params=['c', 'pure'])
-def _loader(
+def _vary_loader(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
     """Run the test under the C loader and again under the pure-Python loader.

--- a/tests/test_core/conftest.py
+++ b/tests/test_core/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for the core suites."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+import yaml
+
+from wiki.core import format
+
+
+@pytest.fixture(params=['c', 'pure'])
+def _loader(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    """Run the test under the C loader and again under the pure-Python loader.
+
+    The C loader is a build-time option of the PyYAML wheel, so the reader
+    falls back to the pure loader where it is missing; the ``pure`` axis
+    removes it the same way. The compose memo is keyed by block text alone,
+    so it is cleared on both axes -- before, so this loader recomposes, and
+    after, so the next test's loader does.
+    """
+    format._compose_cached.cache_clear()
+    if request.param == 'pure':
+        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    yield
+    format._compose_cached.cache_clear()

--- a/tests/test_core/test__search.py
+++ b/tests/test_core/test__search.py
@@ -9,11 +9,9 @@ from __future__ import annotations
 
 import pytest
 
-from wiki.core._search import _build_match_expression
+from wiki.core import _search
 
-__all__ = [
-    'test_search_builds_deduped_match_expressions',
-]
+__all__ = ['test_search_builds_deduped_match_expressions']
 
 
 @pytest.mark.parametrize(
@@ -38,5 +36,5 @@ def test_search_builds_deduped_match_expressions(
     expression: str,
 ) -> None:
     """Safe queries dedupe exact duplicate terms; the prefix term stays exact."""
-    built = _build_match_expression(query, prefix=prefix, tag=None, raw=raw)
+    built = _search._build_match_expression(query, prefix=prefix, tag=None, raw=raw)
     assert built == expression

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -13,6 +13,8 @@ reader saw them, and every value the writer quotes reads back verbatim.
 from __future__ import annotations
 
 import pathlib
+import re
+from collections.abc import Callable
 from typing import Optional
 
 import pytest
@@ -33,6 +35,7 @@ from ._oracle import (
     oracle_extent,
     oracle_mapping,
     oracle_scalar,
+    oracle_scalars,
     oracle_valid,
     yaml_body,
 )
@@ -42,14 +45,41 @@ __all__ = [
     'test_reader_matches_strict_yaml',
     'test_reader_matches_strict_yaml_on_hostile_shapes',
     'test_repair_keeps_authored_values',
+    'test_repair_keeps_authored_values_on_hostile_shapes',
     'test_repair_recognizes_a_spaced_key',
     'test_repair_keeps_column_zero_sequences',
     'test_repair_keeps_the_comments_of_valueless_fields',
+    'test_repair_leaves_removed_field_comments_at_column_zero',
+    'test_repair_removes_every_leading_valueless_copy',
+    'test_repair_keeps_an_aliased_block_in_its_order',
+    'test_repair_inserts_above_a_document_end_marker',
+    'test_repair_fills_a_tagged_empty_value',
+    'test_repair_keeps_a_keep_chomping_item_blank',
+    'test_repair_keeps_the_name_tail_comment',
+    'test_restamp_keeps_a_quoted_stamp_whole',
+    'test_frontmatter_issues_word_a_second_document_as_a_sentence',
+    'test_frontmatter_issues_locate_an_unclosed_flow_collection',
+    'test_frontmatter_issues_name_a_nested_duplicate_key',
+    'test_unaddressable_blocks_are_refused_not_crashed',
+    'test_fallback_repair_sees_a_quoted_key',
+    'test_colon_error_names_the_line_the_scalar_started_on',
+    'test_compose_walks_an_alias_graph_once',
+    'test_compose_refuses_nesting_past_the_bound',
+    'test_tab_on_the_last_block_line_is_named',
+    'test_repair_keeps_an_item_after_a_valued_key_in_place',
+    'test_repair_fills_an_empty_block_over_column_zero_comments',
+    'test_field_ranges_end_at_a_typo_line_under_the_line_grammar',
+    'test_build_frontmatter_escapes_a_multi_line_desc',
+    'test_field_ranges_end_at_a_foreign_key_under_the_line_grammar',
+    'test_repair_breaks_frontmatter_names_a_breaking_repair',
+    'test_strip_blank_lines_keeps_content_blanks_at_any_depth',
     'test_reader_applies_the_documented_policy',
     'test_reader_reads_a_carriage_return_escape_as_a_line_break',
+    'test_fallback_reader_agrees_with_the_repair',
     'test_title_reader_applies_the_null_idiom',
     'test_quote_round_trips_through_yaml',
     'test_quote_escapes_characters_no_stream_may_carry',
+    'test_unquote_decodes_every_double_quoted_escape',
     'test_field_ranges_match_yaml_extents',
     'test_field_ranges_match_yaml_extents_on_hostile_shapes',
 ]
@@ -169,6 +199,55 @@ def test_repair_keeps_authored_values(style: str, body: str, deco: str) -> None:
         assert after == before, (key, text, repaired)
 
 
+@pytest.mark.parametrize(
+    argnames=('key', 'lines'),
+    argvalues=[(key, lines) for _, key, lines in EXTRAS],
+    ids=[extra_id for extra_id, _, _ in EXTRAS],
+)
+def test_repair_keeps_authored_values_on_hostile_shapes(
+    key: str,
+    lines: list[str],
+) -> None:
+    """Valid shapes off the grammar's axes survive the repair as a strict reader saw them.
+
+    A quoted key is the field it names, a quoted scalar continued at
+    column 0 is one value, an alias keeps its anchor above it, and a
+    column-0 comment inside a field stays where it is: the repair rewrites
+    only the name, converges, and leaves a block every strict reader
+    accepts -- with the same authored mapping, minus the valueless title
+    or category it drops.
+    """
+    text = block(key, lines)
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    again = format.repair_frontmatter(
+        repaired,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert again == repaired, repaired
+    assert oracle_valid(yaml_body(repaired)), repaired
+    before = oracle_scalars(yaml_body(text))
+    after = oracle_scalars(yaml_body(repaired))
+    assert after.pop('name') == NAME
+    before.pop('name')
+    # a valueless title or category is dropped, never rewritten
+    for unset in ('title', 'category'):
+        if before.get(unset) in (None, '', 'null'):
+            before.pop(unset, None)
+            assert unset not in after
+    assert after == before, repaired
+
+
 def test_repair_recognizes_a_spaced_key() -> None:
     """A key with a space before its colon is the key it names, not a stranger.
 
@@ -191,15 +270,18 @@ def test_repair_recognizes_a_spaced_key() -> None:
 
 
 @pytest.mark.parametrize('key', ['desc', 'category', 'created'])
-def test_repair_keeps_column_zero_sequences(key: str) -> None:
+@pytest.mark.parametrize('neighbor', ['', 'zz: A: b\n'], ids=['composed', 'fallback'])
+def test_repair_keeps_column_zero_sequences(key: str, neighbor: str) -> None:
     """A column-0 sequence under a repaired key is its value, kept whole.
 
     YAML reads ``key:`` over ``- a`` items as a sequence; a repair that saw
     only indented lines as the value would take the key line for a blank,
     restore a placeholder or stamp over it, and strand the items under the
     field before it -- turning valid YAML into a block no reader accepts.
+    The line grammar's extent carries the items too, so a block one
+    invalid neighbor sends through it repairs the same way.
     """
-    text = block(key, [f'{key}:', '- a', '- b'])
+    text = block(key, [f'{key}:', '- a', '- b']).replace('---\n', f'---\n{neighbor}', 1)
     repaired = format.repair_frontmatter(
         text,
         name=NAME,
@@ -208,9 +290,11 @@ def test_repair_keeps_column_zero_sequences(key: str) -> None:
         category=True,
         order=True,
     )
-    assert oracle_valid(yaml_body(repaired)), repaired
-    mapping = oracle_mapping(yaml_body(repaired))
-    assert mapping[key] == ['a', 'b']
+    assert f'{key}:\n- a\n- b\n' in repaired
+    if not neighbor:
+        assert oracle_valid(yaml_body(repaired)), repaired
+        mapping = oracle_mapping(yaml_body(repaired))
+        assert mapping[key] == ['a', 'b']
 
 
 def test_repair_keeps_the_comments_of_valueless_fields() -> None:
@@ -256,6 +340,633 @@ def test_repair_keeps_the_comments_of_valueless_fields() -> None:
     assert 'title' not in mapping
 
 
+def test_repair_leaves_removed_field_comments_at_column_zero() -> None:
+    """The comments of a removed field land at column 0, a comment after every neighbor.
+
+    Indented under a block-scalar desc they would be its content, so the
+    desc a strict reader loads must not change when the field goes.
+    """
+    text = (
+        '---\n'
+        f'name: {NAME}\n'
+        'desc: |\n'
+        '  Alpha beta.\n'
+        'category:\n'
+        '  # unset for now\n'
+        'title: null # pick one\n'
+        '---'
+    )
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert '\n# unset for now\n# pick one\n' in repaired
+    mapping = oracle_mapping(yaml_body(repaired))
+    assert mapping['desc'] == 'Alpha beta.\n'
+    assert 'category' not in mapping
+    assert 'title' not in mapping
+
+
+def test_repair_removes_every_leading_valueless_copy() -> None:
+    """Every valueless copy before the first real ``title:`` goes in one pass.
+
+    The first occurrence wins for every reader, so the repair keeps
+    removing until the field it leaves in front carries a value; a
+    one-copy-per-run removal would take a run per copy to converge.
+    """
+    text = block('title', ['title:', 'title: null', 'title: Real'])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert repaired.count('title') == 1
+    assert format.read_frontmatter_title(repaired) == 'Real'
+
+
+def test_repair_keeps_an_aliased_block_in_its_order() -> None:
+    """A block carrying an alias is not reordered: the anchor must stay above the alias."""
+    text = block('desc', ['zz: &a Alpha beta.', 'desc: *a'])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert repaired.index('zz: &a') < repaired.index('desc: *a')
+    assert format.read_frontmatter_desc(repaired) == 'Alpha beta.'
+
+
+@pytest.mark.parametrize(
+    argnames='epilogue',
+    argvalues=['...', '... # end', '...\n# trailing'],
+    ids=['marker', 'marker-comment', 'marker-then-comment'],
+)
+def test_repair_inserts_above_a_document_end_marker(epilogue: str) -> None:
+    """A trailing ``...`` marker (a comment with or after it) stays the block's last lines."""
+    text = f'---\ndesc: A page.\nzz: 1\n{epilogue}\n---'
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert repaired.endswith(f'updated: {NOW}\n{epilogue}\n---')
+    scalars = oracle_scalars(yaml_body(repaired))
+    assert scalars['name'] == NAME
+    assert scalars['created'] == NOW
+
+
+@pytest.mark.parametrize(
+    argnames=('field', 'expected'),
+    argvalues=[
+        ('created: !!str', f'created: !!str {NOW}'),
+        ('created: &c !!str # when', f'created: &c !!str {NOW} # when'),
+        ('desc: !!null', 'desc: !!null ...'),
+        ('desc: &d', 'desc: &d ...'),
+        ('title: !!str null', 'title: !!str null'),
+        ('title: !!str', ''),
+    ],
+    ids=[
+        'tagged-stamp',
+        'anchored-tagged-stamp',
+        'tagged-desc',
+        'anchored-desc',
+        'tagged-text',
+        'tagged-empty-title',
+    ],
+)
+def test_repair_fills_a_tagged_empty_value(field: str, expected: str) -> None:
+    """A node property over nothing is a blank the repair fills, keeping the property.
+
+    ``!!str`` alone tags an empty string and ``&c`` alone anchors a null,
+    so the stamp is filled and the placeholder restored behind the
+    property; a tag over a spelled value types it as text, so
+    ``title: !!str null`` is the word and stays.
+    """
+    text = block(field.split(':')[0], [field])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    if expected:
+        assert f'{expected}\n' in repaired
+    else:
+        assert 'title' not in repaired
+
+
+def test_repair_keeps_a_keep_chomping_item_blank() -> None:
+    """A ``- |+`` item at column 0 keeps its trailing blank line, which is its content."""
+    text = block('sources', ['sources:', '- |+', '  a', '', '- b'])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    mapping = oracle_mapping(yaml_body(repaired))
+    assert mapping['sources'] == ['a\n\n', 'b']
+
+
+def test_repair_keeps_the_name_tail_comment() -> None:
+    """The name refresh keeps a comment after the key line's value, as every other field does."""
+    text = block('name', ['name: stale # tail'])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert f'name: {NAME} # tail\n' in repaired
+    assert oracle_scalars(yaml_body(repaired))['name'] == NAME
+
+
+def test_restamp_keeps_a_quoted_stamp_whole() -> None:
+    """A ``#`` inside a quoted stamp is text, never a tail comment to re-attach."""
+    text = "---\nname: x\nupdated: '2026-08-29 #241'\n---"
+    restamped = format.restamp_updated(text, NOW)
+    assert restamped == f'---\nname: x\nupdated: {NOW}\n---'
+    text = "---\nname: x\nupdated: '2026 #1' # by hand\n---"
+    assert (
+        format.restamp_updated(text, NOW)
+        == f'---\nname: x\nupdated: {NOW} # by hand\n---'
+    )
+    text = "---\nname: x\nupdated: !!str '2026 #243'\n---"
+    assert (
+        format.restamp_updated(text, NOW) == f'---\nname: x\nupdated: !!str {NOW}\n---'
+    )
+
+
+def test_frontmatter_issues_word_a_second_document_as_a_sentence() -> None:
+    """A parser problem worded as a fragment keeps the context it continues."""
+    text = f'---\nname: {NAME}\n...\n---\ndesc: A.\n---'
+    issues = format.frontmatter_issues(text)
+    assert [reason for _, reason, _ in issues] == [
+        'expected a single document in the stream, but found another document'
+    ]
+
+
+@pytest.mark.parametrize(
+    argnames='tail',
+    argvalues=['', '\ncreated: 2024-01-01T00:00:00Z'],
+    ids=['last-line', 'followed-by-a-key'],
+)
+def test_frontmatter_issues_locate_an_unclosed_flow_collection(tail: str) -> None:
+    """An unclosed flow collection is reported where it opens, not where the parser gave up."""
+    text = f'---\nname: {NAME}\ndesc: Fine.\nsources: [{tail}\n---'
+    issues = format.frontmatter_issues(text)
+    assert [line for line, _, _ in issues] == [4]
+
+
+@pytest.mark.parametrize(
+    argnames=('body', 'expected'),
+    argvalues=[
+        (
+            'meta:\n  a: 1\n  a: 2',
+            [(5, "duplicate key 'a' in a nested mapping", 'duplicate_key')],
+        ),
+        (
+            'x:\n  a: 1\n  a: 2\ny:\n  b: 1\n  b: 2',
+            [
+                (5, "duplicate key 'a' in a nested mapping", 'duplicate_key'),
+                (8, "duplicate key 'b' in a nested mapping", 'duplicate_key'),
+            ],
+        ),
+        (
+            '&k desc: First.\n*k : Second.',
+            [(4, "key 'desc' is an alias of the node at line 3", 'duplicate_key')],
+        ),
+        (
+            'tags: [&a x]\n*a : y',
+            [(4, "key 'x' is an alias of the node at line 3", 'duplicate_key')],
+        ),
+        (
+            'desc: &x A.\ntitle: &x B.',
+            [(4, 'found duplicate anchor (first at line 3)', 'parse')],
+        ),
+        (
+            'title:T\ndesc: A.',
+            [(3, "could not find expected ':'", 'parse')],
+        ),
+    ],
+    ids=[
+        'nested',
+        'two-nested-in-order',
+        'alias-key',
+        'alias-of-nested',
+        'duplicate-anchor',
+        'typo-line',
+    ],
+)
+def test_frontmatter_issues_name_a_nested_duplicate_key(
+    body: str, expected: list
+) -> None:
+    """Strict-reader findings name the offending line and word the cause in full.
+
+    A key repeated inside a nested mapping, an alias used as a key (of a
+    top-level or nested anchor), a duplicate anchor, and a ``key:value``
+    typo the parser only trips over on the next line are each reported
+    on their own line, in line order.
+    """
+    text = f'---\nname: {NAME}\n{body}\n---'
+    issues = format.frontmatter_issues(text)
+    assert [(line, reason, cause) for line, reason, cause in issues] == expected
+
+
+@pytest.mark.parametrize(
+    argnames='body',
+    argvalues=[
+        '&k desc: First.\n*k : Second.',
+        '<<: {desc: Merged.}\ntags: []',
+        'desc: foo' + chr(0x85) + 'title: bar',
+        chr(0xFEFF) + 'desc: A page.',
+    ],
+    ids=['alias-key', 'merge-key', 'two-keys-one-line', 'body-bom'],
+)
+def test_unaddressable_blocks_are_refused_not_crashed(body: str) -> None:
+    """A mapping whose key lines the writers cannot place is refused, never mis-spliced.
+
+    An alias used as a key has no position of its own, a merge key folds
+    another mapping in, and two keys on one line (a NEL the parser breaks
+    on) share the line: each is read through the parser and refused by the
+    repair. A BOM opening the body shifts one loader's marks, so it is
+    dropped and both loaders address one stream. None is a crash or an
+    empty span.
+    """
+    if body.startswith(chr(0xFEFF)):
+        # the BOM opens the body: both loaders must place name on line 1
+        text = f'---\n{body}\nname: {NAME}\n---'
+        assert not format.is_unaddressable_frontmatter(text)
+        assert format.read_frontmatter_desc(text) == 'A page.'
+        assert format.field_text(text, 'name') == f'name: {NAME}\n'
+    else:
+        text = f'---\nname: {NAME}\n{body}\n---'
+        assert format.is_unaddressable_frontmatter(text)
+        assert format.read_frontmatter_name(text) == NAME
+
+
+@pytest.mark.parametrize(
+    argnames=('text', 'expected'),
+    argvalues=[
+        ('sources:\n- k: |+\n    text\n\n- b', 'sources:\n- k: |+\n    text\n\n- b'),
+        (
+            'meta:\n  inner: |+\n    text\n\ntags: []',
+            'meta:\n  inner: |+\n    text\n\ntags: []',
+        ),
+        (
+            'desc: "line one\n\nline two"\ntags: []',
+            'desc: "line one\n\nline two"\ntags: []',
+        ),
+        ("desc: 'one\n\ntwo'\n\ntags: []", "desc: 'one\n\ntwo'\ntags: []"),
+        ('desc: |-\n  Alpha.\n    \ntags: []', 'desc: |-\n  Alpha.\n    \ntags: []'),
+        ('desc: A.\n\ntags: []', 'desc: A.\ntags: []'),
+        ('desc: &a |+\n  text\n\ntags: []', 'desc: &a |+\n  text\n\ntags: []'),
+        ('desc: !!str >+\n  text\n\ntags: []', 'desc: !!str >+\n  text\n\ntags: []'),
+        ('extra: |2\n   \ntags: []', 'extra: |2\n   \ntags: []'),
+        ('tags: ["a\n\nb"]\nx: 1', 'tags: ["a\n\nb"]\nx: 1'),
+        ('tags: [a,\n\nb]\n\nx: 1', 'tags: [a,\n\nb]\nx: 1'),
+        ('meta: {k: "a\n\nb"}\nx: 1', 'meta: {k: "a\n\nb"}\nx: 1'),
+        ('desc: A\n  "b\ntags: []\n\nx: 1', 'desc: A\n  "b\ntags: []\nx: 1'),
+        ('desc: ["alpha\n  beta."]\n\nx: 1', 'desc: ["alpha\n  beta."]\nx: 1'),
+        ('title: [unclosed\n\ndesc: D.', 'title: [unclosed\ndesc: D.'),
+        ('"desc" : |+\n  Text.\n\ntags: []', '"desc" : |+\n  Text.\n\ntags: []'),
+    ],
+    ids=[
+        'item-mapping-keep',
+        'nested-keep',
+        'dq-column0-blank',
+        'sq-column0-blank-then-stray',
+        'ws-only-over-indented',
+        'stray',
+        'anchored-keep',
+        'tagged-folded-keep',
+        'explicit-indent-ws-body',
+        'flow-seq-quoted-blank',
+        'flow-seq-plain-blank-then-stray',
+        'flow-map-quoted-blank',
+        'plain-continuation-quote-does-not-arm',
+        'flow-quote-across-lines-then-stray',
+        'unclosed-flow-then-key',
+        'quoted-key-spaced-colon-keep',
+    ],
+)
+def test_strip_blank_lines_keeps_content_blanks_at_any_depth(
+    text: str, expected: str
+) -> None:
+    """Blank lines inside a value are content wherever the value opens; strays between fields go."""
+    assert format.strip_blank_lines(f'---\n{text}\n---') == f'---\n{expected}\n---'
+
+
+@pytest.mark.parametrize(
+    argnames='line',
+    argvalues=[
+        '"name": stale',
+        "'name': stale",
+        '!!str name: stale',
+        '&a name: stale',
+    ],
+    ids=['quoted', 'single-quoted', 'tagged', 'anchored'],
+)
+def test_fallback_repair_sees_a_quoted_key(line: str) -> None:
+    """Under the line grammar a quoted, tagged, or anchored key is the field it names.
+
+    The fallback and the parser agree on the key set, so the repair never
+    inserts a duplicate beside a key spelled with a property or quotes.
+    """
+    text = f'---\n{line}\ndesc: D.\ninvalid: A: b\n---'
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert repaired.count('name') == 1
+    assert format.field_text(repaired, 'name') == f'name: {NAME}\n'
+
+
+@pytest.mark.parametrize(
+    argnames=('body', 'line'),
+    argvalues=[
+        ('name:core\ntitle: x', 2),
+        ('name:core\n\ntitle: x', 2),
+        (f'name: {NAME}\ntitle: a: b', 3),
+        (f'name: {NAME}\ndesc: >\n  A folded\n  line.\ntitle: a: b', 6),
+        (f'name: {NAME}\ndesc: Alpha beta\n  gamma: delta.', 4),
+        (
+            f'name: {NAME}\ndesc: A long description that\n  continues and\n  mentions X: y',
+            5,
+        ),
+        ('# c\nname:core\ntitle: x', 3),
+    ],
+    ids=[
+        'typo-line',
+        'typo-line-blank-between',
+        'key-line',
+        'key-line-after-block',
+        'continuation-line',
+        'third-line',
+        'typo-line-after-comment',
+    ],
+)
+@pytest.mark.usefixtures('_loader')
+def test_colon_error_names_the_line_the_scalar_started_on(body: str, line: int) -> None:
+    """A colon the parser trips over is reported where the plain scalar holding it began.
+
+    A ``key:value`` typo opening the block folds into the key line below
+    it (across a blank line too), so the typo's own line is named; a key
+    on the error line opened the scalar itself, so the error line is
+    named even when a multi-line field sits above it.
+    """
+    text = f'---\n{body}\n---'
+    issues = format.frontmatter_issues(text)
+    assert [(issue[0], issue[2]) for issue in issues] == [(line, 'parse')]
+    assert 'mapping values are not allowed' in issues[0][1]
+
+
+@pytest.mark.parametrize(
+    argnames='body',
+    argvalues=[
+        'tags: &a [*a]',
+        'tags: &a {k: *a}',
+        '\n'.join(
+            f'k{level}: &a{level} [*a{level - 1}, *a{level - 1}]'
+            for level in range(1, 25)
+        ),
+    ],
+    ids=['cyclic-sequence', 'cyclic-mapping', 'doubling-dag'],
+)
+def test_compose_walks_an_alias_graph_once(body: str) -> None:
+    """A node reached twice is walked once, so a cyclic or shared alias graph composes in bounded time."""
+    text = f'---\nname: {NAME}\na0: &a0 [x]\n{body}\n---'
+    assert format.frontmatter_issues(text) == []
+    assert format.read_frontmatter_name(text) == NAME
+
+
+@pytest.mark.parametrize(
+    argnames=('body', 'line'),
+    argvalues=[
+        ('desc: ' + '[' * 200 + 'x' + ']' * 200, 3),
+        ('desc: ' + '{a: ' * 200 + 'x' + '}' * 200, 3),
+        ('tags:\n' + '- ' * 200 + 'x', 4),
+        ('tags: ' + '[' * 100 + 'x' + ']' * 100, None),
+        ("desc: rock 'n roll\ntags: " + '[' * 200 + 'x' + ']' * 200, 4),
+        ('desc: a ' + '[' * 200, None),
+        ('desc: |\n' + '\n'.join('  [ x' for _ in range(120)), None),
+        ('desc: |\n  ' + '- ' * 200 + 'x', None),
+        ('desc: plain\n  ' + '[' * 200, None),
+    ],
+    ids=[
+        'flow-sequence',
+        'flow-mapping',
+        'item-chain',
+        'at-the-bound',
+        'apostrophe-before-deep',
+        'brackets-in-plain-value',
+        'brackets-in-block-body',
+        'chain-in-block-body',
+        'brackets-in-continuation',
+    ],
+)
+@pytest.mark.usefixtures('_loader')
+def test_compose_refuses_nesting_past_the_bound(body: str, line: Optional[int]) -> None:
+    """Collections nested past the bound are a strict-reader finding, not a recursion the composer runs.
+
+    The pure loader raises RecursionError a few hundred levels down and the
+    C loader recurses unchecked, so both refuse the block the same way,
+    naming the line that passes the bound; a block at the bound composes.
+    """
+    text = f'---\nname: {NAME}\n{body}\n---'
+    issues = format.frontmatter_issues(text)
+    if line is None:
+        assert issues == []
+    else:
+        assert issues == [(line, 'collections nested deeper than 100 levels', 'parse')]
+
+
+@pytest.mark.usefixtures('_loader')
+def test_tab_on_the_last_block_line_is_named() -> None:
+    """A tab on a whitespace-only line closing the block is reported on that line, not the one above."""
+    issues = format.frontmatter_issues(f'---\nname: {NAME}\ndesc: D.\n\t\n---')
+    assert [(line, cause) for line, _, cause in issues] == [(4, 'parse')]
+
+
+def test_repair_keeps_an_item_after_a_valued_key_in_place() -> None:
+    """A column-0 item after a value on the key line is text outside the field, not the name's body.
+
+    YAML makes column-0 items the value of a bare key alone; after
+    ``name: x`` they are a stray line the parser rejects, so the refresh
+    replaces the key line only and the item stays where the author put it
+    for lint to name.
+    """
+    text = '---\nname: stale\n- draft\ndesc: D.\ninvalid: A: b\n---'
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert f'name: {NAME}\n- draft\n' in repaired
+    assert repaired.count('- draft') == 1
+
+
+@pytest.mark.parametrize('key', ['desc', 'created'])
+def test_repair_fills_an_empty_block_over_column_zero_comments(key: str) -> None:
+    """A block header over column-0 comment lines alone is an empty value the repair fills.
+
+    A column-0 line ends the block, so the comments are no body: the
+    placeholder or stamp lands on the header line and the comments stay
+    under it.
+    """
+    text = f'---\nname: {NAME}\n{key}: |\n# c\n\n# d\n---'
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    value = '...' if key == 'desc' else NOW
+    assert f'{key}: {value}\n# c\n# d\n' in repaired
+    assert format.read_frontmatter_field(repaired, key) == value
+
+
+def test_field_ranges_end_at_a_typo_line_under_the_line_grammar() -> None:
+    """A dedented ``key:value`` typo ends the open field in a block the parser rejects."""
+    text = f'---\nname: {NAME}\ninvalid: A: b\ndesc: x\nurl:http://example.com\n---'
+    lines = text.split('\n')
+    assert format.field_line_ranges(text, lines, ['desc']) == {4}
+
+
+@pytest.mark.parametrize(
+    argnames='desc',
+    argvalues=['Line one.\nctrl' + chr(1) + 'mid.', 'a\nb' + chr(0x85) + 'c'],
+    ids=['control', 'nel'],
+)
+def test_build_frontmatter_escapes_a_multi_line_desc(desc: str) -> None:
+    """A multi-line desc holding a character no block may carry is written double-quoted."""
+    text = format.build_frontmatter(name='x', created=NOW, updated=NOW, desc=desc)
+    assert oracle_valid(yaml_body(text)), text
+    assert oracle_scalar(yaml_body(text), 'desc') == desc
+    assert 'desc: "' in text
+
+
+def test_field_ranges_end_at_a_foreign_key_under_the_line_grammar() -> None:
+    """A dedented key outside the grammar still ends the open field in a block the parser rejects."""
+    text = f'---\nname: {NAME}\ninvalid: A: b\ndesc: x\nmy key: needle\n---'
+    lines = text.split('\n')
+    assert format.field_line_ranges(text, lines, ['desc']) == {4}
+
+
+_REPAIRED = f'name: {NAME}\ndesc: D.\ncreated: {NOW}\nupdated: {NOW}'
+
+
+@pytest.mark.parametrize(
+    argnames=('before', 'after', 'breaks'),
+    argvalues=[
+        (f'---\n{_REPAIRED}\n---', f'---\n{_REPAIRED}\ntitle: T\n---', False),
+        (f'---\n{_REPAIRED}\n---', f'---\n{_REPAIRED}\nname: y\n---', True),
+        ('---\nname: A: b\n---', f'---\nname: A: b\n{_REPAIRED}\n---', False),
+        (
+            '---\ntags: "open\nname: "x\ncustom: y"\n---',
+            f'---\ntags: "open\nname: {NAME}\ndesc: ...\ncustom: y"\n'
+            f'created: {NOW}\nupdated: {NOW}\n---',
+            True,
+        ),
+        (
+            '---\nupdated: "quoted\ncontinued"\ntags: "open\n---',
+            f'---\nname: {NAME}\ndesc: ...\ntags: "open\ncreated: {NOW}\n'
+            f'updated: {NOW}\ncontinued"\n---',
+            True,
+        ),
+        (
+            f'---\nname: {NAME}\nzebra: 27"\ndesc: "open\n---',
+            f'---\nname: {NAME}\ndesc: "open\nzebra: 27"\ncreated: {NOW}\nupdated: {NOW}\n---',
+            True,
+        ),
+        (
+            f'---\nname: "p\ndesc: D.\nx: y"\ncreated: {NOW}\nupdated: {NOW}\n---',
+            f'---\nname: {NAME}\ndesc: ...\ncreated: {NOW}\nupdated: {NOW}\n---',
+            True,
+        ),
+        (
+            f'---\nname: "stale\n2024 review: my notes"\ndesc: D.\n'
+            f'created: {NOW}\nupdated: {NOW}\n---',
+            f'---\nname: {NAME}\ndesc: D.\ncreated: {NOW}\nupdated: {NOW}\n---',
+            True,
+        ),
+        (
+            f'---\nname: "just\n  a wrapped name"\ndesc: D.\n'
+            f'created: {NOW}\nupdated: {NOW}\n---',
+            f'---\nname: {NAME}\ndesc: D.\ncreated: {NOW}\nupdated: {NOW}\n---',
+            False,
+        ),
+        (
+            f'---\nname: {NAME}\ndesc: D.\ncreated: {NOW}\nupdated: "{NOW}"\n'
+            f'# todo: verify the stamp\n---',
+            f'---\nname: {NAME}\ndesc: D.\ncreated: {NOW}\nupdated: "{NOW}"\n'
+            f'# todo: verify the stamp\n---',
+            False,
+        ),
+    ],
+    ids=[
+        'valid-to-valid',
+        'valid-to-invalid',
+        'invalid-to-invalid',
+        'quote-closed-around-name',
+        'quote-closed-around-stamps',
+        'reorder-closes-around-authored-key',
+        'authored-lines-inside-name',
+        'spaced-key-inside-name',
+        'wrapped-name-is-stale-value',
+        'comment-after-quoted-stamp',
+    ],
+)
+def test_repair_breaks_frontmatter_names_a_breaking_repair(
+    before: str,
+    after: str,
+    breaks: bool,
+) -> None:
+    """A repair breaks a block by rejecting an accepted one or by writing fields a strict reader never sees.
+
+    A refresh or a stamp landing inside a quote the line grammar could not
+    see closes it around the written lines, so the block composes as a
+    long scalar with no ``name``, ``desc``, or stamp key: such a result is
+    refused as the parse error is.
+    """
+    assert format.repair_breaks_frontmatter(before, after) is breaks
+
+
 # ------ documented policy
 
 
@@ -271,6 +982,9 @@ def test_repair_keeps_the_comments_of_valueless_fields() -> None:
         ('desc: # to be written', 'desc', None),
         ('desc: |', 'desc', ''),
         ('desc: | # note', 'desc', ''),
+        # a block scalar's final breaks are chomping, not content
+        ('desc: |\n  x', 'desc', 'x'),
+        ('desc: |+\n  x\n', 'desc', 'x'),
         # typed-looking scalars stay strings
         ('title: 2024', 'title', '2024'),
         ('title: 1.10', 'title', '1.10'),
@@ -279,16 +993,24 @@ def test_repair_keeps_the_comments_of_valueless_fields() -> None:
         ('created: 2026-07-10T02:36:41Z', 'created', '2026-07-10T02:36:41Z'),
         # ' #' starts a comment: the text after it reaches no reader
         ('desc: Use #1 approach.', 'desc', 'Use'),
-        # sequences are never resolved: the raw flow text, or absent at column 0
+        # sequences are never resolved: their source text joined, so the search
+        # index tokenizes every item, a ' #' inside quotes kept
         ('tags: [a, b]', 'tags', '[a, b]'),
-        ('tags:\n- a\n- b', 'tags', None),
+        ('tags:\n- a\n- b', 'tags', '- a - b'),
+        ('tags:\n- a\n# c\n- b', 'tags', '- a - b'),
+        ('tags: &t [a, b]', 'tags', '[a, b]'),
+        ('tags: [a, b] # note', 'tags', '[a, b]'),
+        ('tags:\n- a # note\n- b', 'tags', '- a - b'),
+        ("tags: ['A long\n  item #x', beta]", 'tags', "['A long item #x', beta]"),
+        ('tags: ["issue #42", triage]', 'tags', '["issue #42", triage]'),
+        ('tags: [a,\n  b]', 'tags', '[a, b]'),
         # the first occurrence of a duplicated key wins, bare or not
         ('desc:\ndesc: second', 'desc', None),
         ('desc: first\ndesc: second', 'desc', 'first'),
         # tolerated invalid YAML reads through the line grammar as authored
         ('desc: A theorem for X: HR, WR.', 'desc', 'A theorem for X: HR, WR.'),
         ('desc: > one liner.', 'desc', 'one liner.'),
-        ('desc: "unterminated\n  continues', 'desc', '"unterminated'),
+        ('desc: "unterminated\n  continues', 'desc', '"unterminated continues'),
         (
             '<<<<<<< ours\ndesc: Ours.\n=======\ndesc: Theirs.\n>>>>>>> theirs',
             'desc',
@@ -305,6 +1027,8 @@ def test_repair_keeps_the_comments_of_valueless_fields() -> None:
         'keyline-comment-no-body',
         'empty-block',
         'empty-block-header-comment',
+        'literal-chomp',
+        'keep-chomp',
         'int-like',
         'float-like',
         'bool-like',
@@ -313,6 +1037,13 @@ def test_repair_keeps_the_comments_of_valueless_fields() -> None:
         'hash-in-value',
         'flow-sequence',
         'block-sequence',
+        'block-sequence-comment',
+        'flow-sequence-anchored',
+        'flow-sequence-tail-comment',
+        'block-sequence-item-comment',
+        'flow-sequence-wrapped-item-hash',
+        'flow-sequence-quoted-hash',
+        'flow-sequence-two-lines',
         'duplicate-bare-first',
         'duplicate-valued-first',
         'unquoted-colon-space',
@@ -322,6 +1053,7 @@ def test_repair_keeps_the_comments_of_valueless_fields() -> None:
         'invalid-neighbor',
     ],
 )
+@pytest.mark.usefixtures('_loader')
 def test_reader_applies_the_documented_policy(
     field: str,
     key: str,
@@ -343,6 +1075,171 @@ def test_reader_reads_a_carriage_return_escape_as_a_line_break() -> None:
     text = f'---\nname: {NAME}\ndesc: "a{backslash}rb"\ntitle: "c{backslash}rd"\n---'
     assert format.read_frontmatter_field(text, 'desc') == 'a\nb'
     assert format.read_frontmatter_title(text) == 'c d'
+    # a NUL escape has no place on a markdown surface (git would call the
+    # file binary), so it goes
+    text = f'---\nname: {NAME}\ndesc: "a{backslash}0b."\n---'
+    assert format.read_frontmatter_field(text, 'desc') == 'ab.'
+
+
+@pytest.mark.parametrize(
+    argnames=('field', 'read', 'expected'),
+    argvalues=[
+        ('category: null # why', format.read_frontmatter_category, ''),
+        ('category:\n  null', format.read_frontmatter_category, ''),
+        ("category: 'null' # text", format.read_frontmatter_category, 'null'),
+        ('title: null # why', format.read_frontmatter_title, ''),
+        ('desc: # note', format.read_frontmatter_desc, None),
+        ('desc: ... # note', format.read_frontmatter_desc, '...'),
+        ("desc: 'kept # inside'", format.read_frontmatter_desc, 'kept # inside'),
+        ('desc: # note\n  Alpha beta.', format.read_frontmatter_desc, 'Alpha beta.'),
+        ('desc:\n  # note', format.read_frontmatter_desc, None),
+        ('desc:\n# c\n  Alpha beta.', format.read_frontmatter_desc, 'Alpha beta.'),
+        ('desc: >\n  Alpha\n  beta.', format.read_frontmatter_desc, 'Alpha beta.'),
+        ('desc: | # note', format.read_frontmatter_desc, ''),
+        ('desc: "a\\"b" # c', format.read_frontmatter_desc, 'a"b'),
+        (
+            'desc:\n  Alpha\n  # note\n  beta.',
+            format.read_frontmatter_desc,
+            'Alpha beta.',
+        ),
+        ('desc:\n  Alpha\n  beta.', format.read_frontmatter_desc, 'Alpha beta.'),
+        ('desc:\n  Alpha # tail\n  beta.', format.read_frontmatter_desc, 'Alpha beta.'),
+        ('title: ~', format.read_frontmatter_title, '~'),
+        ('"desc": Quoted key.', format.read_frontmatter_desc, 'Quoted key.'),
+        ('title: &a1 First\n  second.', format.read_frontmatter_title, 'First second.'),
+        ('!!str desc: Tagged key.', format.read_frontmatter_desc, 'Tagged key.'),
+        (
+            'desc: ["issue #42", triage]',
+            format.read_frontmatter_desc,
+            '["issue #42", triage]',
+        ),
+        ('desc: [a,\n  b]', format.read_frontmatter_desc, '[a, b]'),
+        ('desc: [unclosed\ntitle: T', format.read_frontmatter_desc, '[unclosed'),
+        ('desc: ["alpha\n  beta."]', format.read_frontmatter_desc, '["alpha beta."]'),
+        ('desc: &a |\n  Hello.', format.read_frontmatter_desc, 'Hello.'),
+        ('title: !!str >\n  T', format.read_frontmatter_title, 'T'),
+        ('desc: &a   !!str |', format.read_frontmatter_desc, ''),
+        (
+            'title: |4\n    Deep title.\n  # note',
+            format.read_frontmatter_title,
+            'Deep title.',
+        ),
+        (
+            'tags:\n- zebra\n- stripes',
+            lambda text: format.read_frontmatter_field(text, 'tags'),
+            '- zebra - stripes',
+        ),
+        (
+            'desc: "Alpha beta.\n  Gamma delta."',
+            format.read_frontmatter_desc,
+            'Alpha beta. Gamma delta.',
+        ),
+        (
+            'tags: [alpha, beta] # editorial note',
+            lambda text: format.read_frontmatter_field(text, 'tags'),
+            '[alpha, beta]',
+        ),
+        ("desc:\n  'A: colon here.'", format.read_frontmatter_desc, 'A: colon here.'),
+        ('desc:\n  "Two\n  lines"', format.read_frontmatter_desc, 'Two lines'),
+        (
+            "tags:\n- 'notes #draft'\n- review",
+            lambda text: format.read_frontmatter_field(text, 'tags'),
+            "- 'notes #draft' - review",
+        ),
+        ("title: 'Bob's Page'", format.read_frontmatter_title, "Bob's Page"),
+        (
+            "desc: 'It's the team's plan: ship in May.'",
+            format.read_frontmatter_desc,
+            "It's the team's plan: ship in May.",
+        ),
+        ("desc:\n  'Bob's page.'", format.read_frontmatter_desc, "Bob's page."),
+        (
+            "tags: ['Bob's #1 hit', beta]",
+            lambda text: format.read_frontmatter_field(text, 'tags'),
+            "['Bob's #1 hit', beta]",
+        ),
+        (
+            "desc:\n  'A long\n  scalar # tag\n  ends.'",
+            format.read_frontmatter_desc,
+            'A long scalar # tag ends.',
+        ),
+    ],
+    ids=[
+        'null-comment',
+        'null-body',
+        'quoted-null',
+        'title-null-comment',
+        'comment-only',
+        'placeholder-comment',
+        'quoted-hash',
+        'commented-key-with-body',
+        'comment-only-body',
+        'column0-comment-mid-field',
+        'folded',
+        'block-header-comment',
+        'escaped-quote-then-comment',
+        'indented-comment-mid-body',
+        'bare-key-two-lines',
+        'bare-key-tail-comment',
+        'tilde-is-text',
+        'quoted-key',
+        'anchored-plain-multiline',
+        'tagged-key',
+        'flow-with-quoted-hash',
+        'flow-two-lines',
+        'unclosed-flow',
+        'flow-quote-across-lines',
+        'anchored-block',
+        'tagged-folded-title',
+        'double-spaced-properties',
+        'block-indentation-comment',
+        'column0-items',
+        'quoted-wrapped',
+        'flow-tail-comment',
+        'bare-key-quoted-body',
+        'bare-key-quoted-two-lines',
+        'quoted-item-hash',
+        'apostrophe-title',
+        'apostrophe-desc',
+        'apostrophe-bare-key-body',
+        'apostrophe-flow-hash',
+        'bare-key-quoted-mid-hash',
+    ],
+)
+def test_fallback_reader_agrees_with_the_repair(
+    field: str,
+    read: Callable[[str], Optional[str]],
+    expected: Optional[str],
+) -> None:
+    """Under the line grammar a field reads as the repair judges it.
+
+    One invalid line sends the block through the line grammar; a
+    ``null`` with a comment, a ``null`` continued on the next line, and a
+    comment-only value must still read as unset there, or the repair
+    removes or fills a field the reader propagated and the update never
+    converges.
+    """
+    text = f'---\nname: {NAME}\ninvalid: A: b\n{field}\n---'
+    assert format.frontmatter_issues(text)
+    assert read(text) == expected
+    # the repair judges the field the same way: a valued field keeps its
+    # lines and reads the same afterwards, a valueless one is filled or gone
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    key = re.sub(r'^(?:[&!]\S*[ \t]+)*', '', field.split(':')[0]).strip('"')
+    if expected:
+        assert read(repaired) == expected
+        assert field.split('\n')[-1] in repaired
+    elif key == 'desc':
+        assert read(repaired) == '...'
+    else:
+        assert format.field_text(repaired, key) is None
 
 
 @pytest.mark.parametrize(
@@ -374,6 +1271,7 @@ def test_reader_reads_a_carriage_return_escape_as_a_line_break() -> None:
         'block-lines',
     ],
 )
+@pytest.mark.usefixtures('_loader')
 def test_title_reader_applies_the_null_idiom(field: str, expected: str) -> None:
     """Only the plain lowercase ``null`` unsets a title; every other spelling is text.
 
@@ -412,6 +1310,18 @@ def test_title_reader_applies_the_null_idiom(field: str, expected: str) -> None:
         '>gt',
         ' padded ',
         '',
+        '-',
+        '?',
+        '<<',
+        '=',
+        ',leading comma',
+        'a' + chr(9) + 'tab',
+        'del' + chr(0x7F) + 'x',
+        '2024-02-30',
+        '2026-01-01 25:00:00',
+        '0x_',
+        '0b_',
+        '-0x_',
     ],
 )
 def test_quote_round_trips_through_yaml(value: str) -> None:
@@ -423,6 +1333,10 @@ def test_quote_round_trips_through_yaml(value: str) -> None:
     """
     assert oracle_scalar(f'k: {format.quote(value)}\n', 'k') == value
     assert format.unquote(format.quote(value)) == value
+    # the block constructs too: a date-shaped value no calendar has is quoted
+    # (an empty plain value constructs as null, which the reader reads as absent)
+    if value:
+        assert oracle_mapping(f'k: {format.quote(value)}\n') == {'k': value}
 
 
 @pytest.mark.parametrize(
@@ -434,20 +1348,85 @@ def test_quote_round_trips_through_yaml(value: str) -> None:
         'bell' + chr(7) + 'rings',
         'carriage' + chr(13) + 'return',
         'quoted "and' + chr(1) + 'escaped\\',
+        'Caf' + chr(0x80) + ' latin',
+        'c1' + chr(0x9F) + 'end',
+        'non' + chr(0xFFFE) + 'character',
+        'two' + chr(10) + 'lines',
     ],
-    ids=['line-separator', 'paragraph-separator', 'nel', 'bell', 'cr', 'mixed'],
+    ids=[
+        'line-separator',
+        'paragraph-separator',
+        'nel',
+        'bell',
+        'cr',
+        'mixed',
+        'c1-first',
+        'c1-last',
+        'noncharacter',
+        'newline',
+    ],
 )
 def test_quote_escapes_characters_no_stream_may_carry(value: str) -> None:
     """A value holding a character YAML forbids in a stream is written escaped.
 
     Plain or single-quoted, such a character makes the whole block
     invalid (or folds as a line break); double-quoted with an escape it
-    reads back verbatim under a strict reader and under ``unquote``.
+    reads back verbatim under a strict reader and under ``unquote``, and
+    a line break spells as the short newline escape.
     """
     written = format.quote(value)
     assert written[0] == written[-1] == '"'
     assert oracle_scalar(f'k: {written}\n', 'k') == value
     assert format.unquote(written) == value
+    assert chr(10) not in written
+    if chr(10) in value:
+        assert '\\n' in written
+
+
+@pytest.mark.parametrize(
+    argnames=('escaped', 'expected'),
+    argvalues=[
+        ('"a\\Nb"', 'a' + chr(0x85) + 'b'),
+        ('"a\\_b"', 'a' + chr(0xA0) + 'b'),
+        ('"a\\Lb\\Pc"', 'a' + chr(0x2028) + 'b' + chr(0x2029) + 'c'),
+        ('"a\\U0001F600b"', 'a' + chr(0x1F600) + 'b'),
+        ('"a\\x41\\u0042c"', 'aABc'),
+        ('"tab\\there\\0end"', 'tab' + chr(9) + 'here' + chr(0) + 'end'),
+        ('"slash\\/quote\\"back\\\\"', 'slash/quote"back\\'),
+    ],
+    ids=['nel', 'nbsp', 'separators', 'wide', 'hex-unicode', 'tab-nul', 'punctuation'],
+)
+def test_unquote_decodes_every_double_quoted_escape(
+    escaped: str, expected: str
+) -> None:
+    """``unquote`` decodes the escapes a strict reader decodes, so ``match`` sees the same text.
+
+    An escape naming no character -- past U+10FFFF, or a lone surrogate --
+    stays verbatim, as libyaml reads it, and never a crash; a comment after
+    a quoted value is not the value.
+    """
+    assert format.unquote(escaped) == expected
+    assert oracle_scalar(f'k: {escaped}\n', 'k') == expected
+    assert format.unquote('"a\\U00110000b\\uD800c"') == 'a\\U00110000b\\uD800c'
+    assert format.field_value("desc: 'a #b' # c") == 'a #b'
+    assert format.field_value('desc: &d !!str Verbatim.') == 'Verbatim.'
+    assert format.field_value('desc: Alpha # note') == 'Alpha'
+    assert format.field_value('my key: v', key='my key') == 'v'
+    assert format.field_value('"my key": v', key='my key') == 'v'
+    assert format.field_value('my key: v') == 'my key: v'
+    assert format.field_value('"a\\"b": v', key='a"b') == 'v'
+    assert format.field_value("'it''s': v", key="it's") == 'v'
+    assert format.field_value("tags: ['alpha #note', beta]", key='tags') == (
+        "['alpha #note', beta]"
+    )
+    assert format.field_value('two: three"', key='') == 'two: three"'
+    assert format.field_value('desc: "Alpha continued', key='desc') == 'Alpha continued'
+    assert format.field_value("desc: 'It's here'") == "It's here"
+    assert format.line_keys(f'---\nname: {NAME}\nmy key: v\n---') == {
+        2: 'name',
+        3: 'my key',
+    }
+    assert format.line_keys(f'---\nname: {NAME}\ndesc: A: b\n---') == {}
 
 
 # ------ field extents

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -61,6 +61,7 @@ __all__ = [
     'test_frontmatter_issues_locate_an_unclosed_flow_collection',
     'test_frontmatter_issues_name_a_nested_duplicate_key',
     'test_unaddressable_blocks_are_refused_not_crashed',
+    'test_strip_blank_lines_keeps_content_blanks_at_any_depth',
     'test_fallback_repair_sees_a_quoted_key',
     'test_colon_error_names_the_line_the_scalar_started_on',
     'test_compose_walks_an_alias_graph_once',
@@ -70,9 +71,9 @@ __all__ = [
     'test_repair_fills_an_empty_block_over_column_zero_comments',
     'test_field_ranges_end_at_a_typo_line_under_the_line_grammar',
     'test_build_frontmatter_escapes_a_multi_line_desc',
+    'test_build_frontmatter_pins_a_padded_first_line',
     'test_field_ranges_end_at_a_foreign_key_under_the_line_grammar',
     'test_repair_breaks_frontmatter_names_a_breaking_repair',
-    'test_strip_blank_lines_keeps_content_blanks_at_any_depth',
     'test_reader_applies_the_documented_policy',
     'test_reader_reads_a_carriage_return_escape_as_a_line_break',
     'test_fallback_reader_agrees_with_the_repair',
@@ -215,9 +216,9 @@ def test_repair_keeps_authored_values_on_hostile_shapes(
     A quoted key is the field it names, a quoted scalar continued at
     column 0 is one value, an alias keeps its anchor above it, and a
     column-0 comment inside a field stays where it is: the repair rewrites
-    only the name, converges, and leaves a block every strict reader
-    accepts -- with the same authored mapping, minus the valueless title
-    or category it drops.
+    only the name, converges, and leaves a block the installed strict
+    reader accepts -- with the same authored mapping, minus the valueless
+    title or category it drops.
     """
     text = block(key, lines)
     repaired = format.repair_frontmatter(
@@ -737,7 +738,7 @@ def test_fallback_repair_sees_a_quoted_key(line: str) -> None:
         'typo-line-after-comment',
     ],
 )
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_colon_error_names_the_line_the_scalar_started_on(body: str, line: int) -> None:
     """A colon the parser trips over is reported where the plain scalar holding it began.
 
@@ -800,7 +801,7 @@ _DEEP = format._MAX_NESTING * 2
         'brackets-in-continuation',
     ],
 )
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_compose_refuses_nesting_past_the_bound(body: str, line: Optional[int]) -> None:
     """Collections nested past the bound are a strict-reader finding, not a recursion the composer runs.
 
@@ -817,7 +818,7 @@ def test_compose_refuses_nesting_past_the_bound(body: str, line: Optional[int]) 
         assert issues == [(line, reason, 'parse')]
 
 
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_tab_on_the_last_block_line_is_named() -> None:
     """A tab on a whitespace-only line closing the block is reported on that line, not the one above."""
     issues = format.frontmatter_issues(f'---\nname: {NAME}\ndesc: D.\n\t\n---')
@@ -886,6 +887,20 @@ def test_build_frontmatter_escapes_a_multi_line_desc(desc: str) -> None:
     assert oracle_valid(yaml_body(text)), text
     assert oracle_scalar(yaml_body(text), 'desc') == desc
     assert 'desc: "' in text
+
+
+@pytest.mark.parametrize(
+    argnames='desc',
+    argvalues=['  padded\nplain', '\ttabbed\nplain', '\n  padded\nplain'],
+    ids=['space-first', 'tab-first', 'blank-then-padded'],
+)
+@pytest.mark.usefixtures('_vary_loader')
+def test_build_frontmatter_pins_a_padded_first_line(desc: str) -> None:
+    """A multi-line desc whose first content line opens with whitespace still writes a block a strict reader accepts."""
+    text = format.build_frontmatter(name='x', created=NOW, updated=NOW, desc=desc)
+    assert oracle_valid(yaml_body(text)), text
+    assert normalize(oracle_scalar(yaml_body(text), 'desc')) == desc
+    assert format.read_frontmatter_desc(text) == desc
 
 
 def test_field_ranges_end_at_a_foreign_key_under_the_line_grammar() -> None:
@@ -1060,7 +1075,7 @@ def test_repair_breaks_frontmatter_names_a_breaking_repair(
         'invalid-neighbor',
     ],
 )
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_reader_applies_the_documented_policy(
     field: str,
     key: str,
@@ -1278,7 +1293,7 @@ def test_fallback_reader_agrees_with_the_repair(
         'block-lines',
     ],
 )
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_title_reader_applies_the_null_idiom(field: str, expected: str) -> None:
     """Only the plain lowercase ``null`` unsets a title; every other spelling is text.
 

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -44,9 +44,13 @@ __all__ = [
     'test_reader_matches_strict_yaml_on_hostile_shapes',
     'test_repair_keeps_authored_values',
     'test_repair_recognizes_a_spaced_key',
+    'test_repair_keeps_column_zero_sequences',
+    'test_repair_keeps_the_comments_of_valueless_fields',
     'test_reader_applies_the_documented_policy',
+    'test_reader_reads_a_carriage_return_escape_as_a_line_break',
     'test_title_reader_applies_the_null_idiom',
     'test_quote_round_trips_through_yaml',
+    'test_quote_escapes_characters_no_stream_may_carry',
     'test_field_ranges_match_yaml_extents',
     'test_field_ranges_match_yaml_extents_on_hostile_shapes',
 ]
@@ -184,6 +188,71 @@ def test_repair_recognizes_a_spaced_key() -> None:
     assert 'desc : A page.' in repaired
 
 
+@pytest.mark.parametrize('key', ['desc', 'category', 'created'])
+def test_repair_keeps_column_zero_sequences(key: str) -> None:
+    """A column-0 sequence under a repaired key is its value, kept whole.
+
+    YAML reads ``key:`` over ``- a`` items as a sequence; a repair that saw
+    only indented lines as the value would take the key line for a blank,
+    restore a placeholder or stamp over it, and strand the items under the
+    field before it -- turning valid YAML into a block no reader accepts.
+    """
+    text = block(key, [f'{key}:', '- a', '- b'])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert oracle_mapping(yaml_body(repaired))[key] == ['a', 'b']
+
+
+def test_repair_keeps_the_comments_of_valueless_fields() -> None:
+    """Comments on a field the repair fills or removes survive the edit.
+
+    A comment-only ``desc:`` or stamp reads as empty, so the repair fills
+    it -- but the annotation the author wrote is not the repair's to
+    delete: a tail comment re-attaches after the written value, an
+    indented comment line stays under it, and the comment on an unset
+    ``title:`` stands alone once the line goes.
+    """
+    text = (
+        '---\n'
+        f'name: {NAME}\n'
+        'title: # TODO pick one\n'
+        'desc: # to be written\n'
+        'created: # stamped at birth\n'
+        'updated:\n'
+        '  # the last write\n'
+        '---'
+    )
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert repaired == (
+        '---\n'
+        f'name: {NAME}\n'
+        '# TODO pick one\n'
+        'desc: ... # to be written\n'
+        f'created: {NOW} # stamped at birth\n'
+        f'updated: {NOW}\n'
+        '  # the last write\n'
+        '---'
+    )
+    mapping = oracle_mapping(yaml_body(repaired))
+    assert mapping['desc'] == '...'
+    assert 'title' not in mapping
+
+
 # ------ documented policy
 
 
@@ -260,6 +329,19 @@ def test_reader_applies_the_documented_policy(
     assert format.read_frontmatter_field(text, key) == expected
 
 
+def test_reader_reads_a_carriage_return_escape_as_a_line_break() -> None:
+    """A double-quoted carriage-return escape reads as a line break, never a bare return.
+
+    Every consumer splits on newlines; a bare carriage return inside a
+    title or desc would ride into the H1 and the parent row and split the
+    line model on the next read, so update would never converge.
+    """
+    backslash = chr(92)
+    text = f'---\nname: {NAME}\ndesc: "a{backslash}rb"\ntitle: "c{backslash}rd"\n---'
+    assert format.read_frontmatter_field(text, 'desc') == 'a\nb'
+    assert format.read_frontmatter_title(text) == 'c d'
+
+
 @pytest.mark.parametrize(
     argnames=('field', 'expected'),
     argvalues=[
@@ -270,6 +352,7 @@ def test_reader_applies_the_documented_policy(
         ('title: Null', 'Null'),
         ('title: NULL', 'NULL'),
         ("title: 'null'", 'null'),
+        ('title: !!str null', 'null'),
         ('title: |\n  null', 'null'),
         ('title: Draft\n  heading', 'Draft heading'),
         ('title: |\n  Two\n  lines', 'Two lines'),
@@ -282,6 +365,7 @@ def test_reader_applies_the_documented_policy(
         'Null',
         'NULL',
         'quoted-null',
+        'tagged-null',
         'block-null',
         'continuation',
         'block-lines',
@@ -337,6 +421,32 @@ def test_quote_round_trips_through_yaml(value: str) -> None:
     node = yaml.compose(f'k: {format.quote(value)}\n', Loader=yaml.SafeLoader)
     assert node.value[0][1].value == value
     assert format.unquote(format.quote(value)) == value
+
+
+@pytest.mark.parametrize(
+    argnames='value',
+    argvalues=[
+        'line' + chr(0x2028) + 'separator',
+        'para' + chr(0x2029) + 'separator',
+        'next' + chr(0x85) + 'line',
+        'bell' + chr(7) + 'rings',
+        'carriage' + chr(13) + 'return',
+        'quoted "and' + chr(1) + 'escaped\\',
+    ],
+    ids=['line-separator', 'paragraph-separator', 'nel', 'bell', 'cr', 'mixed'],
+)
+def test_quote_escapes_characters_no_stream_may_carry(value: str) -> None:
+    """A value holding a character YAML forbids in a stream is written escaped.
+
+    Plain or single-quoted, such a character makes the whole block
+    invalid (or folds as a line break); double-quoted with an escape it
+    reads back verbatim under a strict reader and under ``unquote``.
+    """
+    written = format.quote(value)
+    assert written[0] == written[-1] == '"'
+    node = yaml.compose(f'k: {written}\n', Loader=yaml.SafeLoader)
+    assert node.value[0][1].value == value
+    assert format.unquote(written) == value
 
 
 # ------ field extents

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -26,10 +26,12 @@ from ._oracle import (
     KEYS,
     NAME,
     NOW,
+    SEQUENCES,
     block,
     frontmatter,
     grammar,
     normalize,
+    oracle_extent,
     oracle_mapping,
     oracle_scalar,
     oracle_valid,
@@ -41,9 +43,12 @@ __all__ = [
     'test_reader_matches_strict_yaml',
     'test_reader_matches_strict_yaml_on_hostile_shapes',
     'test_repair_keeps_authored_values',
+    'test_repair_recognizes_a_spaced_key',
     'test_reader_applies_the_documented_policy',
     'test_title_reader_applies_the_null_idiom',
     'test_quote_round_trips_through_yaml',
+    'test_field_ranges_match_yaml_extents',
+    'test_field_ranges_match_yaml_extents_on_hostile_shapes',
 ]
 
 # ------ engine cover
@@ -156,6 +161,27 @@ def test_repair_keeps_authored_values(style: str, body: str, deco: str) -> None:
         assert after.pop('name') == NAME, (key, text, repaired)
         before.pop('name')
         assert after == before, (key, text, repaired)
+
+
+def test_repair_recognizes_a_spaced_key() -> None:
+    """A key with a space before its colon is the key it names, not a stranger.
+
+    ``desc : x`` is the ``desc`` field to every YAML reader; a repair that
+    saw no ``desc:`` would insert the placeholder beside it, writing a
+    duplicate key that strict readers reject.
+    """
+    text = block('desc', ['desc : A page.'])
+    repaired = format.repair_frontmatter(
+        text,
+        name=NAME,
+        now=NOW,
+        title=True,
+        category=True,
+        order=True,
+    )
+    assert oracle_valid(yaml_body(repaired)), repaired
+    assert repaired.count('desc') == 1
+    assert 'desc : A page.' in repaired
 
 
 # ------ documented policy
@@ -311,3 +337,35 @@ def test_quote_round_trips_through_yaml(value: str) -> None:
     node = yaml.compose(f'k: {format.quote(value)}\n', Loader=yaml.SafeLoader)
     assert node.value[0][1].value == value
     assert format.unquote(format.quote(value)) == value
+
+
+# ------ field extents
+
+
+@_shapes
+def test_field_ranges_match_yaml_extents(style: str, body: str, deco: str) -> None:
+    """``field_line_ranges`` attributes lines the way a strict reader's key marks do.
+
+    The line ranges scope ``match --field`` and the wrap-mangle lint, so
+    a field that ends early (a continuation misread as a key) or late (a
+    key misread as a continuation) hides or misattributes matches.
+    """
+    for key in KEYS:
+        text = frontmatter(key, style, body, deco)
+        ranges = format.field_line_ranges(text, text.split('\n'), [key])
+        assert ranges == oracle_extent(yaml_body(text), key), (key, text)
+
+
+@pytest.mark.parametrize(
+    argnames=('key', 'lines'),
+    argvalues=[(key, lines) for _, key, lines in EXTRAS + SEQUENCES],
+    ids=[extra_id for extra_id, _, _ in EXTRAS + SEQUENCES],
+)
+def test_field_ranges_match_yaml_extents_on_hostile_shapes(
+    key: str,
+    lines: list[str],
+) -> None:
+    """Off-grammar shapes -- a column-0 item holding a colon, a spaced key -- scope right."""
+    text = block(key, lines)
+    ranges = format.field_line_ranges(text, text.split('\n'), [key])
+    assert ranges == oracle_extent(yaml_body(text), key)

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -80,6 +80,8 @@ __all__ = [
     'test_quote_round_trips_through_yaml',
     'test_quote_escapes_characters_no_stream_may_carry',
     'test_unquote_decodes_every_double_quoted_escape',
+    'test_field_value_strips_keys_quotes_and_comments',
+    'test_line_keys_names_composed_key_lines',
     'test_field_ranges_match_yaml_extents',
     'test_field_ranges_match_yaml_extents_on_hostile_shapes',
 ]
@@ -769,18 +771,22 @@ def test_compose_walks_an_alias_graph_once(body: str) -> None:
     assert format.read_frontmatter_name(text) == NAME
 
 
+# one level past the nesting bound, however the collections nest
+_DEEP = format._MAX_NESTING * 2
+
+
 @pytest.mark.parametrize(
     argnames=('body', 'line'),
     argvalues=[
-        ('desc: ' + '[' * 200 + 'x' + ']' * 200, 3),
-        ('desc: ' + '{a: ' * 200 + 'x' + '}' * 200, 3),
-        ('tags:\n' + '- ' * 200 + 'x', 4),
-        ('tags: ' + '[' * 100 + 'x' + ']' * 100, None),
-        ("desc: rock 'n roll\ntags: " + '[' * 200 + 'x' + ']' * 200, 4),
-        ('desc: a ' + '[' * 200, None),
-        ('desc: |\n' + '\n'.join('  [ x' for _ in range(120)), None),
-        ('desc: |\n  ' + '- ' * 200 + 'x', None),
-        ('desc: plain\n  ' + '[' * 200, None),
+        ('desc: ' + '[' * _DEEP + 'x' + ']' * _DEEP, 3),
+        ('desc: ' + '{a: ' * _DEEP + 'x' + '}' * _DEEP, 3),
+        ('tags:\n' + '- ' * _DEEP + 'x', 4),
+        ('tags: ' + '[' * format._MAX_NESTING + 'x' + ']' * format._MAX_NESTING, None),
+        ("desc: rock 'n roll\ntags: " + '[' * _DEEP + 'x' + ']' * _DEEP, 4),
+        ('desc: a ' + '[' * _DEEP, None),
+        ('desc: |\n' + '\n'.join('  [ x' for _ in range(_DEEP)), None),
+        ('desc: |\n  ' + '- ' * _DEEP + 'x', None),
+        ('desc: plain\n  ' + '[' * _DEEP, None),
     ],
     ids=[
         'flow-sequence',
@@ -804,10 +810,11 @@ def test_compose_refuses_nesting_past_the_bound(body: str, line: Optional[int]) 
     """
     text = f'---\nname: {NAME}\n{body}\n---'
     issues = format.frontmatter_issues(text)
+    reason = f'collections nested deeper than {format._MAX_NESTING} levels'
     if line is None:
         assert issues == []
     else:
-        assert issues == [(line, 'collections nested deeper than 100 levels', 'parse')]
+        assert issues == [(line, reason, 'parse')]
 
 
 @pytest.mark.usefixtures('_loader')
@@ -1409,19 +1416,36 @@ def test_unquote_decodes_every_double_quoted_escape(
     assert oracle_scalar(f'k: {escaped}\n', 'k') == expected
     assert format.unquote('"a\\U00110000b\\uD800c"') == 'a\\U00110000b\\uD800c'
     assert format.field_value("desc: 'a #b' # c") == 'a #b'
+
+
+def test_field_value_strips_keys_quotes_and_comments() -> None:
+    """``field_value`` yields the line's value however its key and quotes are spelled.
+
+    Node properties and comment tails are not the value; a composed key
+    (``line_keys``) strips whatever its spelling, ``''`` marks a line the
+    composed block says opens no key, and a quote mid-text or one closing
+    on a later line is content.
+    """
+    # the line grammar's key shapes strip; a spaced key stays without help
     assert format.field_value('desc: &d !!str Verbatim.') == 'Verbatim.'
     assert format.field_value('desc: Alpha # note') == 'Alpha'
+    assert format.field_value('my key: v') == 'my key: v'
+    # a composed key strips whatever its spelling
     assert format.field_value('my key: v', key='my key') == 'v'
     assert format.field_value('"my key": v', key='my key') == 'v'
-    assert format.field_value('my key: v') == 'my key: v'
     assert format.field_value('"a\\"b": v', key='a"b') == 'v'
     assert format.field_value("'it''s': v", key="it's") == 'v'
+    # quotes decode: mid-text quotes are content, an open quote is not value text
     assert format.field_value("tags: ['alpha #note', beta]", key='tags') == (
         "['alpha #note', beta]"
     )
     assert format.field_value('two: three"', key='') == 'two: three"'
     assert format.field_value('desc: "Alpha continued', key='desc') == 'Alpha continued'
     assert format.field_value("desc: 'It's here'") == "It's here"
+
+
+def test_line_keys_names_composed_key_lines() -> None:
+    """``line_keys`` maps file lines to composed keys, empty where the line grammar rules."""
     assert format.line_keys(f'---\nname: {NAME}\nmy key: v\n---') == {
         2: 'name',
         3: 'my key',

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -1,18 +1,52 @@
 """Test the ``wiki.core.format`` module.
 
-Functions over the on-disk page format, driven only through the engine;
-the behavior-named core suites (``test_authoring``, ``test_update``,
-``test_lint``) are the primary cover, exercising parse/render
-round-trips exactly as the tool does.
+Functions over the on-disk page format. The behavior-named core suites
+(``test_authoring``, ``test_update``, ``test_lint``) drive them through
+the engine; this module holds the differential oracle harness, which
+drives the frontmatter reader, repair, and writer directly over an
+enumerated grammar of scalar shapes (see ``_oracle``) and judges them
+against a strict YAML reader: every value the wiki reads is the value a
+strict reader sees, every repair leaves authored values as the strict
+reader saw them, and every value the writer quotes reads back verbatim.
 """
 
 from __future__ import annotations
 
 import pathlib
+from typing import Optional
+
+import pytest
+import yaml
+
+from wiki.core import format
 
 from ._helpers import _make_wiki
+from ._oracle import (
+    EXTRAS,
+    KEYS,
+    NAME,
+    NOW,
+    block,
+    frontmatter,
+    grammar,
+    normalize,
+    oracle_mapping,
+    oracle_scalar,
+    oracle_valid,
+    yaml_body,
+)
 
-__all__ = ['test_plain_multiline_desc_propagates']
+__all__ = [
+    'test_plain_multiline_desc_propagates',
+    'test_reader_matches_strict_yaml',
+    'test_reader_matches_strict_yaml_on_hostile_shapes',
+    'test_repair_keeps_authored_values',
+    'test_reader_applies_the_documented_policy',
+    'test_title_reader_applies_the_null_idiom',
+    'test_quote_round_trips_through_yaml',
+]
+
+# ------ engine cover
 
 
 def test_plain_multiline_desc_propagates(tmp_path: pathlib.Path) -> None:
@@ -37,3 +71,243 @@ def test_plain_multiline_desc_propagates(tmp_path: pathlib.Path) -> None:
     core_index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
     assert 'A plain multi-line scalar value.' in core_index
     assert wiki.update() == []
+
+
+# ------ differential oracle
+
+_shapes = pytest.mark.parametrize(
+    argnames=('style', 'body', 'deco'),
+    argvalues=grammar(),
+    ids=['-'.join(shape) for shape in grammar()],
+)
+
+
+@_shapes
+def test_reader_matches_strict_yaml(style: str, body: str, deco: str) -> None:
+    """Every key reads exactly the value a strict YAML reader sees, for every shape."""
+    for key in KEYS:
+        text = frontmatter(key, style, body, deco)
+        expected = oracle_scalar(yaml_body(text), key)
+        actual = format.read_frontmatter_field(text, key)
+        assert normalize(actual) == normalize(expected), (key, text)
+
+
+@pytest.mark.parametrize(
+    argnames=('key', 'lines'),
+    argvalues=[(key, lines) for _, key, lines in EXTRAS],
+    ids=[extra_id for extra_id, _, _ in EXTRAS],
+)
+def test_reader_matches_strict_yaml_on_hostile_shapes(
+    key: str, lines: list[str]
+) -> None:
+    """Valid shapes off the grammar's axes read as a strict reader reads them.
+
+    Comments on the key line, quoted and block openers under a bare key,
+    end-of-line comments, escaped line breaks, a space before the colon,
+    and node properties are the shapes hand-derived reading rules miss
+    first; each must read as the composed scalar, never as raw line text.
+    """
+    text = block(key, lines)
+    expected = oracle_scalar(yaml_body(text), key)
+    assert normalize(format.read_frontmatter_field(text, key)) == normalize(expected)
+
+
+@_shapes
+def test_repair_keeps_authored_values(style: str, body: str, deco: str) -> None:
+    """The repair converges, stays valid YAML, and rewrites only the name.
+
+    A stamp continued on an indented line is a value, so ``created`` and
+    ``updated`` must survive the repair like every authored field; a
+    ``#`` line the strict reader does not fold into a value is a comment
+    and must survive too.
+    """
+    for key in KEYS:
+        text = frontmatter(key, style, body, deco)
+        # the engine's exact call shape, applied twice
+        repaired = format.repair_frontmatter(
+            text,
+            name=NAME,
+            now=NOW,
+            title=True,
+            category=True,
+            order=True,
+        )
+        again = format.repair_frontmatter(
+            repaired,
+            name=NAME,
+            now=NOW,
+            title=True,
+            category=True,
+            order=True,
+        )
+        assert again == repaired, (key, text)
+        # the output is valid for a strict reader
+        assert oracle_valid(yaml_body(repaired)), (key, text, repaired)
+        # a strict reader loads exactly the refreshed name -- never a stranded
+        # continuation folded into it -- and the same authored mapping
+        before = oracle_mapping(yaml_body(text))
+        after = oracle_mapping(yaml_body(repaired))
+        # a comment line survives the repair (a hash line inside a block
+        # scalar's body is content, which the name refresh may replace)
+        values = ' '.join(map(str, before.values()))
+        for line in text.split('\n'):
+            if line.lstrip().startswith('#') and line.strip() not in values:
+                assert line in repaired, (key, text, repaired)
+        assert after.pop('name') == NAME, (key, text, repaired)
+        before.pop('name')
+        assert after == before, (key, text, repaired)
+
+
+# ------ documented policy
+
+
+@pytest.mark.parametrize(
+    argnames=('field', 'key', 'expected'),
+    argvalues=[
+        # the placeholder is read as its spelling, quoted or not
+        ('desc: ...', 'desc', '...'),
+        ("desc: '...'", 'desc', '...'),
+        # a valueless key is absent, an empty block scalar is empty text
+        ('desc:', 'desc', None),
+        ('desc:   ', 'desc', None),
+        ('desc: # to be written', 'desc', None),
+        ('desc: |', 'desc', ''),
+        ('desc: | # note', 'desc', ''),
+        # typed-looking scalars stay strings
+        ('title: 2024', 'title', '2024'),
+        ('title: 1.10', 'title', '1.10'),
+        ('title: yes', 'title', 'yes'),
+        ('title: 2026-01-01', 'title', '2026-01-01'),
+        ('created: 2026-07-10T02:36:41Z', 'created', '2026-07-10T02:36:41Z'),
+        # ' #' starts a comment: the text after it reaches no reader
+        ('desc: Use #1 approach.', 'desc', 'Use'),
+        # sequences are never resolved: the raw flow text, or absent at column 0
+        ('tags: [a, b]', 'tags', '[a, b]'),
+        ('tags:\n- a\n- b', 'tags', None),
+        # the first occurrence of a duplicated key wins, bare or not
+        ('desc:\ndesc: second', 'desc', None),
+        ('desc: first\ndesc: second', 'desc', 'first'),
+        # tolerated invalid YAML reads through the line grammar as authored
+        ('desc: A theorem for X: HR, WR.', 'desc', 'A theorem for X: HR, WR.'),
+        ('desc: > one liner.', 'desc', 'one liner.'),
+        ('desc: "unterminated\n  continues', 'desc', '"unterminated'),
+        (
+            '<<<<<<< ours\ndesc: Ours.\n=======\ndesc: Theirs.\n>>>>>>> theirs',
+            'desc',
+            'Ours.',
+        ),
+        # one invalid line sends every field of the block through the line grammar
+        ('desc: A theorem for X: HR, WR.\ncategory: |\n  Cat', 'category', 'Cat'),
+    ],
+    ids=[
+        'placeholder',
+        'quoted-placeholder',
+        'bare-key',
+        'bare-key-trailing-spaces',
+        'keyline-comment-no-body',
+        'empty-block',
+        'empty-block-header-comment',
+        'int-like',
+        'float-like',
+        'bool-like',
+        'date-like',
+        'timestamp',
+        'hash-in-value',
+        'flow-sequence',
+        'block-sequence',
+        'duplicate-bare-first',
+        'duplicate-valued-first',
+        'unquoted-colon-space',
+        'indicator-inline-text',
+        'unterminated-quote',
+        'conflict-markers',
+        'invalid-neighbor',
+    ],
+)
+def test_reader_applies_the_documented_policy(
+    field: str,
+    key: str,
+    expected: Optional[str],
+) -> None:
+    """Where the wiki departs from strict YAML on purpose, the departure is pinned."""
+    text = f'---\nname: {NAME}\n{field}\n---'
+    assert format.read_frontmatter_field(text, key) == expected
+
+
+@pytest.mark.parametrize(
+    argnames=('field', 'expected'),
+    argvalues=[
+        ('title: null', ''),
+        ('title: null # why', ''),
+        ('title:', ''),
+        ('title: ~', '~'),
+        ('title: Null', 'Null'),
+        ('title: NULL', 'NULL'),
+        ("title: 'null'", 'null'),
+        ('title: |\n  null', 'null'),
+        ('title: Draft\n  heading', 'Draft heading'),
+        ('title: |\n  Two\n  lines', 'Two lines'),
+    ],
+    ids=[
+        'null',
+        'null-comment',
+        'bare-key',
+        'tilde',
+        'Null',
+        'NULL',
+        'quoted-null',
+        'block-null',
+        'continuation',
+        'block-lines',
+    ],
+)
+def test_title_reader_applies_the_null_idiom(field: str, expected: str) -> None:
+    """Only the plain lowercase ``null`` unsets a title; every other spelling is text.
+
+    The heading renders on one line, so a multi-line title joins; a
+    trailing comment after ``null`` is not part of the spelling.
+    """
+    text = f'---\nname: {NAME}\n{field}\n---'
+    assert format.read_frontmatter_title(text) == expected
+
+
+# ------ writer twin
+
+
+@pytest.mark.parametrize(
+    argnames='value',
+    argvalues=[
+        'plain text',
+        'A: colon inside',
+        'ends with colon:',
+        'Notes on issue #3 and the fix.',
+        '#hashtag',
+        '[Draft] X',
+        '{y}',
+        '- item',
+        '? question',
+        '@handle',
+        '`cmd`',
+        '%percent',
+        '!tag',
+        '&anchor',
+        '*alias',
+        "'single-quoted'",
+        '"double-quoted"',
+        "it's",
+        '|pipe',
+        '>gt',
+        ' padded ',
+        '',
+    ],
+)
+def test_quote_round_trips_through_yaml(value: str) -> None:
+    """A written value reads back verbatim under a strict reader and under ``unquote``.
+
+    The writer is the reader's twin: every value the tool writes plain
+    must be one a strict reader (Obsidian's included) reads back as the
+    same text, or an adopted heading is rewritten on the next update.
+    """
+    node = yaml.compose(f'k: {format.quote(value)}\n', Loader=yaml.SafeLoader)
+    assert node.value[0][1].value == value
+    assert format.unquote(format.quote(value)) == value

--- a/tests/test_core/test_format.py
+++ b/tests/test_core/test_format.py
@@ -16,7 +16,6 @@ import pathlib
 from typing import Optional
 
 import pytest
-import yaml
 
 from wiki.core import format
 
@@ -84,6 +83,7 @@ def test_plain_multiline_desc_propagates(tmp_path: pathlib.Path) -> None:
 
 # ------ differential oracle
 
+
 _shapes = pytest.mark.parametrize(
     argnames=('style', 'body', 'deco'),
     argvalues=grammar(),
@@ -107,7 +107,8 @@ def test_reader_matches_strict_yaml(style: str, body: str, deco: str) -> None:
     ids=[extra_id for extra_id, _, _ in EXTRAS],
 )
 def test_reader_matches_strict_yaml_on_hostile_shapes(
-    key: str, lines: list[str]
+    key: str,
+    lines: list[str],
 ) -> None:
     """Valid shapes off the grammar's axes read as a strict reader reads them.
 
@@ -118,7 +119,8 @@ def test_reader_matches_strict_yaml_on_hostile_shapes(
     """
     text = block(key, lines)
     expected = oracle_scalar(yaml_body(text), key)
-    assert normalize(format.read_frontmatter_field(text, key)) == normalize(expected)
+    actual = format.read_frontmatter_field(text, key)
+    assert normalize(actual) == normalize(expected)
 
 
 @_shapes
@@ -160,7 +162,7 @@ def test_repair_keeps_authored_values(style: str, body: str, deco: str) -> None:
         # scalar's body is content, which the name refresh may replace)
         values = ' '.join(map(str, before.values()))
         for line in text.split('\n'):
-            if line.lstrip().startswith('#') and line.strip() not in values:
+            if line.lstrip().startswith('#') and (line.strip() not in values):
                 assert line in repaired, (key, text, repaired)
         assert after.pop('name') == NAME, (key, text, repaired)
         before.pop('name')
@@ -207,7 +209,8 @@ def test_repair_keeps_column_zero_sequences(key: str) -> None:
         order=True,
     )
     assert oracle_valid(yaml_body(repaired)), repaired
-    assert oracle_mapping(yaml_body(repaired))[key] == ['a', 'b']
+    mapping = oracle_mapping(yaml_body(repaired))
+    assert mapping[key] == ['a', 'b']
 
 
 def test_repair_keeps_the_comments_of_valueless_fields() -> None:
@@ -390,7 +393,7 @@ def test_title_reader_applies_the_null_idiom(field: str, expected: str) -> None:
         'plain text',
         'A: colon inside',
         'ends with colon:',
-        'Notes on issue #3 and the fix.',
+        'Notes on room #12 and the key.',
         '#hashtag',
         '[Draft] X',
         '{y}',
@@ -418,8 +421,7 @@ def test_quote_round_trips_through_yaml(value: str) -> None:
     must be one a strict reader (Obsidian's included) reads back as the
     same text, or an adopted heading is rewritten on the next update.
     """
-    node = yaml.compose(f'k: {format.quote(value)}\n', Loader=yaml.SafeLoader)
-    assert node.value[0][1].value == value
+    assert oracle_scalar(f'k: {format.quote(value)}\n', 'k') == value
     assert format.unquote(format.quote(value)) == value
 
 
@@ -444,8 +446,7 @@ def test_quote_escapes_characters_no_stream_may_carry(value: str) -> None:
     """
     written = format.quote(value)
     assert written[0] == written[-1] == '"'
-    node = yaml.compose(f'k: {written}\n', Loader=yaml.SafeLoader)
-    assert node.value[0][1].value == value
+    assert oracle_scalar(f'k: {written}\n', 'k') == value
     assert format.unquote(written) == value
 
 

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -15,6 +15,7 @@ import shutil
 
 import pytest
 
+from wiki.core import format
 from wiki.core.wiki import Issue, Wiki
 from wiki.util import markdown
 
@@ -1147,7 +1148,8 @@ def test_lint_reports_deep_nesting_instead_of_crashing(tmp_path: pathlib.Path) -
     # the sweep completes with the block named as invalid, and update converges
     issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
     assert [issue.fields['path'] for issue in issues] == ['core/design.md']
-    assert issues[0].fields['reason'] == 'collections nested deeper than 100 levels'
+    reason = f'collections nested deeper than {format._MAX_NESTING} levels'
+    assert issues[0].fields['reason'] == reason
     assert issues[0].fields['line'] == 4
     wiki.update()
     assert Wiki(tmp_path).update() == []

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -14,6 +14,7 @@ import re
 import shutil
 
 import pytest
+import yaml
 
 from wiki.core.wiki import Issue, Wiki
 from wiki.util import markdown
@@ -54,6 +55,10 @@ __all__ = [
     'test_lint_flags_unparseable_stamp',
     'test_lint_future_stamp_is_clean',
     'test_lint_stamp_parse_follows_configured_format',
+    'test_lint_flags_frontmatter_a_strict_yaml_reader_rejects',
+    'test_lint_reports_deep_nesting_instead_of_crashing',
+    'test_lint_invalid_yaml_yields_to_merge_states',
+    'test_lint_names_a_comment_truncated_desc',
     'test_lint_hyphen_dangle',
     'test_lint_wrapped_list_marker',
     'test_lint_blank_led_list_is_clean',
@@ -278,6 +283,11 @@ def test_lint_issues_are_typed(tmp_path: pathlib.Path) -> None:
         'See [[core]] for more.\n\n<!-- start: no-lint -->\n',
         encoding='utf-8',
     )
+    # frontmatter a strict YAML reader rejects
+    (tmp_path / 'data' / 'unquoted.md').write_text(
+        '---\nname: unquoted\ndesc: A lane for X: HR, WR.\n---\n\n# unquoted\n\nBody.\n',
+        encoding='utf-8',
+    )
     # an emptied index (and, with a page to link, its missing delimiter)
     trunc = tmp_path / 'trunc'
     trunc.mkdir()
@@ -327,6 +337,7 @@ def test_lint_issues_are_typed(tmp_path: pathlib.Path) -> None:
         'invalid_folder_name',
         'invalid_page_name',
         'invalid_wiki_name',
+        'invalid_yaml',
         'malformed_frontmatter',
         'missing_delimiter',
         'missing_index',
@@ -921,6 +932,161 @@ def test_lint_stamp_parse_follows_configured_format(
         encoding='utf-8',
     )
     assert any('Unparseable created' in issue for issue in wiki.lint())
+
+
+@pytest.mark.parametrize('loader', ['c', 'pure'])
+@pytest.mark.parametrize(
+    argnames=('field', 'line', 'reason'),
+    argvalues=[
+        ('desc: Independent lane for L1: the harness.', 3, 'mapping values'),
+        ('title: Theorem for X: HR, WR', 3, 'mapping values'),
+        ('desc: Ends with a colon:', 3, 'mapping values'),
+        ('desc: One.\ndesc: Two.', 4, 'duplicate key'),
+        ('desc: Position and\x0c routes.', 3, 'characters are not allowed'),
+        ('? [a, b]\n: x', 3, 'not a scalar'),
+    ],
+    ids=[
+        'colon-space-desc',
+        'colon-space-title',
+        'trailing-colon',
+        'duplicate-key',
+        'control-char',
+        'complex-key',
+    ],
+)
+def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    line: int,
+    reason: str,
+    loader: str,
+) -> None:
+    """A block the wiki reads leniently but a strict YAML reader refuses is an issue.
+
+    The wiki reads an unquoted ``: `` value as the authored text through
+    the line grammar, but a strict reader (Obsidian's) drops the whole
+    block; lint names the file and line as a hard issue typed for
+    ``--json``, under the C loader and the pure-Python loader alike, and
+    update leaves the authored bytes alone (the fix is the author's).
+    """
+    if loader == 'pure':
+        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    desc = '' if field.startswith('desc:') else 'desc: A page.\n'
+    page.write_text(
+        f'---\nname: core/design\n{field}\n{desc}tags: []\nsources: []\n'
+        'created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n'
+        '\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the finding names the line; the block is otherwise read leniently
+    issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
+    assert [issue.fields['path'] for issue in issues] == ['core/design.md']
+    assert issues[0].fields['line'] == line
+    assert reason in issues[0].fields['reason']
+    assert f'core/design.md: Invalid YAML frontmatter (line {line})' in issues[0]
+    # update never rewrites an authored value: the field lines stay as typed
+    wiki.update()
+    assert field in page.read_text(encoding='utf-8').split('---\n')[1]
+    assert any(issue.kind == 'invalid_yaml' for issue in Wiki(tmp_path).lint())
+
+
+def test_lint_reports_deep_nesting_instead_of_crashing(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nesting past the pure loader's recursion limit is an issue, never an abort.
+
+    The pure-Python loader recurses once per nesting level and raises
+    ``RecursionError`` -- not a YAML error -- on a deeply nested flow
+    collection; lint must report the block, not lose the whole sweep to
+    the exception.
+    """
+    monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    nested = '[' * 2000 + ']' * 2000
+    page.write_text(
+        f'---\nname: core/design\ndesc: A page.\nextra: {nested}\n---\n\n'
+        '# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the sweep completes with the block named as invalid
+    issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
+    assert [issue.fields['path'] for issue in issues] == ['core/design.md']
+    assert issues[0].fields['reason'] == 'RecursionError'
+    assert wiki.update() is not None
+
+
+def test_lint_invalid_yaml_yields_to_merge_states(tmp_path: pathlib.Path) -> None:
+    """Merge debris keeps its own finding: markers win, the hint stays valid YAML.
+
+    Conflict markers inside a block make it unparseable, but the marker
+    check runs first and suppresses the per-file checks, so the file
+    reports only ``conflict_markers``; the driver's resolution hint is
+    valid YAML for every parser, so it reports only ``merge_hint``.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    index = tmp_path / 'core' / '_index.md'
+    lines = page.read_text(encoding='utf-8').split('\n')
+    lines[2:3] = [
+        '<<<<<<< ours',
+        lines[2],
+        '=======',
+        'desc: Theirs.',
+        '>>>>>>> theirs',
+    ]
+    page.write_text('\n'.join(lines), encoding='utf-8')
+    hint = (
+        '<!-- index *** separator missing on one side: likely formatter'
+        ' damage; restore the *** line (wiki update repairs it), redo the'
+        ' merge, and delete this line when resolving -->'
+    )
+    lines = index.read_text(encoding='utf-8').split('\n')
+    lines.insert(2, hint)
+    index.write_text('\n'.join(lines), encoding='utf-8')
+
+    # each file carries exactly its merge-state finding
+    kinds: dict[str, set[str]] = {}
+    for issue in wiki.lint():
+        kinds.setdefault(issue.fields['path'], set()).add(issue.kind)
+    assert kinds['core/design.md'] == {'conflict_markers'}
+    assert kinds['core/_index.md'] == {'merge_hint'}
+
+
+def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
+    """A desc cut short by a ``' #'`` comment fails the period check with the cause named.
+
+    A YAML reader stops a plain value at ``' #'``, so the parent row and
+    the period check see only the text before it; the message says so
+    instead of leaving the author to guess, while a comment after a
+    complete sentence draws nothing.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['cut', 'commented']})
+    (tmp_path / 'core' / 'cut.md').write_text(
+        '---\nname: core/cut\ndesc: Notes on issue #3 and the fix.\n---\n\n'
+        '# cut\n\nBody.\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'core' / 'commented.md').write_text(
+        '---\nname: core/commented\ndesc: Short summary.  # TODO expand\n---\n\n'
+        '# commented\n\nBody.\n',
+        encoding='utf-8',
+    )
+    wiki.update()
+
+    # the truncated desc is named with its cause; the intentional comment is silent
+    issues = [issue for issue in wiki.lint() if issue.kind == 'missing_period']
+    assert [issue.fields['path'] for issue in issues] == ['core/cut.md']
+    assert "Missing period in desc (the text after ' #' is a YAML comment" in issues[0]
+    index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    assert '[[core/cut|cut]]: Notes on issue\n' in index
+    assert '[[core/commented|commented]]: Short summary.\n' in index
 
 
 # ------ wrap mangles

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -14,9 +14,7 @@ import re
 import shutil
 
 import pytest
-import yaml
 
-from wiki.core import format
 from wiki.core.wiki import Issue, Wiki
 from wiki.util import markdown
 
@@ -57,7 +55,11 @@ __all__ = [
     'test_lint_future_stamp_is_clean',
     'test_lint_stamp_parse_follows_configured_format',
     'test_lint_flags_frontmatter_a_strict_yaml_reader_rejects',
+    'test_lint_flags_a_stamp_that_is_a_sequence',
+    'test_lint_flags_a_block_whose_repair_would_break_it',
+    'test_lint_flags_an_unaddressable_block_as_malformed',
     'test_lint_reports_deep_nesting_instead_of_crashing',
+    'test_lint_reports_an_escape_naming_no_character',
     'test_lint_invalid_yaml_yields_to_merge_states',
     'test_lint_names_a_comment_truncated_desc',
     'test_lint_hyphen_dangle',
@@ -935,21 +937,49 @@ def test_lint_stamp_parse_follows_configured_format(
     assert any('Unparseable created' in issue for issue in wiki.lint())
 
 
-@pytest.mark.parametrize('loader', ['c', 'pure'])
 @pytest.mark.parametrize(
-    argnames=('field', 'line', 'reason'),
+    argnames=('field', 'line', 'reason', 'advice'),
     argvalues=[
-        ('desc: Independent lane for L1: the harness.', 3, 'mapping values'),
-        ('title: Theorem for X: HR, WR', 3, 'mapping values'),
-        ('desc: Ends with a colon:', 3, 'mapping values'),
-        ('desc: One.\ndesc: Two.', 4, 'duplicate key'),
-        ('desc: Position and\x0c routes.', 3, 'characters are not allowed'),
+        (
+            'desc: Independent lane for L1: the harness.',
+            3,
+            'mapping values',
+            'quote or rewrite the value',
+        ),
+        (
+            'title: Theorem for X: HR, WR',
+            3,
+            'mapping values',
+            'quote or rewrite the value',
+        ),
+        ('desc: Ends with a colon:', 3, 'mapping values', 'quote or rewrite the value'),
+        ('desc: One.\ndesc: Two.', 4, 'duplicate key', 'the wiki reads the first'),
+        (
+            'desc: Position and\x0c routes.',
+            3,
+            'characters are not allowed',
+            'quote or rewrite the value',
+        ),
         (
             'desc: caf\xe9 caf\xe9 caf\xe9.\ncategory: bad\x0c',
             4,
             'characters are not allowed',
+            'quote or rewrite the value',
         ),
-        ('? [a, b]\n: x', 3, 'not a scalar'),
+        ('? [a, b]\n: x', 3, 'not a scalar', 'line grammar alone'),
+        ('desc: "a\x85b"\ndesc: Two.', 4, 'duplicate key', 'the wiki reads the first'),
+        (
+            'desc: "unterminated\ntags: []',
+            3,
+            'end of stream',
+            'quote or rewrite the value',
+        ),
+        (
+            'stray\ndesc: A.',
+            3,
+            "could not find expected ':'",
+            'quote or rewrite the value',
+        ),
     ],
     ids=[
         'colon-space-desc',
@@ -959,31 +989,32 @@ def test_lint_stamp_parse_follows_configured_format(
         'control-char',
         'control-char-after-non-ascii',
         'complex-key',
+        'nel-before-the-error',
+        'unterminated-quote',
+        'stray-line',
     ],
 )
+@pytest.mark.usefixtures('_loader')
 def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
     tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
     field: str,
     line: int,
     reason: str,
-    loader: str,
+    advice: str,
 ) -> None:
     """A block the wiki reads leniently but a strict YAML reader refuses is an issue.
 
     The wiki reads an unquoted ``: `` value as the authored text through
     the line grammar, but a strict reader (Obsidian's) drops the whole
     block; lint names the file and line as a hard issue typed for
-    ``--json``, under the C loader and the pure-Python loader alike, and
-    update leaves the authored bytes alone (the fix is the author's). A
-    forbidden character after accented text still lands on its own line:
-    the C loader counts stream positions in bytes, the pure loader in
-    characters, and the finding locates the character itself.
+    ``--json`` with the remedy for its cause, under the C loader and the
+    pure-Python loader alike, and update leaves the authored bytes alone
+    (the fix is the author's). The line is the offending one whatever
+    precedes it: a forbidden character after accented text (the C loader
+    counts stream positions in bytes), an error after a NEL the parser
+    counts as a line break, an unterminated quote or a stray line the
+    parser only notices further on.
     """
-    if loader == 'pure':
-        # the memo is keyed by block text alone, so the pure loader must recompose
-        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
-        format._compose_fields.cache_clear()
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
     page = tmp_path / 'core' / 'design.md'
     desc = '' if field.startswith('desc:') else 'desc: A page.\n'
@@ -994,31 +1025,116 @@ def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
         encoding='utf-8',
     )
 
-    # the finding names the line; the block is otherwise read leniently
+    # the finding names the line and the remedy; the block is otherwise read leniently
     issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
     assert [issue.fields['path'] for issue in issues] == ['core/design.md']
     assert issues[0].fields['line'] == line
     assert reason in issues[0].fields['reason']
     assert f'core/design.md: Invalid YAML frontmatter (line {line})' in issues[0]
+    assert advice in issues[0]
     # update never rewrites an authored value: the field lines stay as typed
     wiki.update()
     assert field in page.read_text(encoding='utf-8').split('---\n')[1]
     assert any(issue.kind == 'invalid_yaml' for issue in Wiki(tmp_path).lint())
 
 
-def test_lint_reports_deep_nesting_instead_of_crashing(
+@pytest.mark.parametrize(
+    argnames=('stamp', 'value'),
+    argvalues=[
+        ('created:\n- 2025-01-01', '- 2025-01-01'),
+        ('created: [2025-01-01]', '[2025-01-01]'),
+        ('created: {a: b}', '{a: b}'),
+        ('created: []', '[]'),
+    ],
+    ids=['block-sequence', 'flow-sequence', 'flow-mapping', 'empty-sequence'],
+)
+def test_lint_flags_a_stamp_that_is_a_sequence(
     tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
+    stamp: str,
+    value: str,
 ) -> None:
-    """Nesting past the pure loader's recursion limit is an issue, never an abort.
+    """A ``created:`` over a sequence or mapping is an unparseable stamp, not an absent one.
+
+    The reader resolves no collection, so the key would otherwise read as
+    missing and neither update (which fills only a valueless key) nor
+    lint would say a word about a stamp no format parses -- whether the
+    collection sits under the key or on its line.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: core/design\ndesc: A page.\n{stamp}\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+    wiki.update()
+
+    # the collection is named as the unparseable stamp it is
+    issues = [issue for issue in wiki.lint() if issue.kind == 'unparseable_stamp']
+    assert [issue.fields['field'] for issue in issues] == ['created']
+    assert issues[0].fields['value'] == value
+
+
+def test_lint_flags_a_block_whose_repair_would_break_it(tmp_path: pathlib.Path) -> None:
+    """A block update refuses to repair is a malformed-frontmatter issue, not a silent stall.
+
+    Refreshing an anchored ``name:`` would strand the alias of it; update
+    keeps the page as written with a notice on every run, and lint names
+    the same refusal so the stale name is never a surprise.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    authored = (
+        '---\nname: &n wrong\ndesc: A page.\ntitle: *n\n---\n\n# design\n\nBody.\n'
+    )
+    page.write_text(authored, encoding='utf-8')
+
+    # update keeps the page and lint names the refusal
+    wiki.update()
+    assert page.read_text(encoding='utf-8') == authored
+    issues = [
+        issue
+        for issue in Wiki(tmp_path).lint()
+        if issue.kind == 'malformed_frontmatter'
+    ]
+    assert [str(issue) for issue in issues] == [
+        'core/design.md: Malformed frontmatter (its repair would break the YAML)'
+    ]
+
+
+def test_lint_flags_an_unaddressable_block_as_malformed(tmp_path: pathlib.Path) -> None:
+    """A mapping with no column-0 key lines is malformed frontmatter to lint, page or index.
+
+    A collection-valued stamp inside such a mapping is the same finding,
+    never a crash of the whole run.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    (tmp_path / 'core' / 'design.md').write_text(
+        '---\n{name: x, desc: Flow.}\n---\n\n# design\n\nBody.\n', encoding='utf-8'
+    )
+    (tmp_path / 'core' / '_index.md').write_text(
+        '---\n  created: []\n  name: core\n  desc: Indented.\n---\n\n# core\n\n***\n\nProse.\n',
+        encoding='utf-8',
+    )
+
+    # both files carry the malformed-frontmatter issue with the reason
+    issues = [issue for issue in wiki.lint() if issue.kind == 'malformed_frontmatter']
+    assert sorted(issue.fields['path'] for issue in issues) == [
+        'core/_index.md',
+        'core/design.md',
+    ]
+    assert all('keys are not column-0 key: value lines' in issue for issue in issues)
+
+
+@pytest.mark.usefixtures('_loader')
+def test_lint_reports_deep_nesting_instead_of_crashing(tmp_path: pathlib.Path) -> None:
+    """Nesting past the composer's bound is an issue, never an abort or a crash.
 
     The pure-Python loader recurses once per nesting level and raises
-    ``RecursionError`` -- not a YAML error -- on a deeply nested flow
-    collection; lint must report the block, not lose the whole sweep to
-    the exception.
+    ``RecursionError`` -- not a YAML error -- a few hundred levels down,
+    and the C loader recurses unchecked into the C stack; the bound
+    refuses the block before either, so lint reports it the same way
+    under both loaders and the sweep goes on.
     """
-    monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
-    format._compose_fields.cache_clear()
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
     page = tmp_path / 'core' / 'design.md'
     nested = '[' * 2000 + ']' * 2000
@@ -1031,8 +1147,41 @@ def test_lint_reports_deep_nesting_instead_of_crashing(
     # the sweep completes with the block named as invalid, and update converges
     issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
     assert [issue.fields['path'] for issue in issues] == ['core/design.md']
-    assert issues[0].fields['reason'] == 'RecursionError'
+    assert issues[0].fields['reason'] == 'collections nested deeper than 100 levels'
+    assert issues[0].fields['line'] == 4
     wiki.update()
+    assert Wiki(tmp_path).update() == []
+
+
+@pytest.mark.usefixtures('_loader')
+@pytest.mark.parametrize(
+    argnames='escape',
+    argvalues=['\\U00110000', '\\uD800'],
+    ids=['past-unicode', 'surrogate'],
+)
+def test_lint_reports_an_escape_naming_no_character(
+    tmp_path: pathlib.Path, escape: str
+) -> None:
+    """A double-quoted escape naming no character is an issue, never a crash, under either loader.
+
+    The C loader rejects it as an invalid escape; the pure loader decodes
+    it into text no writer can emit (or raises from ``chr``), which the
+    reader turns into the same finding, so ``update`` completes and the
+    value reads verbatim through the line grammar.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: core/design\ndesc: "a{escape}b."\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the sweep completes, the block is named, and the parent row reads the escape as text
+    wiki.update()
+    issues = [issue for issue in Wiki(tmp_path).lint() if issue.kind == 'invalid_yaml']
+    assert [issue.fields['path'] for issue in issues] == ['core/design.md']
+    index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    assert f'[[core/design|design]]: a{escape}b.' in index
     assert Wiki(tmp_path).update() == []
 
 
@@ -1081,10 +1230,25 @@ def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
     instead of leaving the author to guess, while a comment after a
     complete sentence draws nothing.
     """
-    wiki = _make_wiki(tmp_path, folders={'core': ['cut', 'commented', 'header']})
+    pages = ['cut', 'bare', 'commented', 'header', 'fallback', 'quoted', 'under']
+    wiki = _make_wiki(tmp_path, folders={'core': pages})
+    (tmp_path / 'core' / 'quoted.md').write_text(
+        "---\nname: core/quoted\ndesc: 'Notes on room #12'\n---\n\n# quoted\n\nBody.\n",
+        encoding='utf-8',
+    )
+    (tmp_path / 'core' / 'under.md').write_text(
+        '---\nname: core/under\ndesc: Notes\n  # a comment line under the value\n---\n\n'
+        '# under\n\nBody.\n',
+        encoding='utf-8',
+    )
     (tmp_path / 'core' / 'cut.md').write_text(
         '---\nname: core/cut\ndesc: Notes on room #12 and the key.\n---\n\n'
         '# cut\n\nBody.\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'core' / 'bare.md').write_text(
+        '---\nname: core/bare\ndesc:\n  Notes on room #12 and the key.\n---\n\n'
+        '# bare\n\nBody.\n',
         encoding='utf-8',
     )
     (tmp_path / 'core' / 'commented.md').write_text(
@@ -1097,18 +1261,37 @@ def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
         '# header\n\nBody.\n',
         encoding='utf-8',
     )
+    (tmp_path / 'core' / 'fallback.md').write_text(
+        '---\nname: core/fallback\ndesc: Notes on room #12 and the key.\nzz: A: b\n---\n\n'
+        '# fallback\n\nBody.\n',
+        encoding='utf-8',
+    )
     wiki.update()
 
-    # the truncated desc is named with its cause; the intentional comment is
-    # silent; a block header's comment truncates nothing, so no hint
+    # a truncated desc is named with its cause, on the key line or a
+    # continuation line; the intentional comment is silent; a block header's
+    # comment truncates nothing; a block the parser rejects reads through the
+    # line grammar, where the hint would explain nothing
     issues = {
         issue.fields['path']: issue
         for issue in wiki.lint()
         if issue.kind == 'missing_period'
     }
-    assert sorted(issues) == ['core/cut.md', 'core/header.md']
-    assert "(the text after ' #' is a YAML comment" in issues['core/cut.md']
-    assert issues['core/header.md'] == 'core/header.md: Missing period in desc'
+    hint = "(the text after ' #' is a YAML comment"
+    assert sorted(issues) == [
+        'core/bare.md',
+        'core/cut.md',
+        'core/fallback.md',
+        'core/header.md',
+        'core/quoted.md',
+        'core/under.md',
+    ]
+    assert hint in issues['core/cut.md']
+    assert hint in issues['core/bare.md']
+    # a quoted value, a comment line under the value, a block header's
+    # comment, and a block the parser rejects lost nothing to a comment
+    for page in ('header', 'fallback', 'quoted', 'under'):
+        assert issues[f'core/{page}.md'] == f'core/{page}.md: Missing period in desc'
     index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
     assert '[[core/cut|cut]]: Notes on room\n' in index
     assert '[[core/commented|commented]]: Short summary.\n' in index

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -56,6 +56,7 @@ __all__ = [
     'test_lint_future_stamp_is_clean',
     'test_lint_stamp_parse_follows_configured_format',
     'test_lint_flags_frontmatter_a_strict_yaml_reader_rejects',
+    'test_lint_locates_a_forbidden_character_after_non_ascii_text',
     'test_lint_reports_deep_nesting_instead_of_crashing',
     'test_lint_invalid_yaml_yields_to_merge_states',
     'test_lint_names_a_comment_truncated_desc',
@@ -994,6 +995,35 @@ def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
     assert any(issue.kind == 'invalid_yaml' for issue in Wiki(tmp_path).lint())
 
 
+@pytest.mark.parametrize('loader', ['c', 'pure'])
+def test_lint_locates_a_forbidden_character_after_non_ascii_text(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    loader: str,
+) -> None:
+    """A forbidden character is reported on its own line, whatever precedes it.
+
+    The C loader counts stream positions in bytes and the pure loader in
+    characters; the finding must still land on the line that holds the
+    character, after accented text, under both loaders.
+    """
+    if loader == 'pure':
+        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    accented = 'caf' + chr(0xE9)
+    page.write_text(
+        f'---\nname: core/design\ndesc: {accented} {accented} {accented}.\n'
+        f'category: bad{chr(12)}\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the finding names line 4, the line that holds the character
+    issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
+    assert [issue.fields['line'] for issue in issues] == [4]
+    assert 'characters are not allowed' in issues[0].fields['reason']
+
+
 def test_lint_reports_deep_nesting_instead_of_crashing(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1067,7 +1097,7 @@ def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
     instead of leaving the author to guess, while a comment after a
     complete sentence draws nothing.
     """
-    wiki = _make_wiki(tmp_path, folders={'core': ['cut', 'commented']})
+    wiki = _make_wiki(tmp_path, folders={'core': ['cut', 'commented', 'header']})
     (tmp_path / 'core' / 'cut.md').write_text(
         '---\nname: core/cut\ndesc: Notes on issue #3 and the fix.\n---\n\n'
         '# cut\n\nBody.\n',
@@ -1078,12 +1108,23 @@ def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
         '# commented\n\nBody.\n',
         encoding='utf-8',
     )
+    (tmp_path / 'core' / 'header.md').write_text(
+        '---\nname: core/header\ndesc: | # note\n  No period here\n---\n\n'
+        '# header\n\nBody.\n',
+        encoding='utf-8',
+    )
     wiki.update()
 
-    # the truncated desc is named with its cause; the intentional comment is silent
-    issues = [issue for issue in wiki.lint() if issue.kind == 'missing_period']
-    assert [issue.fields['path'] for issue in issues] == ['core/cut.md']
-    assert "Missing period in desc (the text after ' #' is a YAML comment" in issues[0]
+    # the truncated desc is named with its cause; the intentional comment is
+    # silent; a block header's comment truncates nothing, so no hint
+    issues = {
+        issue.fields['path']: issue
+        for issue in wiki.lint()
+        if issue.kind == 'missing_period'
+    }
+    assert sorted(issues) == ['core/cut.md', 'core/header.md']
+    assert "(the text after ' #' is a YAML comment" in issues['core/cut.md']
+    assert issues['core/header.md'] == 'core/header.md: Missing period in desc'
     index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
     assert '[[core/cut|cut]]: Notes on issue\n' in index
     assert '[[core/commented|commented]]: Short summary.\n' in index

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -995,7 +995,7 @@ def test_lint_stamp_parse_follows_configured_format(
         'stray-line',
     ],
 )
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
     tmp_path: pathlib.Path,
     field: str,
@@ -1126,7 +1126,7 @@ def test_lint_flags_an_unaddressable_block_as_malformed(tmp_path: pathlib.Path) 
     assert all('keys are not column-0 key: value lines' in issue for issue in issues)
 
 
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 def test_lint_reports_deep_nesting_instead_of_crashing(tmp_path: pathlib.Path) -> None:
     """Nesting past the composer's bound is an issue, never an abort or a crash.
 
@@ -1155,7 +1155,7 @@ def test_lint_reports_deep_nesting_instead_of_crashing(tmp_path: pathlib.Path) -
     assert Wiki(tmp_path).update() == []
 
 
-@pytest.mark.usefixtures('_loader')
+@pytest.mark.usefixtures('_vary_loader')
 @pytest.mark.parametrize(
     argnames='escape',
     argvalues=['\\U00110000', '\\uD800'],

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -16,6 +16,7 @@ import shutil
 import pytest
 import yaml
 
+from wiki.core import format
 from wiki.core.wiki import Issue, Wiki
 from wiki.util import markdown
 
@@ -56,7 +57,6 @@ __all__ = [
     'test_lint_future_stamp_is_clean',
     'test_lint_stamp_parse_follows_configured_format',
     'test_lint_flags_frontmatter_a_strict_yaml_reader_rejects',
-    'test_lint_locates_a_forbidden_character_after_non_ascii_text',
     'test_lint_reports_deep_nesting_instead_of_crashing',
     'test_lint_invalid_yaml_yields_to_merge_states',
     'test_lint_names_a_comment_truncated_desc',
@@ -944,6 +944,11 @@ def test_lint_stamp_parse_follows_configured_format(
         ('desc: Ends with a colon:', 3, 'mapping values'),
         ('desc: One.\ndesc: Two.', 4, 'duplicate key'),
         ('desc: Position and\x0c routes.', 3, 'characters are not allowed'),
+        (
+            'desc: caf\xe9 caf\xe9 caf\xe9.\ncategory: bad\x0c',
+            4,
+            'characters are not allowed',
+        ),
         ('? [a, b]\n: x', 3, 'not a scalar'),
     ],
     ids=[
@@ -952,6 +957,7 @@ def test_lint_stamp_parse_follows_configured_format(
         'trailing-colon',
         'duplicate-key',
         'control-char',
+        'control-char-after-non-ascii',
         'complex-key',
     ],
 )
@@ -969,10 +975,15 @@ def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
     the line grammar, but a strict reader (Obsidian's) drops the whole
     block; lint names the file and line as a hard issue typed for
     ``--json``, under the C loader and the pure-Python loader alike, and
-    update leaves the authored bytes alone (the fix is the author's).
+    update leaves the authored bytes alone (the fix is the author's). A
+    forbidden character after accented text still lands on its own line:
+    the C loader counts stream positions in bytes, the pure loader in
+    characters, and the finding locates the character itself.
     """
     if loader == 'pure':
+        # the memo is keyed by block text alone, so the pure loader must recompose
         monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+        format._compose_fields.cache_clear()
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
     page = tmp_path / 'core' / 'design.md'
     desc = '' if field.startswith('desc:') else 'desc: A page.\n'
@@ -995,35 +1006,6 @@ def test_lint_flags_frontmatter_a_strict_yaml_reader_rejects(
     assert any(issue.kind == 'invalid_yaml' for issue in Wiki(tmp_path).lint())
 
 
-@pytest.mark.parametrize('loader', ['c', 'pure'])
-def test_lint_locates_a_forbidden_character_after_non_ascii_text(
-    tmp_path: pathlib.Path,
-    monkeypatch: pytest.MonkeyPatch,
-    loader: str,
-) -> None:
-    """A forbidden character is reported on its own line, whatever precedes it.
-
-    The C loader counts stream positions in bytes and the pure loader in
-    characters; the finding must still land on the line that holds the
-    character, after accented text, under both loaders.
-    """
-    if loader == 'pure':
-        monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
-    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
-    page = tmp_path / 'core' / 'design.md'
-    accented = 'caf' + chr(0xE9)
-    page.write_text(
-        f'---\nname: core/design\ndesc: {accented} {accented} {accented}.\n'
-        f'category: bad{chr(12)}\n---\n\n# design\n\nBody.\n',
-        encoding='utf-8',
-    )
-
-    # the finding names line 4, the line that holds the character
-    issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
-    assert [issue.fields['line'] for issue in issues] == [4]
-    assert 'characters are not allowed' in issues[0].fields['reason']
-
-
 def test_lint_reports_deep_nesting_instead_of_crashing(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1036,6 +1018,7 @@ def test_lint_reports_deep_nesting_instead_of_crashing(
     the exception.
     """
     monkeypatch.delattr(yaml, 'CSafeLoader', raising=False)
+    format._compose_fields.cache_clear()
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
     page = tmp_path / 'core' / 'design.md'
     nested = '[' * 2000 + ']' * 2000
@@ -1045,11 +1028,12 @@ def test_lint_reports_deep_nesting_instead_of_crashing(
         encoding='utf-8',
     )
 
-    # the sweep completes with the block named as invalid
+    # the sweep completes with the block named as invalid, and update converges
     issues = [issue for issue in wiki.lint() if issue.kind == 'invalid_yaml']
     assert [issue.fields['path'] for issue in issues] == ['core/design.md']
     assert issues[0].fields['reason'] == 'RecursionError'
-    assert wiki.update() is not None
+    wiki.update()
+    assert Wiki(tmp_path).update() == []
 
 
 def test_lint_invalid_yaml_yields_to_merge_states(tmp_path: pathlib.Path) -> None:
@@ -1099,7 +1083,7 @@ def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
     """
     wiki = _make_wiki(tmp_path, folders={'core': ['cut', 'commented', 'header']})
     (tmp_path / 'core' / 'cut.md').write_text(
-        '---\nname: core/cut\ndesc: Notes on issue #3 and the fix.\n---\n\n'
+        '---\nname: core/cut\ndesc: Notes on room #12 and the key.\n---\n\n'
         '# cut\n\nBody.\n',
         encoding='utf-8',
     )
@@ -1126,7 +1110,7 @@ def test_lint_names_a_comment_truncated_desc(tmp_path: pathlib.Path) -> None:
     assert "(the text after ' #' is a YAML comment" in issues['core/cut.md']
     assert issues['core/header.md'] == 'core/header.md: Missing period in desc'
     index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
-    assert '[[core/cut|cut]]: Notes on issue\n' in index
+    assert '[[core/cut|cut]]: Notes on room\n' in index
     assert '[[core/commented|commented]]: Short summary.\n' in index
 
 

--- a/tests/test_core/test_match.py
+++ b/tests/test_core/test_match.py
@@ -67,7 +67,7 @@ def test_match_field_matches_value_only(tmp_path: pathlib.Path) -> None:
         '---\nname: note: draft\ndesc: d\n---\n\n# note: draft\n\nBody.\n',
         encoding='utf-8',
     )
-    # a custom key may carry a hyphen (the field grammar is [\w-]+)
+    # a custom key may carry a hyphen (the field grammar is [\w.-]+)
     (tmp_path / 'core' / 'tracked.md').write_text(
         '---\nname: tracked\ndesc: d\nreview-status: approved\n---\n\n# t\n\nBody.\n',
         encoding='utf-8',

--- a/tests/test_core/test_match.py
+++ b/tests/test_core/test_match.py
@@ -72,6 +72,11 @@ def test_match_field_matches_value_only(tmp_path: pathlib.Path) -> None:
         '---\nname: tracked\ndesc: d\nreview-status: approved\n---\n\n# t\n\nBody.\n',
         encoding='utf-8',
     )
+    # a key outside the grammar is still stripped when it opens the matched field
+    (tmp_path / 'core' / 'spaced.md').write_text(
+        '---\nname: spaced\ndesc: d\nmy key: inner space value\n---\n\n# s\n\nBody.\n',
+        encoding='utf-8',
+    )
     # a dotted key is a field of its own and ends its neighbor
     (tmp_path / 'core' / 'foreign.md').write_text(
         '---\nname: foreign\ndesc: d\ncom.example: |\n  needle body\n---\n'
@@ -82,6 +87,17 @@ def test_match_field_matches_value_only(tmp_path: pathlib.Path) -> None:
     (tmp_path / 'core' / 'cited.md').write_text(
         '---\nname: cited\ndesc: d\nsources:\n- https://doi.org/10.1/x\n---\n'
         '\n# c\n\nBody.\n',
+        encoding='utf-8',
+    )
+    # ... under the line grammar too, when a neighbor line spoils the block
+    (tmp_path / 'core' / 'typo.md').write_text(
+        '---\nname: typo\ndesc: A: b\nsources:\n- https://doi.org/10.1/y\n---\n'
+        '\n# t\n\nBody.\n',
+        encoding='utf-8',
+    )
+    # a quoted scalar's continuation line is value text, however key-shaped
+    (tmp_path / 'core' / 'quoted.md').write_text(
+        '---\nname: quoted\ndesc: "one\ntwo: three"\n---\n\n# q\n\nBody.\n',
         encoding='utf-8',
     )
     wiki.update()
@@ -108,7 +124,19 @@ def test_match_field_matches_value_only(tmp_path: pathlib.Path) -> None:
     assert wiki.match('needle', field='desc') == []
     # a URL item at column 0 is part of its sequence field, colon and all
     hits = wiki.match('doi.org', field='sources')
-    assert [relpath for relpath, _, _ in hits] == ['core/cited.md']
+    assert [relpath for relpath, _, _ in hits] == ['core/cited.md', 'core/typo.md']
+    # a key spelled with a space is stripped from its line like any other
+    hits = wiki.match('^inner', field='my key')
+    assert [relpath for relpath, _, _ in hits] == ['core/spaced.md']
+    assert wiki.match('my key', field='my key') == []
+    # a quoted desc continued below matches from its first character on both
+    # lines: the opening quote is not value text, and neither is a key shape
+    # on the continuation line
+    hits = wiki.match('^one', field='desc')
+    assert [relpath for relpath, _, _ in hits] == ['core/quoted.md']
+    hits = wiki.match('^two', field='desc')
+    assert [relpath for relpath, _, _ in hits] == ['core/quoted.md']
+    assert wiki.match('^three', field='desc') == []
 
 
 def test_all_files_matches_non_markdown_whole(tmp_path: pathlib.Path) -> None:

--- a/tests/test_core/test_match.py
+++ b/tests/test_core/test_match.py
@@ -72,10 +72,16 @@ def test_match_field_matches_value_only(tmp_path: pathlib.Path) -> None:
         '---\nname: tracked\ndesc: d\nreview-status: approved\n---\n\n# t\n\nBody.\n',
         encoding='utf-8',
     )
-    # a dotted key sits outside the field grammar but still ends its neighbor
+    # a dotted key is a field of its own and ends its neighbor
     (tmp_path / 'core' / 'foreign.md').write_text(
         '---\nname: foreign\ndesc: d\ncom.example: |\n  needle body\n---\n'
         '\n# f\n\nBody.\n',
+        encoding='utf-8',
+    )
+    # a column-0 sequence item holding a colon belongs to its field
+    (tmp_path / 'core' / 'cited.md').write_text(
+        '---\nname: cited\ndesc: d\nsources:\n- https://doi.org/10.1/x\n---\n'
+        '\n# c\n\nBody.\n',
         encoding='utf-8',
     )
     wiki.update()
@@ -100,6 +106,9 @@ def test_match_field_matches_value_only(tmp_path: pathlib.Path) -> None:
     # a dotted key's line and block body never attribute to the field
     # before it: field-scoped search must not hit foreign-key content
     assert wiki.match('needle', field='desc') == []
+    # a URL item at column 0 is part of its sequence field, colon and all
+    hits = wiki.match('doi.org', field='sources')
+    assert [relpath for relpath, _, _ in hits] == ['core/cited.md']
 
 
 def test_all_files_matches_non_markdown_whole(tmp_path: pathlib.Path) -> None:

--- a/tests/test_core/test_plan.py
+++ b/tests/test_core/test_plan.py
@@ -268,16 +268,16 @@ def test_update_survives_page_deleted_mid_page_pass(
             doomed.unlink()
         return real(self, path, now, **kwargs)
 
-    # the mid-pass deletion is handled, not crashed on
+    # the mid-pass deletion is handled, not crashed on, and the vanished
+    # page's row is pruned with the ordinary notice -- in this run, since the
+    # indexes plan after the pages, and never again
     monkeypatch.setattr(Wiki, '_plan_page', racy)
-    wiki.update()
-
-    # the next run prunes the vanished page's row with the ordinary notice
     notices = _capture_notices(wiki)
     wiki.update()
     err = '\n'.join(event.description for event in notices)
     assert 'Pruned link' in err
     assert 'doomed' in err
+    assert Wiki(tmp_path).update() == []
 
 
 def test_update_survives_page_deleted_mid_read(
@@ -301,16 +301,15 @@ def test_update_survives_page_deleted_mid_read(
             doomed.unlink()
         return real(self, path)
 
-    # the mid-read deletion is handled, not crashed on
+    # the mid-read deletion is handled, not crashed on, and the vanished
+    # page's row is pruned with the ordinary notice in this run
     monkeypatch.setattr(Wiki, '_read_text', racy)
-    wiki.update()
-
-    # the next run prunes the vanished page's row with the ordinary notice
     notices = _capture_notices(wiki)
     wiki.update()
     err = '\n'.join(event.description for event in notices)
     assert 'Pruned link' in err
     assert 'doomed' in err
+    assert Wiki(tmp_path).update() == []
 
 
 def test_update_survives_folder_deleted_mid_walk(

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -937,11 +937,12 @@ def test_update_keeps_over_indented_block_body_whitespace(
 
 
 def test_update_keeps_exotic_key_block_body_blanks(tmp_path: pathlib.Path) -> None:
-    """A block body under a key outside the schema grammar keeps its blanks.
+    """A block body under a key outside the schema keeps its blanks and its slot.
 
     Frontmatter is user-extensible, so the block-body detection is not
-    gated on the schema's field-name grammar -- a dotted or otherwise
-    exotic key opening a block scalar arms the same body handling.
+    gated on the schema's field names -- a dotted or otherwise exotic key
+    opening a block scalar arms the same body handling -- and the key
+    sorts as a custom field, below the known fields.
     """
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
 
@@ -953,10 +954,10 @@ def test_update_keeps_exotic_key_block_body_blanks(tmp_path: pathlib.Path) -> No
         encoding='utf-8',
     )
 
-    # the custom block body keeps its paragraph break
+    # the custom block body keeps its paragraph break, below the known fields
     wiki.update()
     updated = page.read_text(encoding='utf-8')
-    assert 'com.example: |\n  One.\n\n  Two.\ntags: []\n' in updated
+    assert 'tags: []\ncom.example: |\n  One.\n\n  Two.\ncreated:' in updated
     assert Wiki(tmp_path).update() == []
 
 

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -28,6 +28,7 @@ from ._helpers import (
     _make_wiki,
     page_index,
 )
+from ._oracle import field_lines, grammar
 
 __all__ = [
     'test_update_full_workflow',
@@ -63,6 +64,7 @@ __all__ = [
     'test_update_preserves_authored_yaml_values',
     'test_update_refreshes_any_name_shape_to_the_path',
     'test_update_folds_and_preserves_inline_desc',
+    'test_update_propagates_every_multi_line_desc_shape',
     'test_update_preserves_prose_above_delimiter',
     'test_update_preserves_prose_below_delimiter_above_h1',
     'test_update_broken_links',
@@ -75,15 +77,18 @@ __all__ = [
     'test_update_rewrapped_desc_converges_quietly',
     'test_update_blank_line_in_desc_row_converges_quietly',
     'test_update_converges_on_wrap_mangled_desc',
+    'test_update_converges_on_every_grammar_shape',
     'test_update_scoped',
     'test_reclaimed_index_keeps_link_shaped_continuation',
     'test_body_edits_never_dirty_the_tree',
     'test_update_fills_blank_frontmatter_values',
+    'test_update_keeps_a_bare_key_stamp_body',
     'test_update_inserts_timestamps_in_canonical_order',
     'test_update_inserts_desc_in_schema_order',
     'test_update_enforces_canonical_field_order',
     'test_read_frontmatter_category',
     'test_quoted_desc_propagates_and_lints_clean',
+    'test_update_reads_category_and_title_per_yaml',
     'test_update_category_labels',
     'test_category_propagates_and_clears',
     'test_sort_unlisted_category',
@@ -741,20 +746,28 @@ def test_update_drops_block_scalar_name_body(tmp_path: pathlib.Path) -> None:
     assert Wiki(tmp_path).update() == []
 
 
-def test_update_keeps_a_comment_under_name(tmp_path: pathlib.Path) -> None:
-    """An indented ``# comment`` under a one-line ``name:`` survives the refresh.
+@pytest.mark.parametrize(
+    argnames='field',
+    argvalues=[
+        'name: core/design\n  # named for the design doc',
+        'name:\n  core/design\n  # named for the design doc',
+    ],
+    ids=['plain-value', 'bare-key-body'],
+)
+def test_update_keeps_a_comment_under_name(tmp_path: pathlib.Path, field: str) -> None:
+    """An indented ``# comment`` under ``name:`` survives the refresh.
 
-    Under a plain value an indented hash line is a YAML comment, not a
-    continuation -- the refresh consumes value lines and blanks only, so
-    an authored annotation is neither folded into the name nor deleted.
+    Under a plain value -- on the key line or as a bare key's indented
+    body -- an indented hash line is a YAML comment, not a continuation:
+    the refresh consumes value lines and blanks only, so an authored
+    annotation is neither folded into the name nor deleted.
     """
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
 
     # author a child page annotating its (already canonical) name
     page = tmp_path / 'core' / 'design.md'
     page.write_text(
-        '---\nname: core/design\n  # named for the design doc\ndesc: A page.\n'
-        '---\n\n# design\n\nBody.\n',
+        f'---\n{field}\ndesc: A page.\n---\n\n# design\n\nBody.\n',
         encoding='utf-8',
     )
 
@@ -1147,6 +1160,56 @@ def test_update_folds_and_preserves_inline_desc(tmp_path: pathlib.Path) -> None:
     assert 'inline summary here.' in core_index
 
 
+@pytest.mark.parametrize(
+    argnames='shape',
+    argvalues=[
+        'desc: Explains the first half.\n  And the second half.',
+        "desc: 'Explains the first half.\n  And the second half.'",
+        'desc: "Explains the first half.\n  And the second half."',
+        'desc:\n  Explains the first half.\n  And the second half.\n  # authored note',
+        'desc:  \n  Explains the first half.\n  And the second half.',
+        'desc: |\n  Explains the first half.\n  And the second half.',
+    ],
+    ids=[
+        'inline-continuation',
+        'single-quoted-spanning',
+        'double-quoted-spanning',
+        'bare-key-with-comment',
+        'bare-key-trailing-spaces',
+        'literal-block',
+    ],
+)
+def test_update_propagates_every_multi_line_desc_shape(
+    tmp_path: pathlib.Path,
+    shape: str,
+) -> None:
+    """Every multi-line desc shape propagates its whole text to the parent row.
+
+    A plain scalar continuing below the key line, a quoted scalar spanning
+    lines, a bare key over a body (with a trailing comment or trailing
+    spaces on the key line) and a literal block all carry the same two
+    sentences; the parent row reads both, no comment text leaks into it,
+    lint is clean, and the second update is a no-op.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: core/design\n{shape}\ntags: []\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the parent row carries both sentences (one line or two) and no comment
+    wiki.update()
+    index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    rows = ' '.join(index.split('\n\n***')[0].split())
+    assert (
+        '[[core/design|design]]: Explains the first half. And the second half.' in rows
+    )
+    assert 'authored note' not in index
+    assert Wiki(tmp_path).lint() == []
+    assert Wiki(tmp_path).update() == []
+
+
 def test_update_preserves_prose_above_delimiter(tmp_path: pathlib.Path) -> None:
     """Prose placed above the '***' delimiter is preserved, not silently dropped.
 
@@ -1518,6 +1581,34 @@ def test_update_converges_on_wrap_mangled_desc(tmp_path: pathlib.Path) -> None:
     assert any(issue.startswith('core/_index.md: Hyphen dangle') for issue in issues)
 
 
+def test_update_converges_on_every_grammar_shape(tmp_path: pathlib.Path) -> None:
+    """Every grammar shape of every authored field converges in one update.
+
+    Churn as an engine property: a page whose ``name``, ``title``,
+    ``desc``, and ``category`` all take one scalar shape is repaired
+    once, the second run is a byte no-op, and lint reports no repair
+    still pending -- so no shape makes the reader and the repair disagree
+    about what the page says.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': []})
+    for shape in grammar():
+        stem = '-'.join(shape).replace('|', 'literal').replace('>', 'folded')
+        stem = stem.replace('+', 'plus')
+        lines = ['---']
+        for key in ('name', 'title', 'desc', 'category'):
+            lines.extend(field_lines(key, *shape))
+        lines.extend(['---', '', f'# {stem}', '', 'Body.', ''])
+        (tmp_path / 'core' / f'{stem}.md').write_text(
+            '\n'.join(lines), encoding='utf-8'
+        )
+
+    # one update repairs every page; the second is a no-op with nothing pending
+    wiki.update()
+    assert Wiki(tmp_path).update() == []
+    pending = {'requires_update', 'malformed_frontmatter', 'truncated_index'}
+    assert [issue for issue in Wiki(tmp_path).lint() if issue.kind in pending] == []
+
+
 def test_update_scoped(tmp_path: pathlib.Path) -> None:
     """Scoped update only modifies the specified subtree."""
     # build a populated wiki with two sibling folders
@@ -1664,6 +1755,38 @@ def test_update_fills_blank_frontmatter_values(
 
     # the fill is idempotent
     assert wiki.update() == []
+
+
+@pytest.mark.parametrize('field', ['created', 'updated'])
+def test_update_keeps_a_bare_key_stamp_body(tmp_path: pathlib.Path, field: str) -> None:
+    """A stamp continued on an indented line is a value, never a blank to stamp over.
+
+    ``created:`` over an indented stamp is a plain multi-line scalar; a
+    repair that read the bare key line as blank would stamp the run's
+    clock onto it and strand the authored stamp below, where a strict
+    reader folds both into one unparseable value. ``created:`` keeps its
+    body, and ``updated:`` -- re-stamped on every real write -- is
+    replaced as one line, body included.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    stamp = '2026-07-24T20:35:56Z'
+    page.write_text(
+        f'---\nname: core/design\ndesc: A page.\n{field}:\n  {stamp}\n---\n\n'
+        '# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the authored stamp is kept whole or replaced whole, never split
+    wiki.update()
+    frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
+    if field == 'created':
+        assert f'created:\n  {stamp}\n' in frontmatter
+    else:
+        assert re.search(r'^updated: \S+\n(?![ \t])', frontmatter, re.M)
+        assert stamp not in frontmatter
+    assert Wiki(tmp_path).lint() == []
+    assert Wiki(tmp_path).update() == []
 
 
 @pytest.mark.parametrize(
@@ -1858,6 +1981,49 @@ def test_quoted_desc_propagates_and_lints_clean(
     # the parent link line carries the desc without the quotes
     core_index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
     assert f'[[core/design|design]]: {desc}' in core_index
+
+
+@pytest.mark.parametrize(
+    argnames=('field', 'label', 'heading'),
+    argvalues=[
+        ('category: Foo\n  Bar', '[Foo Bar] design', '# core/design'),
+        ('category:  \n  Foo', '[Foo] design', '# core/design'),
+        ('title: Draft\n  heading', 'design', '# Draft heading'),
+        ('title:  \n  Draft heading', 'design', '# Draft heading'),
+    ],
+    ids=[
+        'category-continuation',
+        'category-bare-key-trailing-spaces',
+        'title-continuation',
+        'title-bare-key-trailing-spaces',
+    ],
+)
+def test_update_reads_category_and_title_per_yaml(
+    tmp_path: pathlib.Path,
+    field: str,
+    label: str,
+    heading: str,
+) -> None:
+    """A category or title continued on an indented line reads whole, per YAML.
+
+    The parent row's ``[category]`` label and the page's H1 are built
+    from the reader's value, so a continuation line read as absent, or
+    dropped, would silently mislabel the row or shorten the heading.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: core/design\ndesc: A page.\n{field}\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the label and the heading carry the whole value
+    wiki.update()
+    index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    assert f'[[core/design|{label}]]' in index
+    assert f'\n{heading}\n' in page.read_text(encoding='utf-8')
+    assert Wiki(tmp_path).lint() == []
+    assert Wiki(tmp_path).update() == []
 
 
 def test_update_category_labels(tmp_path: pathlib.Path) -> None:
@@ -2534,6 +2700,8 @@ def test_quoted_colon_title_renders_unquoted_heading(
         ('﻿# The L25 Wall\n\nBody prose.\n', 'title: The L25 Wall'),
         ('Body prose only.\n', None),
         ('﻿Body prose only.\n', None),
+        ('# TODO #123\n\nBody prose.\n', "title: 'TODO #123'"),
+        ('# [Draft] X\n\nBody prose.\n', "title: '[Draft] X'"),
     ],
     ids=[
         'h1',
@@ -2543,6 +2711,8 @@ def test_quoted_colon_title_renders_unquoted_heading(
         'bom-h1',
         'no-h1',
         'bom-no-h1',
+        'hash-h1',
+        'indicator-h1',
     ],
 )
 def test_update_adopts_bare_page_seeding_title(
@@ -2556,8 +2726,10 @@ def test_update_adopts_bare_page_seeding_title(
     the author wrote -- the seeded title wins the H1 rewrite, a heading
     reading ``null`` is seeded quoted so it survives as text, and a
     heading wrapped in quote chars is seeded re-quoted so the read does
-    not strip the authored quotes -- while a page with no H1 gains the
-    path-joined heading, title-less. A UTF-8 BOM is dropped, so it
+    not strip the authored quotes, and a heading a strict reader would
+    misread plain (a ``' #'`` comment start, a leading indicator) is
+    seeded quoted so it reads back whole -- while a page with no H1 gains
+    the path-joined heading, title-less. A UTF-8 BOM is dropped, so it
     neither hides the authored H1 nor lands mid-file under the fresh
     frontmatter.
     """

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -2056,7 +2056,7 @@ def test_update_stamps_keep_their_anchors(
         encoding='utf-8',
     )
 
-    # one update converges on a block every strict reader still accepts
+    # one update converges on a block the installed strict reader still accepts
     wiki.update()
     frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
     assert re.search(expected, frontmatter, re.M), frontmatter

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -1309,7 +1309,7 @@ def test_update_emits_every_notice(tmp_path: pathlib.Path) -> None:
         for event in notices
         if event.description.startswith('Pruned link:')
     ]
-    assert len(detailed) == 8
+    assert len(detailed) == len(pages)
 
 
 def test_update_announces_created_index(tmp_path: pathlib.Path) -> None:

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -51,6 +51,9 @@ __all__ = [
     'test_update_accepts_block_scalar_name',
     'test_update_joins_multiline_block_scalar_name',
     'test_update_drops_block_scalar_name_body',
+    'test_update_refuses_a_repair_a_quote_would_swallow',
+    'test_update_keeps_a_comment_behind_a_column_zero_bom',
+    'test_update_reads_the_block_as_the_restamp_leaves_it',
     'test_update_keeps_a_comment_under_name',
     'test_update_drops_plain_name_continuations',
     'test_update_drops_stray_frontmatter_blanks',
@@ -83,6 +86,13 @@ __all__ = [
     'test_body_edits_never_dirty_the_tree',
     'test_update_fills_blank_frontmatter_values',
     'test_update_leaves_a_non_mapping_block_untouched',
+    'test_update_leaves_an_unaddressable_block_untouched',
+    'test_update_stamps_keep_their_anchors',
+    'test_update_rows_read_the_repaired_child',
+    'test_update_converges_when_the_restamp_drops_the_only_alias',
+    'test_update_drops_a_bom_opening_the_body',
+    'test_update_converges_on_a_key_missing_its_space',
+    'test_update_restamps_with_the_stamp_comments',
     'test_update_keeps_a_bare_key_stamp_body',
     'test_update_inserts_timestamps_in_canonical_order',
     'test_update_inserts_desc_in_schema_order',
@@ -114,6 +124,7 @@ __all__ = [
     'test_quoted_colon_title_renders_unquoted_heading',
     'test_update_adopts_bare_page_seeding_title',
     'test_required_titles_seed_lint_and_flip_off',
+    'test_required_titles_converge_over_a_duplicated_name',
     'test_required_titles_adopts_no_h1_page',
     'test_update_materializes_missing_settings',
     'test_update_skips_symlinked_page',
@@ -488,7 +499,8 @@ def test_update_ignores_wikis_above_the_root(tmp_path: pathlib.Path) -> None:
     assert wiki.lint() == []
 
 
-def test_update_refuses_conflict_markers(tmp_path: pathlib.Path) -> None:
+@pytest.mark.parametrize('width', [7, 8], ids=['default-markers', 'marker-size-8'])
+def test_update_refuses_conflict_markers(tmp_path: pathlib.Path, width: int) -> None:
     """Conflict-marked files refuse the sweep before anything mutates.
 
     A half-resolved merge would otherwise ride the rewrite -- the plan
@@ -496,11 +508,12 @@ def test_update_refuses_conflict_markers(tmp_path: pathlib.Path) -> None:
     regenerated files. Update refuses, naming every marked file, and
     the dry run refuses alike rather than previewing the damage; a
     well-formed ``no-lint`` region sanctions marker-shaped lines (e.g.
-    a git tutorial).
+    a git tutorial). Markers lengthened by git's ``conflict-marker-size``
+    attribute count too.
     """
     wiki = _make_wiki(tmp_path, folders={'core': ['design', 'api']})
     # plant a real conflict in a page and an index
-    conflict = '\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n'
+    conflict = f'\n{"<" * width} HEAD\nours\n=======\ntheirs\n{">" * width} branch\n'
     marked = {}
     for rel in ('core/design.md', 'core/_index.md'):
         path = tmp_path / rel
@@ -734,16 +747,145 @@ def test_update_drops_block_scalar_name_body(tmp_path: pathlib.Path) -> None:
     # author a child page whose name uses a multi-line block scalar
     page = tmp_path / 'core' / 'design.md'
     page.write_text(
-        '---\nname: |\n  old\n  broken\ndesc: A page.\n---\n\n# design\n\nBody.\n',
+        '---\nname: |\n  old\n  # note\n  broken\ndesc: A page.\n---\n\n# design\n\nBody.\n',
         encoding='utf-8',
     )
 
-    # the path-derived name lands as a one-line scalar, body lines gone
+    # the path-derived name lands as a one-line scalar, body lines gone -- an
+    # indented hash line inside the block is body, not a comment to keep
     wiki.update()
     updated = page.read_text(encoding='utf-8')
     assert 'name: core/design\n' in updated
     assert '  old' not in updated
+    assert '# note' not in updated
     assert '  broken' not in updated
+    assert Wiki(tmp_path).update() == []
+
+
+@pytest.mark.parametrize(
+    argnames='body',
+    argvalues=[
+        'tags: "open\nname: "x\ncustom: y"',
+        "category: 'open\n'name': x\ndesc: d\n'",
+        'updated: "quoted\ncontinued"\n\ntags: "open',
+    ],
+    ids=['quote-closes-around-name', 'quote-closes-around-insert', 'stamp-strands'],
+)
+def test_update_refuses_a_repair_a_quote_would_swallow(
+    tmp_path: pathlib.Path,
+    body: str,
+) -> None:
+    """A block whose repair lands inside a quote the line grammar cannot see is kept as written.
+
+    The parser rejects the block, so the line grammar refreshes the
+    ``name:`` line or stamps ``updated:`` it finds at column 0 -- inside a
+    quoted scalar left open above, which the edit then closes around the
+    written lines. The block composes with no ``name``, ``desc``, or stamp
+    key, so writing it would lose the fields and never converge; update
+    refuses it with the malformed notice, lint reports it, and every other
+    page is still repaired.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design', 'other']})
+    page = tmp_path / 'core' / 'design.md'
+    authored = f'---\n{body}\n---\n\n# design\n\nBody.\n'
+    page.write_text(authored, encoding='utf-8')
+    other = tmp_path / 'core' / 'other.md'
+    other.write_text('---\nname: stale\ndesc: Other.\n---\n\n# other\n\nBody.\n')
+
+    # the page is named and kept byte-identical; its sibling is repaired
+    notices = _capture_notices(wiki)
+    wiki.update()
+    err = '\n'.join(event.description for event in notices)
+    assert (
+        'Malformed frontmatter (its repair would break the YAML) in core/design.md'
+        in err
+    )
+    assert page.read_text(encoding='utf-8') == authored
+    assert 'name: core/other\n' in other.read_text(encoding='utf-8')
+    kinds = [
+        issue.kind
+        for issue in Wiki(tmp_path).lint()
+        if issue.fields['path'] == 'core/design.md'
+    ]
+    assert 'malformed_frontmatter' in kinds
+    assert Wiki(tmp_path).update() == []
+
+
+def test_update_keeps_a_comment_behind_a_column_zero_bom(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A BOM at column 0 goes, and the ``# comment`` it hid stays a comment.
+
+    The C loader skips a BOM at column 0 on any line, so a strict reader
+    saw a comment; the repair drops the BOM rather than take the line for
+    a value's content and delete it with the field it rewrites.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        '---\nname: stale\ndesc: A page.\n\n\ufeff# keep me\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+    wiki.update()
+    text = page.read_text(encoding='utf-8')
+    assert '\n# keep me\n' in text
+    assert '\ufeff' not in text
+    assert Wiki(tmp_path).update() == []
+
+
+@pytest.mark.parametrize(
+    argnames=('field', 'stamp', 'expected'),
+    argvalues=[
+        ('title: "Quoted\n  Title"', 'updated: "unclosed', '# Quoted Title\n'),
+        (
+            'desc: "Alpha\n  beta."',
+            'updated: [a,',
+            '[[core/design|design]]: Alpha beta.\n',
+        ),
+        (
+            'desc: !!str |\n  Folded text.',
+            'updated: "open',
+            '[[core/design|design]]: Folded text.\n',
+        ),
+        (
+            'desc: "Multi\ncategory: fake\nend."\ncategory: real',
+            'updated: "unclosed',
+            '[[core/design|[real] design]]: Multi category: fake end.\n',
+        ),
+        ('desc: Fixed desc.', 'updated: "open\n\n- item', 'Z\n- item\n---\n'),
+    ],
+    ids=[
+        'title-quoted-multiline',
+        'desc-quoted-multiline',
+        'desc-tagged-block',
+        'category-inside-quoted-desc',
+        'stamp-quote-blank-item',
+    ],
+)
+def test_update_reads_the_block_as_the_restamp_leaves_it(
+    tmp_path: pathlib.Path,
+    field: str,
+    stamp: str,
+    expected: str,
+) -> None:
+    """The H1 and the parent row read the block the write lands, so the update converges in one run.
+
+    An ``updated:`` value the parser rejects sends the block through the
+    line grammar; the re-stamp replaces that value and the block composes,
+    so a read before the re-stamp -- through a grammar that may resolve a
+    tagged block or a mid-value key line differently -- lags the write by
+    a run.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: core/design\n{field}\n{stamp}\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+    wiki.update()
+    page_text = page.read_text(encoding='utf-8')
+    index_text = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    assert expected in page_text + index_text
     assert Wiki(tmp_path).update() == []
 
 
@@ -1597,7 +1739,7 @@ def test_update_converges_on_every_grammar_shape(tmp_path: pathlib.Path) -> None
         stem = '-'.join(shape).replace('|', 'literal').replace('>', 'folded')
         stem = stem.replace('+', 'plus')
         lines = ['---']
-        for key in ('name', 'title', 'desc', 'category'):
+        for key in ('name', 'title', 'desc', 'category', 'created', 'updated'):
             lines.extend(field_lines(key, *shape))
         lines.extend(['---', '', f'# {stem}', '', 'Body.', ''])
         (tmp_path / 'core' / f'{stem}.md').write_text(
@@ -1605,9 +1747,15 @@ def test_update_converges_on_every_grammar_shape(tmp_path: pathlib.Path) -> None
         )
 
     # one update repairs every page; the second is a no-op with nothing pending
+    # and no block the tool left in a shape a strict reader rejects
     wiki.update()
     assert Wiki(tmp_path).update() == []
-    pending = {'requires_update', 'malformed_frontmatter', 'truncated_index'}
+    pending = {
+        'requires_update',
+        'malformed_frontmatter',
+        'truncated_index',
+        'invalid_yaml',
+    }
     assert [issue for issue in Wiki(tmp_path).lint() if issue.kind in pending] == []
 
 
@@ -1761,8 +1909,13 @@ def test_update_fills_blank_frontmatter_values(
 
 @pytest.mark.parametrize(
     argnames='body',
-    argvalues=['Just a sentence.', '- a\n- b', 'name:core/design'],
-    ids=['prose', 'list', 'missing-space'],
+    argvalues=[
+        'Just a sentence.',
+        '- a\n- b',
+        'name:core/design',
+        '[a,\ndesc: no period]',
+    ],
+    ids=['prose', 'list', 'missing-space', 'flow-list-with-key-text'],
 )
 def test_update_leaves_a_non_mapping_block_untouched(
     tmp_path: pathlib.Path,
@@ -1802,9 +1955,249 @@ def test_update_leaves_a_non_mapping_block_untouched(
     for issue in issues:
         assert issue.fields['line'] == 1
         assert issue.fields['reason'] == 'frontmatter is not a mapping'
+        assert 'no strict reader finds key: value pairs in it' in issue
+    # a body with no fields reads none: no other finding, no field match
+    kinds = {
+        issue.kind
+        for issue in Wiki(tmp_path).lint()
+        if 'design' in issue.fields['path']
+    }
+    assert kinds == {'invalid_yaml'}
+    assert Wiki(tmp_path).match('period', field='desc') == []
     assert Wiki(tmp_path).update() == []
     assert page.read_text(encoding='utf-8') == authored_page
     assert index.read_text(encoding='utf-8') == authored_index
+
+
+@pytest.mark.parametrize(
+    argnames=('body', 'desc'),
+    argvalues=[
+        ('{name: x, desc: Flow.}', 'Flow.'),
+        ('  name: x\n  desc: Indented.', 'Indented.'),
+        ('? name\n: x\ndesc: Explicit.', 'Explicit.'),
+        ('&k desc: Aliased.\n*k : Second.', 'Aliased.'),
+        ('desc: Merged.\n<<: {tags: []}', 'Merged.'),
+        ('desc: Broken' + chr(0x85) + 'title: T', 'Broken'),
+    ],
+    ids=[
+        'flow-mapping',
+        'indented-mapping',
+        'explicit-key',
+        'alias-key',
+        'merge-key',
+        'two-keys-one-line',
+    ],
+)
+def test_update_leaves_an_unaddressable_block_untouched(
+    tmp_path: pathlib.Path,
+    body: str,
+    desc: str,
+) -> None:
+    """A mapping whose key lines the writers cannot place is kept as written, named, and linted.
+
+    The byte-level repair refreshes, fills, and reorders column-0 key
+    lines; a flow mapping, an indented mapping, an explicit key, an alias
+    used as a key, a merge key, or two keys on one line (a NEL the parser
+    breaks on) leaves it none to edit safely, so appending fields would
+    leave a block no reader accepts. Update keeps the page byte-identical
+    and names it, lint reports it as malformed, and the parser still reads
+    its fields into the parent row.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    authored = f'---\n{body}\n---\n\n# design\n\nBody.\n'
+    page.write_text(authored, encoding='utf-8')
+
+    # update names the page and rewrites nothing; lint reports it
+    notices = _capture_notices(wiki)
+    wiki.update()
+    err = '\n'.join(event.description for event in notices)
+    assert (
+        'Malformed frontmatter (keys are not column-0 key: value lines) in core/design.md'
+        in err
+    )
+    assert page.read_text(encoding='utf-8') == authored
+    kinds = [
+        issue.kind
+        for issue in Wiki(tmp_path).lint()
+        if issue.fields['path'] == 'core/design.md'
+    ]
+    assert 'malformed_frontmatter' in kinds
+    index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    assert f'[[core/design|design]]: {desc}' in index
+    assert Wiki(tmp_path).update() == []
+
+
+@pytest.mark.parametrize(
+    argnames=('stamp', 'expected'),
+    argvalues=[
+        ('updated: &u 2026-01-01T00:00:00Z\nzz: *u', r'^updated: &u \S+\nzz: \*u$'),
+        ('created: \'\'\nupdated: "" # c', r'^created: \S+Z\nupdated: \S+Z # c$'),
+        (
+            'created: &c\nupdated: 2026-01-01T00:00:00Z',
+            r'^created: &c \S+\nupdated: \S+$',
+        ),
+    ],
+    ids=['anchored-restamp', 'quoted-empty', 'anchored-null'],
+)
+def test_update_stamps_keep_their_anchors(
+    tmp_path: pathlib.Path, stamp: str, expected: str
+) -> None:
+    """A stamp's anchor stays on the fresh value, and a quoted-empty or anchored-null stamp is filled.
+
+    Dropping the anchor from a re-stamped ``updated:`` would strand every
+    alias of it; the properties ride onto the new stamp instead, and the
+    block a strict reader accepted stays accepted.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: wrong\ndesc: A page.\n{stamp}\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # one update converges on a block every strict reader still accepts
+    wiki.update()
+    frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
+    assert re.search(expected, frontmatter, re.M), frontmatter
+    assert format.frontmatter_issues(f'---\n{frontmatter}---') == []
+    assert Wiki(tmp_path).update() == []
+
+
+def test_update_rows_read_the_repaired_child(tmp_path: pathlib.Path) -> None:
+    """A parent row reads the child's repaired frontmatter, so it converges in the same run.
+
+    A child whose repair changes what the reader returns -- a block the
+    name refresh makes parseable, a stray blank the repair drops under an
+    inline value -- would otherwise feed the parent its pre-repair text
+    and the row would catch up a run late.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['flip', 'blank']})
+    (tmp_path / 'core' / 'flip.md').write_text(
+        "---\nname: 'it's gamma.'\ndesc: D.\ncategory: # head note\n  Cat.\n---\n\n"
+        '# flip\n\nBody.\n',
+        encoding='utf-8',
+    )
+    (tmp_path / 'core' / 'blank.md').write_text(
+        "---\nname: blank\ndesc: >gt it's.\n   \n---\n\n# blank\n\nBody.\n",
+        encoding='utf-8',
+    )
+
+    # the first update writes the rows the repaired children read as
+    wiki.update()
+    index = (tmp_path / 'core' / '_index.md').read_text(encoding='utf-8')
+    assert '[[core/flip|[Cat.] flip]]: D.' in index
+    assert Wiki(tmp_path).update() == []
+
+
+def test_update_converges_when_the_restamp_drops_the_only_alias(
+    tmp_path: pathlib.Path,
+) -> None:
+    """An alias sitting alone on ``updated:`` pins the order only until the re-stamp replaces it.
+
+    The written block carries no alias, so the write orders it as the
+    next run would have, and the next run is a no-op.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        '---\ncreated: &c 2026-01-01T00:00:00Z\nupdated: *c\ndesc: A.\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # one update lands the canonical order with a plain stamp
+    wiki.update()
+    frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
+    assert re.match(
+        r'name: core/design\ndesc: A.\ncreated: &c \S+\nupdated: \S+\n$', frontmatter
+    )
+    assert Wiki(tmp_path).update() == []
+
+
+def test_update_drops_a_bom_opening_the_body(tmp_path: pathlib.Path) -> None:
+    """A UTF-8 BOM after the opening fence goes, so the key it rode on stays a top-level key.
+
+    Left on its line, the order pass could move the BOM mid-block, where
+    the C loader nests the key under its neighbor.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    bom = chr(0xFEFF)
+    page.write_text(
+        f'---\n{bom}created: 2026-01-01T00:00:00Z\na.b: x\ndesc: A.\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # one update converges with created a top-level stamp and no BOM
+    wiki.update()
+    text = page.read_text(encoding='utf-8')
+    assert bom not in text
+    assert format.frontmatter_issues(text.split('\n---\n')[0] + '\n---') == []
+    assert format.read_frontmatter_field(text.split('\n---\n')[0] + '\n---', 'created')
+    assert Wiki(tmp_path).update() == []
+
+
+@pytest.mark.parametrize(
+    argnames='line',
+    argvalues=['updated:X', 'desc:needle text', 'name:core/design'],
+    ids=['stamp', 'desc', 'name'],
+)
+def test_update_converges_on_a_key_missing_its_space(
+    tmp_path: pathlib.Path, line: str
+) -> None:
+    """A ``key:value`` line with no space after the colon is not a key to any grammar.
+
+    YAML reads it as text, and so does the wiki's line grammar for the
+    repair, the field order, and ``match --field`` alike, so the repair
+    inserts the field it does not see and the block converges in one
+    update -- lint names the invalid line, and the author's fix is one
+    space.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        f'---\nname: core/design\n{line}\ncreated: 2026-01-01T00:00:00Z\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # one update converges; lint keeps naming the line as invalid YAML
+    wiki.update()
+    assert Wiki(tmp_path).update() == []
+    kinds = {
+        issue.kind
+        for issue in Wiki(tmp_path).lint()
+        if issue.fields['path'] == 'core/design.md'
+    }
+    assert 'invalid_yaml' in kinds
+    assert 'requires_update' not in kinds
+
+
+def test_update_restamps_with_the_stamp_comments(tmp_path: pathlib.Path) -> None:
+    """The ``updated:`` re-stamp keeps the key line's tail comment and the comment lines under it.
+
+    A comment carrying a Unicode line separator is one comment line to
+    the wiki (a strict reader breaks the line there, which lint names),
+    so the re-stamp never splits it and swallows the closing fence.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    separator = chr(0x2028)
+    page.write_text(
+        '---\nname: wrong\ndesc: A page.\nupdated: 2026-01-01T00:00:00Z # by hand\n'
+        f'  # note{separator}more\n---\n\n# design\n\nBody.\n',
+        encoding='utf-8',
+    )
+
+    # the rewrite re-stamps and both comments ride along; the block stays closed
+    wiki.update()
+    frontmatter, body = page.read_text(encoding='utf-8').split('\n---\n')
+    assert re.search(
+        rf'^updated: \S+ # by hand\n  # note{separator}more$', frontmatter, re.M
+    )
+    assert body.startswith('\n# core/design\n')
+    kinds = {issue.kind for issue in Wiki(tmp_path).lint()}
+    assert kinds <= {'invalid_yaml'}
+    assert Wiki(tmp_path).update() == []
 
 
 @pytest.mark.parametrize('field', ['created', 'updated'])
@@ -2856,6 +3249,33 @@ def test_required_titles_seed_lint_and_flip_off(tmp_path: pathlib.Path) -> None:
     assert 'title:' not in files[-1].read_text(encoding='utf-8')
     assert wiki.lint() == []
     assert wiki.update() == []
+
+
+def test_required_titles_converge_over_a_duplicated_name(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Seeding ``title: null`` under a duplicated ``name:`` converges in one run.
+
+    The seed lands under the first ``name:`` extent and the write orders
+    the block, which sorts both ``name:`` copies above the title; the plan
+    orders the block the same way, or every run would move the title back.
+    """
+    _make_wiki(tmp_path, folders={'core': ['design']})
+    settings = tmp_path / '.wiki' / 'settings.json'
+    settings.write_text(
+        json.dumps({'titles': {'required': True}}) + '\n', encoding='utf-8'
+    )
+    for path in (tmp_path / 'core' / 'design.md', tmp_path / 'core' / '_index.md'):
+        text = path.read_text(encoding='utf-8')
+        path.write_text(text.replace('name: ', 'name: a\nname: ', 1), encoding='utf-8')
+
+    # one update seeds the placeholder and lands the block in its final order
+    wiki = Wiki(tmp_path)
+    wiki.update()
+    for path in (tmp_path / 'core' / 'design.md', tmp_path / 'core' / '_index.md'):
+        text = path.read_text(encoding='utf-8')
+        assert re.search(r'^name: .*\nname: .*\ntitle: null\n', text, re.M)
+    assert Wiki(tmp_path).update() == []
 
 
 def test_required_titles_adopts_no_h1_page(tmp_path: pathlib.Path) -> None:

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -82,7 +82,7 @@ __all__ = [
     'test_reclaimed_index_keeps_link_shaped_continuation',
     'test_body_edits_never_dirty_the_tree',
     'test_update_fills_blank_frontmatter_values',
-    'test_update_repairs_a_key_missing_its_space',
+    'test_update_leaves_a_non_mapping_block_untouched',
     'test_update_keeps_a_bare_key_stamp_body',
     'test_update_inserts_timestamps_in_canonical_order',
     'test_update_inserts_desc_in_schema_order',
@@ -1759,25 +1759,52 @@ def test_update_fills_blank_frontmatter_values(
     assert wiki.update() == []
 
 
-def test_update_repairs_a_key_missing_its_space(tmp_path: pathlib.Path) -> None:
-    """A block whose only key lacks the space after its colon is repaired, not refused.
+@pytest.mark.parametrize(
+    argnames='body',
+    argvalues=['Just a sentence.', '- a\n- b', 'name:core/design'],
+    ids=['prose', 'list', 'missing-space'],
+)
+def test_update_leaves_a_non_mapping_block_untouched(
+    tmp_path: pathlib.Path,
+    body: str,
+) -> None:
+    """A block that is valid YAML but not ``key: value`` pairs is kept as written and named.
 
-    ``name:core/design`` composes as one plain scalar, so to a strict
-    reader the block is not a mapping -- but it is a typo, not prose, and
-    the line grammar reads the key; update rewrites it as ``name: core/design``
-    and fills the rest, instead of leaving the page untouched.
+    A bare sentence, a list, or a ``name:core/design`` typo composes to a
+    scalar or sequence root with no fields to read or repair; appending
+    ``name:``, ``desc:``, and stamps under the text would leave a block no
+    reader accepts. Update keeps the page and the index byte-identical
+    and names each with its reason, lint reports the block on its first
+    line, and the next update finds nothing to do.
     """
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
     page = tmp_path / 'core' / 'design.md'
-    page.write_text(
-        '---\nname:core/design\n---\n\n# design\n\nBody.\n', encoding='utf-8'
-    )
+    index = tmp_path / 'core' / '_index.md'
+    authored_page = f'---\n{body}\n---\n\n# design\n\nBody.\n'
+    authored_index = f'---\n{body}\n---\n\n# core\n\n***\n\nProse.\n'
+    page.write_text(authored_page, encoding='utf-8')
+    index.write_text(authored_index, encoding='utf-8')
 
-    # the typo is repaired and the page converges
+    # update names both files and rewrites neither
+    notices = _capture_notices(wiki)
     wiki.update()
-    frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
-    assert frontmatter.startswith('name: core/design\ndesc: ...\n')
+    err = '\n'.join(event.description for event in notices)
+    assert 'Malformed frontmatter (not a key: value mapping) in core/design.md' in err
+    assert 'Malformed frontmatter (not a key: value mapping) in core/_index.md' in err
+    assert page.read_text(encoding='utf-8') == authored_page
+    assert index.read_text(encoding='utf-8') == authored_index
+    # lint names each block on its first line, and the next update is a no-op
+    issues = [issue for issue in Wiki(tmp_path).lint() if issue.kind == 'invalid_yaml']
+    assert sorted(issue.fields['path'] for issue in issues) == [
+        'core/_index.md',
+        'core/design.md',
+    ]
+    for issue in issues:
+        assert issue.fields['line'] == 1
+        assert issue.fields['reason'] == 'frontmatter is not a mapping'
     assert Wiki(tmp_path).update() == []
+    assert page.read_text(encoding='utf-8') == authored_page
+    assert index.read_text(encoding='utf-8') == authored_index
 
 
 @pytest.mark.parametrize('field', ['created', 'updated'])
@@ -1789,14 +1816,15 @@ def test_update_keeps_a_bare_key_stamp_body(tmp_path: pathlib.Path, field: str) 
     clock onto it and strand the authored stamp below, where a strict
     reader folds both into one unparseable value. ``created:`` keeps its
     body, and ``updated:`` -- re-stamped on every real write -- is
-    replaced as one line, body included.
+    replaced as one line, body included, while the comment line under it
+    rides along.
     """
     wiki = _make_wiki(tmp_path, folders={'core': ['design']})
     page = tmp_path / 'core' / 'design.md'
     stamp = '2026-07-24T20:35:56Z'
     page.write_text(
-        f'---\nname: core/design\ndesc: A page.\n{field}:\n  {stamp}\n---\n\n'
-        '# design\n\nBody.\n',
+        f'---\nname: core/design\ndesc: A page.\n{field}:\n  {stamp}\n  # hand note\n'
+        '---\n\n# design\n\nBody.\n',
         encoding='utf-8',
     )
 
@@ -1804,9 +1832,9 @@ def test_update_keeps_a_bare_key_stamp_body(tmp_path: pathlib.Path, field: str) 
     wiki.update()
     frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
     if field == 'created':
-        assert f'created:\n  {stamp}\n' in frontmatter
+        assert f'created:\n  {stamp}\n  # hand note\n' in frontmatter
     else:
-        assert re.search(r'^updated: \S+\n(?![ \t])', frontmatter, re.M)
+        assert re.search(r'^updated: \S+\n  # hand note\n(?![ \t])', frontmatter, re.M)
         assert stamp not in frontmatter
     assert Wiki(tmp_path).lint() == []
     assert Wiki(tmp_path).update() == []

--- a/tests/test_core/test_update.py
+++ b/tests/test_core/test_update.py
@@ -82,6 +82,7 @@ __all__ = [
     'test_reclaimed_index_keeps_link_shaped_continuation',
     'test_body_edits_never_dirty_the_tree',
     'test_update_fills_blank_frontmatter_values',
+    'test_update_repairs_a_key_missing_its_space',
     'test_update_keeps_a_bare_key_stamp_body',
     'test_update_inserts_timestamps_in_canonical_order',
     'test_update_inserts_desc_in_schema_order',
@@ -1756,6 +1757,27 @@ def test_update_fills_blank_frontmatter_values(
 
     # the fill is idempotent
     assert wiki.update() == []
+
+
+def test_update_repairs_a_key_missing_its_space(tmp_path: pathlib.Path) -> None:
+    """A block whose only key lacks the space after its colon is repaired, not refused.
+
+    ``name:core/design`` composes as one plain scalar, so to a strict
+    reader the block is not a mapping -- but it is a typo, not prose, and
+    the line grammar reads the key; update rewrites it as ``name: core/design``
+    and fills the rest, instead of leaving the page untouched.
+    """
+    wiki = _make_wiki(tmp_path, folders={'core': ['design']})
+    page = tmp_path / 'core' / 'design.md'
+    page.write_text(
+        '---\nname:core/design\n---\n\n# design\n\nBody.\n', encoding='utf-8'
+    )
+
+    # the typo is repaired and the page converges
+    wiki.update()
+    frontmatter = page.read_text(encoding='utf-8').split('---\n')[1]
+    assert frontmatter.startswith('name: core/design\ndesc: ...\n')
+    assert Wiki(tmp_path).update() == []
 
 
 @pytest.mark.parametrize('field', ['created', 'updated'])

--- a/wiki/_assets/git/merge_index.sh
+++ b/wiki/_assets/git/merge_index.sh
@@ -179,28 +179,39 @@ done
 
 # normalize the regenerated keys to ours' values on all three inputs, so the
 # frontmatter merge below only ever sees authored-field differences; a value
-# moves as its whole extent -- the key line plus the indented or blank lines
-# under it -- so a block-scalar or bare-key value never strands its body under
-# the other side's one-liner (the value travels through the environment so awk
-# never mangles a backslash in a name)
+# moves as its whole extent so a block-scalar or bare-key value never strands
+# its body under the other side's one-liner (the value travels through the
+# environment so awk never mangles a backslash in a name)
 for KEY in "${REGENERATED_KEYS[@]}"; do
     # the extent ends at the first dedented line; a blank run belongs to it
     # only when an indented line follows, otherwise it separates the fields
-    # and stays where it is on every side (the key may be spelled `name :`)
+    # and stays where it is on every side -- mirrors Python FIELD_EXTENT minus
+    # its trailing blanks (a shared separator must stay on every side) and its
+    # column-0 sequence items (a regenerated key carries a scalar); the key
+    # match mirrors the Python `^key[ \t]*:` anchor, so `name :` is `name:`
     OURS_EXTENT=$(awk -v key="$KEY" '
         found && /^[[:space:]]*$/ { pending++; next }
-        found && /^[[:space:]]/ { for (i = 0; i < pending; i++) print ""; pending = 0; print; next }
+        found && /^[[:space:]]/ {
+            for (i = 0; i < pending; i++) print ""
+            pending = 0
+            print
+            next
+        }
         found { exit }
         $0 ~ "^" key "[[:blank:]]*:" { print; found = 1 }
     ' "$WORK/ours_fm")
     for SIDE in base theirs; do
         FM="$WORK/${SIDE}_fm"
-        # an empty extent (ours dropped the key) drops it from the other
-        # inputs too
+        # an empty extent (ours dropped the key) drops it from
+        # the other inputs too
         OURS_EXTENT="$OURS_EXTENT" awk -v key="$KEY" '
             skipping && /^[[:space:]]*$/ { pending++; next }
             skipping && /^[[:space:]]/ { pending = 0; next }
-            skipping { for (i = 0; i < pending; i++) print ""; pending = 0; skipping = 0 }
+            skipping {
+                for (i = 0; i < pending; i++) print ""
+                pending = 0
+                skipping = 0
+            }
             $0 ~ "^" key "[[:blank:]]*:" {
                 if (ENVIRON["OURS_EXTENT"] != "") print ENVIRON["OURS_EXTENT"]
                 skipping = 1

--- a/wiki/_assets/git/merge_index.sh
+++ b/wiki/_assets/git/merge_index.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# the driver's grammar is ASCII and the file's bytes are the user's: keep awk,
+# grep, and sed byte-oriented, so a byte no UTF-8 decodes merges verbatim
+# instead of aborting a multibyte-aware awk
+export LC_ALL=C
 
 # Custom git merge driver for _index.md files
 # -------------------------------------------
@@ -173,9 +177,14 @@ for SIDE in ours theirs; do
 done
 
 # ------ normalize regenerated keys
-# add/add (empty base file): both sides seed created: from their own wiki
-# update runs, so the stamps are churn, not authorship -- normalize it too
-[[ ! -s "$BASE" ]] && REGENERATED_KEYS+=(created)
+# a base without a created: stamp (an empty add/add base, a hand-written or
+# imported index, a bare or quoted-empty created: key): both sides seed
+# created: from their own wiki update runs, so the stamps are churn, not
+# authorship -- normalize it too, in the canonical order, so a side gaining
+# both stamps takes them as ours lays them out; a stamp is a plain token or a
+# non-empty quoted scalar after the colon
+grep -Eq "^created[[:blank:]]*:[[:blank:]]+([^[:space:]#\"']|\"[^\"\r]|'[^'\r])" "$WORK/base_fm" \
+    || REGENERATED_KEYS=(name created updated)
 
 # normalize the regenerated keys to ours' values on all three inputs, so the
 # frontmatter merge below only ever sees authored-field differences; a value
@@ -183,42 +192,83 @@ done
 # its body under the other side's one-liner (the value travels through the
 # environment so awk never mangles a backslash in a name)
 for KEY in "${REGENERATED_KEYS[@]}"; do
-    # the extent ends at the first dedented line; a blank run belongs to it
-    # only when an indented line follows, otherwise it separates the fields
-    # and stays where it is on every side -- mirrors Python FIELD_EXTENT minus
-    # its trailing blanks (a shared separator must stay on every side) and its
-    # column-0 sequence items (a regenerated key carries a scalar); the key
-    # match mirrors the Python `^key[ \t]*:` anchor, so `name :` is `name:`
-    OURS_EXTENT=$(awk -v key="$KEY" '
-        found && /^[[:space:]]*$/ { pending++; next }
+    # the extent is the key line plus the indented lines that continue its
+    # value: every indented line under a block-scalar header (`|`/`>`, node
+    # properties allowed before it), else the indented non-comment lines of
+    # a plain value; a comment (indented or not) is authored, so it merges as
+    # an ordinary line, and, like a blank run, belongs to the extent only
+    # when a value line follows (a comment between a key and its indented
+    # value must not strand the value under the other side's one-liner),
+    # otherwise it separates the fields and stays where it is on every side,
+    # byte for byte (a CRLF or whitespace-only separator included) -- mirrors
+    # Python FIELD_EXTENT minus its trailing blanks, its column-0 sequence
+    # items (a regenerated key carries a scalar), and its trailing comments;
+    # the key match mirrors the Python `^key[ \t]*:(?:[ \t]|$)` anchor, so
+    # `name :` is `name:` while a `name:core` typo is text, and a CRLF bare
+    # key still matches; the extent travels through a file, as the
+    # environment caps a value's size
+    awk -v key="$KEY" '
+        found && /^[[:space:]]*$/ { pending = pending $0 "\n"; next }
+        found && !block && /^[[:space:]]*#/ { pending = pending $0 "\n"; next }
         found && /^[[:space:]]/ {
-            for (i = 0; i < pending; i++) print ""
-            pending = 0
+            printf "%s", pending
+            pending = ""
             print
             next
         }
         found { exit }
-        $0 ~ "^" key "[[:blank:]]*:" { print; found = 1 }
-    ' "$WORK/ours_fm")
+        $0 ~ "^" key "[[:blank:]]*:([[:blank:]\r]|$)" {
+            block = ($0 ~ ("^" key "[[:blank:]]*:[[:blank:]]*([&!][^[:blank:]]*[[:blank:]]+)*[|>]"))
+            print
+            found = 1
+        }
+    ' "$WORK/ours_fm" >"$WORK/extent"
+    HAVE_EXTENT=0
+    [[ -s "$WORK/extent" ]] && HAVE_EXTENT=1
     for SIDE in base theirs; do
         FM="$WORK/${SIDE}_fm"
-        # an empty extent (ours dropped the key) drops it from
-        # the other inputs too
-        OURS_EXTENT="$OURS_EXTENT" awk -v key="$KEY" '
-            skipping && /^[[:space:]]*$/ { pending++; next }
-            skipping && /^[[:space:]]/ { pending = 0; next }
+        # an empty extent (ours dropped the key) drops it from the other
+        # inputs too; the value lines of this side go, with the comments and
+        # blank run a value line follows, while those trailing the value
+        # stay; a side without the key (a base index written by hand, a side
+        # that never ran wiki update) gains ours' extent where wiki update
+        # puts the key -- name: under the opening fence, a stamp above the
+        # closing one -- so the other side adding the key is no change to
+        # merge; the extent path travels through the environment, as awk -v
+        # would decode a backslash in it
+        HAS_KEY=$(grep -Ec "^${KEY}[[:blank:]]*:([[:space:]]|$)" "$FM" || true)
+        EXTENT="$WORK/extent" awk -v key="$KEY" -v have_extent="$HAVE_EXTENT" \
+            -v has_key="$HAS_KEY" '
+            skipping && /^[[:space:]]*$/ { pending = pending $0 "\n"; next }
+            skipping && !block && /^[[:space:]]*#/ { pending = pending $0 "\n"; next }
+            skipping && /^[[:space:]]/ {
+                pending = ""
+                next
+            }
             skipping {
-                for (i = 0; i < pending; i++) print ""
-                pending = 0
+                printf "%s", pending
+                pending = ""
                 skipping = 0
             }
-            $0 ~ "^" key "[[:blank:]]*:" {
-                if (ENVIRON["OURS_EXTENT"] != "") print ENVIRON["OURS_EXTENT"]
+            NR == 1 && key == "name" && have_extent && !has_key {
+                print
+                while ((getline line < ENVIRON["EXTENT"]) > 0) print line
+                close(ENVIRON["EXTENT"])
+                next
+            }
+            NR > 1 && key != "name" && have_extent && !has_key && /^---[[:space:]\r]*$/ {
+                while ((getline line < ENVIRON["EXTENT"]) > 0) print line
+                close(ENVIRON["EXTENT"])
+            }
+            $0 ~ "^" key "[[:blank:]]*:([[:blank:]\r]|$)" {
+                block = ($0 ~ ("^" key "[[:blank:]]*:[[:blank:]]*([&!][^[:blank:]]*[[:blank:]]+)*[|>]"))
+                while ((getline line < ENVIRON["EXTENT"]) > 0) print line
+                close(ENVIRON["EXTENT"])
                 skipping = 1
                 next
             }
             { print }
-            END { for (i = 0; i < pending; i++) print "" }
+            END { printf "%s", pending }
         ' "$FM" >"$FM.new"
         mv "$FM.new" "$FM"
     done
@@ -238,35 +288,69 @@ git merge-file --marker-size="$MARKER_SIZE" -p -L ours -L base -L theirs \
 if grep -q '^\*\*\*[[:space:]]*$' "$WORK/ours_links"; then
     # rows key on their [[target| prefix (mirrors Python _LINK_ROW);
     # continuation and blank lines ride with the row that precedes them,
-    # and theirs' heading/preamble (before its first row) is never collected
+    # and a side's heading/preamble (before its first row) is never
+    # collected. Ours' rows stream through in ours' layout; a row both
+    # sides carry keeps ours' text unless ours left base's text alone while
+    # theirs changed it -- an authored desc edit on a row wiki update does
+    # not regenerate (an asset, a child still on the placeholder) -- and
+    # then theirs' text lands, as a three-way merge would land it; a row
+    # only theirs has rides over, appended directly above ours' closing ***
+    # (the region ends at its first ***, so the anchor is unambiguous)
     awk '
-        FNR == 1 { part++ }
-        part == 1 {
+        # a row block without its trailing blank lines (CRLF and
+        # whitespace-only ones included): the text a side edited, whatever
+        # separated the rows on that side
+        function body(s) {
+            while (s ~ /\r?\n[[:blank:]]*\r?\n$/) sub(/[[:blank:]]*\r?\n$/, "", s)
+            return s
+        }
+        function flush() {
+            if (row == "") return
+            if (((2, row) in text) && ((1, row) in text) \
+                && body(held) == body(text[1, row]) \
+                && body(text[2, row]) != body(text[1, row]))
+                printf "%s%s", body(text[2, row]), substr(held, length(body(held)) + 1)
+            else
+                printf "%s", held
+            row = ""
+            held = ""
+        }
+        # the parts are the input files in order: an empty base (add/add)
+        # yields no record, so the file name, not the record count, says
+        # which part a line belongs to
+        { part = (FILENAME == ARGV[3]) ? 3 : (FILENAME == ARGV[2]) ? 2 : 1 }
+        FNR == 1 { key = "" }
+        part < 3 {
+            if ($0 ~ /^\*\*\*[[:space:]]*$/) { key = ""; next }
             if ($0 ~ /^\[\[.*\|/) {
                 key = $0
                 sub(/\|.*$/, "", key)
-                ours[key] = 1
+                if (part == 2 && !((2, key) in text)) order[++count] = key
             }
+            if (key != "") text[part, key] = text[part, key] $0 "\n"
             next
         }
-        /^\*\*\*[[:space:]]*$/ { exit }
-        /^\[\[.*\|/ {
-            key = $0
-            sub(/\|.*$/, "", key)
-            keep = !(key in ours)
-        }
-        keep { print }
-    ' "$WORK/ours_links" "$WORK/theirs_links" >"$WORK/extra_links"
-    # insert the extras directly above ours' closing *** (the region ends
-    # at its first ***, so the anchor is unambiguous); the extras path
-    # travels through the environment so awk never mangles it
-    EXTRAS="$WORK/extra_links" awk '
         /^\*\*\*[[:space:]]*$/ && !done {
-            while ((getline line < ENVIRON["EXTRAS"]) > 0) print line
+            flush()
+            for (i = 1; i <= count; i++)
+                if (!(order[i] in ours)) printf "%s", text[2, order[i]]
             done = 1
+            print
+            next
         }
+        done { print; next }
+        /^\[\[.*\|/ {
+            flush()
+            row = $0
+            sub(/\|.*$/, "", row)
+            ours[row] = 1
+            held = $0 "\n"
+            next
+        }
+        row != "" { held = held $0 "\n"; next }
         { print }
-    ' "$WORK/ours_links" >"$WORK/result_links"
+        END { flush() }
+    ' "$WORK/base_links" "$WORK/theirs_links" "$WORK/ours_links" >"$WORK/result_links"
 else
     # ours lost its closing *** (an empty above region): nothing anchors
     # an insertion, so take ours as-is

--- a/wiki/_assets/git/merge_index.sh
+++ b/wiki/_assets/git/merge_index.sh
@@ -177,21 +177,34 @@ done
 # update runs, so the stamps are churn, not authorship -- normalize it too
 [[ ! -s "$BASE" ]] && REGENERATED_KEYS+=(created)
 
-# normalize the regenerated keys to ours' lines on all three inputs, so the
-# frontmatter merge below only ever sees authored-field differences (the value
-# travels through the environment so awk never mangles a backslash in a name)
+# normalize the regenerated keys to ours' values on all three inputs, so the
+# frontmatter merge below only ever sees authored-field differences; a value
+# moves as its whole extent -- the key line plus the indented or blank lines
+# under it -- so a block-scalar or bare-key value never strands its body under
+# the other side's one-liner (the value travels through the environment so awk
+# never mangles a backslash in a name)
 for KEY in "${REGENERATED_KEYS[@]}"; do
-    OURS_LINE=$(grep -m1 "^${KEY}:" "$WORK/ours_fm" || true)
+    OURS_EXTENT=$(awk -v key="$KEY" '
+        found && /^[[:space:]]*$/ { print; next }
+        found && /^[[:space:]]/ { print; next }
+        found { exit }
+        index($0, key ":") == 1 { print; found = 1 }
+    ' "$WORK/ours_fm")
     for SIDE in base theirs; do
         FM="$WORK/${SIDE}_fm"
-        if [[ -n "$OURS_LINE" ]]; then
-            OURS_LINE="$OURS_LINE" awk -v key="$KEY" \
-                'index($0, key ":") == 1 { print ENVIRON["OURS_LINE"]; next } { print }' \
-                "$FM" >"$FM.new"
-        else
-            # ours dropped the key -- drop it from the other inputs too
-            grep -v "^${KEY}:" "$FM" >"$FM.new" || true
-        fi
+        # an empty extent (ours dropped the key) drops it from the other
+        # inputs too
+        OURS_EXTENT="$OURS_EXTENT" awk -v key="$KEY" '
+            skipping && /^[[:space:]]*$/ { next }
+            skipping && /^[[:space:]]/ { next }
+            { skipping = 0 }
+            index($0, key ":") == 1 {
+                if (ENVIRON["OURS_EXTENT"] != "") print ENVIRON["OURS_EXTENT"]
+                skipping = 1
+                next
+            }
+            { print }
+        ' "$FM" >"$FM.new"
         mv "$FM.new" "$FM"
     done
 done

--- a/wiki/_assets/git/merge_index.sh
+++ b/wiki/_assets/git/merge_index.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# the driver's grammar is ASCII and the file's bytes are the user's: keep awk,
-# grep, and sed byte-oriented, so a byte no UTF-8 decodes merges verbatim
-# instead of aborting a multibyte-aware awk
-export LC_ALL=C
 
 # Custom git merge driver for _index.md files
 # -------------------------------------------
@@ -21,10 +17,11 @@ export LC_ALL=C
 # is authored (update never invents a value), so it must stay out of
 # REGENERATED_KEYS -- normalizing it to ours would silently discard
 # theirs' titles; the H1 rides ours' link-block layout, so a merged-in
-# title shows in the H1 only after the post-merge wiki update. On
-# add/add merges (empty base) created joins the regenerated keys: both
-# sides seed it from independent wiki update runs, so the stamps are
-# churn, not authorship. A side whose frontmatter is undetectable
+# title shows in the H1 only after the post-merge wiki update. When the
+# base carries no created: stamp (an add/add merge's empty base, a
+# hand-written index) created joins the regenerated keys: both sides
+# seed it from independent wiki update runs, so the stamps are churn,
+# not authorship. A side whose frontmatter is undetectable
 # (formatter-mangled or unclosed) is treated as unchanged from base,
 # never as a deletion of the block; a side missing the *** separator
 # entirely cannot be split into regions at all, so it surfaces a
@@ -50,6 +47,15 @@ OURS="$1"
 BASE="$2"
 THEIRS="$3"
 MARKER_SIZE="${4:-7}"
+
+# the driver's grammar is ASCII and the file's bytes are the user's: keep awk,
+# grep, and sed byte-oriented, so a byte no UTF-8 decodes merges verbatim
+# instead of aborting a multibyte-aware awk
+export LC_ALL=C
+
+# a literal carriage return for grep bracket expressions, where \r is the
+# two characters backslash and r
+CR=$'\r'
 
 # keys wiki update owns, normalized to ours before the frontmatter merge
 REGENERATED_KEYS=(name updated)
@@ -183,8 +189,8 @@ done
 # authorship -- normalize it too, in the canonical order, so a side gaining
 # both stamps takes them as ours lays them out; a stamp is a plain token or a
 # non-empty quoted scalar after the colon
-grep -Eq "^created[[:blank:]]*:[[:blank:]]+([^[:space:]#\"']|\"[^\"\r]|'[^'\r])" "$WORK/base_fm" \
-    || REGENERATED_KEYS=(name created updated)
+grep -Eq "^created[[:blank:]]*:[[:blank:]]+([^[:space:]#\"']|\"[^\"$CR]|'[^'$CR])" \
+    "$WORK/base_fm" || REGENERATED_KEYS=(name created updated)
 
 # normalize the regenerated keys to ours' values on all three inputs, so the
 # frontmatter merge below only ever sees authored-field differences; a value
@@ -208,6 +214,10 @@ for KEY in "${REGENERATED_KEYS[@]}"; do
     # key still matches; the extent travels through a file, as the
     # environment caps a value's size
     awk -v key="$KEY" '
+        BEGIN {
+            header = "^" key "[[:blank:]]*:[[:blank:]]*" \
+                "([&!][^[:blank:]]*[[:blank:]]+)*[|>]"
+        }
         found && /^[[:space:]]*$/ { pending = pending $0 "\n"; next }
         found && !block && /^[[:space:]]*#/ { pending = pending $0 "\n"; next }
         found && /^[[:space:]]/ {
@@ -218,11 +228,13 @@ for KEY in "${REGENERATED_KEYS[@]}"; do
         }
         found { exit }
         $0 ~ "^" key "[[:blank:]]*:([[:blank:]\r]|$)" {
-            block = ($0 ~ ("^" key "[[:blank:]]*:[[:blank:]]*([&!][^[:blank:]]*[[:blank:]]+)*[|>]"))
+            block = ($0 ~ header)
             print
             found = 1
         }
     ' "$WORK/ours_fm" >"$WORK/extent"
+    # 0/1 flags for awk -v, whose truth test is numeric -- any non-empty
+    # string, "false" included, would read as true
     HAVE_EXTENT=0
     [[ -s "$WORK/extent" ]] && HAVE_EXTENT=1
     for SIDE in base theirs; do
@@ -236,9 +248,13 @@ for KEY in "${REGENERATED_KEYS[@]}"; do
         # closing one -- so the other side adding the key is no change to
         # merge; the extent path travels through the environment, as awk -v
         # would decode a backslash in it
-        HAS_KEY=$(grep -Ec "^${KEY}[[:blank:]]*:([[:space:]]|$)" "$FM" || true)
+        HAS_KEY=$(grep -Ec "^${KEY}[[:blank:]]*:([[:blank:]$CR]|$)" "$FM" || true)
         EXTENT="$WORK/extent" awk -v key="$KEY" -v have_extent="$HAVE_EXTENT" \
             -v has_key="$HAS_KEY" '
+            BEGIN {
+                header = "^" key "[[:blank:]]*:[[:blank:]]*" \
+                    "([&!][^[:blank:]]*[[:blank:]]+)*[|>]"
+            }
             skipping && /^[[:space:]]*$/ { pending = pending $0 "\n"; next }
             skipping && !block && /^[[:space:]]*#/ { pending = pending $0 "\n"; next }
             skipping && /^[[:space:]]/ {
@@ -261,7 +277,7 @@ for KEY in "${REGENERATED_KEYS[@]}"; do
                 close(ENVIRON["EXTENT"])
             }
             $0 ~ "^" key "[[:blank:]]*:([[:blank:]\r]|$)" {
-                block = ($0 ~ ("^" key "[[:blank:]]*:[[:blank:]]*([&!][^[:blank:]]*[[:blank:]]+)*[|>]"))
+                block = ($0 ~ header)
                 while ((getline line < ENVIRON["EXTENT"]) > 0) print line
                 close(ENVIRON["EXTENT"])
                 skipping = 1
@@ -289,7 +305,7 @@ if grep -q '^\*\*\*[[:space:]]*$' "$WORK/ours_links"; then
     # rows key on their [[target| prefix (mirrors Python _LINK_ROW);
     # continuation and blank lines ride with the row that precedes them,
     # and a side's heading/preamble (before its first row) is never
-    # collected. Ours' rows stream through in ours' layout; a row both
+    # collected -- ours' rows stream through in ours' layout; a row both
     # sides carry keeps ours' text unless ours left base's text alone while
     # theirs changed it -- an authored desc edit on a row wiki update does
     # not regenerate (an asset, a child still on the placeholder) -- and

--- a/wiki/_assets/git/merge_index.sh
+++ b/wiki/_assets/git/merge_index.sh
@@ -184,26 +184,30 @@ done
 # the other side's one-liner (the value travels through the environment so awk
 # never mangles a backslash in a name)
 for KEY in "${REGENERATED_KEYS[@]}"; do
+    # the extent ends at the first dedented line; a blank run belongs to it
+    # only when an indented line follows, otherwise it separates the fields
+    # and stays where it is on every side (the key may be spelled `name :`)
     OURS_EXTENT=$(awk -v key="$KEY" '
-        found && /^[[:space:]]*$/ { print; next }
-        found && /^[[:space:]]/ { print; next }
+        found && /^[[:space:]]*$/ { pending++; next }
+        found && /^[[:space:]]/ { for (i = 0; i < pending; i++) print ""; pending = 0; print; next }
         found { exit }
-        index($0, key ":") == 1 { print; found = 1 }
+        $0 ~ "^" key "[[:blank:]]*:" { print; found = 1 }
     ' "$WORK/ours_fm")
     for SIDE in base theirs; do
         FM="$WORK/${SIDE}_fm"
         # an empty extent (ours dropped the key) drops it from the other
         # inputs too
         OURS_EXTENT="$OURS_EXTENT" awk -v key="$KEY" '
-            skipping && /^[[:space:]]*$/ { next }
-            skipping && /^[[:space:]]/ { next }
-            { skipping = 0 }
-            index($0, key ":") == 1 {
+            skipping && /^[[:space:]]*$/ { pending++; next }
+            skipping && /^[[:space:]]/ { pending = 0; next }
+            skipping { for (i = 0; i < pending; i++) print ""; pending = 0; skipping = 0 }
+            $0 ~ "^" key "[[:blank:]]*:" {
                 if (ENVIRON["OURS_EXTENT"] != "") print ENVIRON["OURS_EXTENT"]
                 skipping = 1
                 next
             }
             { print }
+            END { for (i = 0; i < pending; i++) print "" }
         ' "$FM" >"$FM.new"
         mv "$FM.new" "$FM"
     done

--- a/wiki/cli/cmd/wiki.py
+++ b/wiki/cli/cmd/wiki.py
@@ -130,10 +130,10 @@ _UPDATE_CATEGORIES = [
     ),
     (
         FrontmatterMalformedEvent,
-        '1 page with malformed frontmatter',
-        '{n} pages with malformed frontmatter',
-        '1 page with malformed frontmatter',
-        '{n} pages with malformed frontmatter',
+        '1 file with malformed frontmatter',
+        '{n} files with malformed frontmatter',
+        '1 file with malformed frontmatter',
+        '{n} files with malformed frontmatter',
     ),
     (
         IndexTruncatedEvent,
@@ -294,6 +294,7 @@ def init(app: typer.Typer) -> typer.Typer:
         # initialize wiki, streaming its notices to stderr
         wiki = Wiki(path)
         wiki.on_notice = _echo_notice
+        _require_utf8('NAME', name)
         wiki.init(name, settings=settings)
         # materialize Obsidian config (downloads community plugins)
         warnings = wiki.update_config()
@@ -784,6 +785,10 @@ def new(
         folder), so pending maintenance in that scope -- adoptions,
         prunes -- lands in the same run.
         """
+        # the inputs land in frontmatter and prose, which every writer encodes
+        # as UTF-8: an argv byte no UTF-8 decodes is refused at the boundary
+        for option, value in (('NAME', name), ('--desc', desc), ('--content', content)):
+            _require_utf8(option, value)
         wiki = resolve(path)
         # the scoped sweep narrates like update: condensed count lines
         notices: list[Event] = []
@@ -1178,6 +1183,19 @@ def _condense(notices: list[Event], check: bool) -> list[str]:
         line = one if n == 1 else many.format(n=n)
         lines.append((position, line))
     return [line for _position, line in sorted(lines)]
+
+
+def _require_utf8(option: str, value: str) -> None:
+    """Refuse an argument holding a byte no UTF-8 decodes.
+
+    The shell hands such a byte over as a lone surrogate, which every
+    writer's UTF-8 encoding rejects; refusing at the boundary keeps it
+    out of a frontmatter block that would then fail every later run.
+    """
+    try:
+        value.encode('utf-8')
+    except UnicodeEncodeError:
+        raise typer.BadParameter(f'{option} is not valid UTF-8') from None
 
 
 def _echo_notice(event: Event, **kwargs: Any) -> Event:

--- a/wiki/cli/cmd/wiki.py
+++ b/wiki/cli/cmd/wiki.py
@@ -23,6 +23,7 @@ from wiki.cli.utils import (
     parse_settings,
     parse_slice,
     refuse_nested_init,
+    require_utf8,
     resolve_wiki,
     resolve_wiki_root,
     trust_root,
@@ -282,6 +283,8 @@ def init(app: typer.Typer) -> typer.Typer:
         else:
             path = pathlib.Path.cwd() / DEFAULT_WIKI_NAME
             name = name or pathlib.Path.cwd().name
+        # a name byte no UTF-8 decodes is refused before any work starts
+        require_utf8('NAME', name)
         # parse the optional settings JSON
         settings = parse_settings(settings)
         # refuse to scaffold inside an enclosing wiki
@@ -294,7 +297,6 @@ def init(app: typer.Typer) -> typer.Typer:
         # initialize wiki, streaming its notices to stderr
         wiki = Wiki(path)
         wiki.on_notice = _echo_notice
-        _require_utf8('NAME', name)
         wiki.init(name, settings=settings)
         # materialize Obsidian config (downloads community plugins)
         warnings = wiki.update_config()
@@ -788,7 +790,7 @@ def new(
         # the inputs land in frontmatter and prose, which every writer encodes
         # as UTF-8: an argv byte no UTF-8 decodes is refused at the boundary
         for option, value in (('NAME', name), ('--desc', desc), ('--content', content)):
-            _require_utf8(option, value)
+            require_utf8(option, value)
         wiki = resolve(path)
         # the scoped sweep narrates like update: condensed count lines
         notices: list[Event] = []
@@ -1183,19 +1185,6 @@ def _condense(notices: list[Event], check: bool) -> list[str]:
         line = one if n == 1 else many.format(n=n)
         lines.append((position, line))
     return [line for _position, line in sorted(lines)]
-
-
-def _require_utf8(option: str, value: str) -> None:
-    """Refuse an argument holding a byte no UTF-8 decodes.
-
-    The shell hands such a byte over as a lone surrogate, which every
-    writer's UTF-8 encoding rejects; refusing at the boundary keeps it
-    out of a frontmatter block that would then fail every later run.
-    """
-    try:
-        value.encode('utf-8')
-    except UnicodeEncodeError:
-        raise typer.BadParameter(f'{option} is not valid UTF-8') from None
 
 
 def _echo_notice(event: Event, **kwargs: Any) -> Event:

--- a/wiki/cli/cmd/wiki.py
+++ b/wiki/cli/cmd/wiki.py
@@ -619,7 +619,7 @@ def match(
         # which the command wrapper renders and exits 2 on
         wiki = resolve(path)
         matches = wiki.match(
-            pattern,
+            pattern=pattern,
             name=name,
             field=field,
             ignore_case=ignore_case,

--- a/wiki/cli/cmd/wiki.py
+++ b/wiki/cli/cmd/wiki.py
@@ -130,10 +130,10 @@ _UPDATE_CATEGORIES = [
     ),
     (
         FrontmatterMalformedEvent,
-        '1 page with malformed frontmatter (no closing ---)',
-        '{n} pages with malformed frontmatter (no closing ---)',
-        '1 page with malformed frontmatter (no closing ---)',
-        '{n} pages with malformed frontmatter (no closing ---)',
+        '1 page with malformed frontmatter',
+        '{n} pages with malformed frontmatter',
+        '1 page with malformed frontmatter',
+        '{n} pages with malformed frontmatter',
     ),
     (
         IndexTruncatedEvent,

--- a/wiki/cli/utils.py
+++ b/wiki/cli/utils.py
@@ -34,6 +34,7 @@ __all__ = [
     'command',
     'parse_slice',
     'parse_settings',
+    'require_utf8',
     'is_trusted',
     'trust_root',
     'load_wiki_class',
@@ -123,6 +124,19 @@ def parse_settings(value: Optional[str]) -> Optional[dict]:
     if not isinstance(result, dict):
         raise typer.BadParameter('--settings must be a JSON object.')
     return result
+
+
+def require_utf8(option: str, value: str) -> None:
+    """Refuse an argument holding a byte no UTF-8 decodes.
+
+    The shell hands such a byte over as a lone surrogate, which every
+    writer's UTF-8 encoding rejects; refusing at the boundary keeps it
+    out of a frontmatter block that would then fail every later run.
+    """
+    try:
+        value.encode('utf-8')
+    except UnicodeEncodeError:
+        raise typer.BadParameter(f'{option} is not valid UTF-8.') from None
 
 
 def is_trusted(root: pathlib.Path, /) -> bool:

--- a/wiki/core/_search.py
+++ b/wiki/core/_search.py
@@ -21,7 +21,7 @@ __all__ = []
 _CACHE_NAME = 'search.db'
 # any change to the notes_fts columns, tokenizer, or field extraction
 # must bump this so stale indexes drop and rebuild on the next query
-_SCHEMA_VERSION = '2'
+_SCHEMA_VERSION = '3'
 # ATX headings at any depth, harvested into the weighted headings field
 _HEADING = re.compile(r'^#{1,6}\s+(.*)$', re.MULTILINE)
 # BM25 weights for (title, desc, headings, tags, body): curated metadata

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -811,14 +811,16 @@ def repair_breaks_frontmatter(before: str, after: str) -> bool:
             text = field_text(before, key) or ''
             span_lines = text.split('\n')
             value = re.sub(
-                r'^(?:[&!]\S*(?:\s+|$))+', '', span_lines[0].split(':', 1)[1].strip()
+                pattern=r'^(?:[&!]\S*(?:\s+|$))+',
+                repl='',
+                string=span_lines[0].split(':', 1)[1].strip(),
             )
             if (value[:1] not in ('"', "'")) or (_quote_close(value) != -1):
                 continue
             for line in span_lines[1:]:
-                if re.match(r'^(?:\S.*?)?:(?:[ \t]|$)', line) or re.match(
-                    r'-(?:[ \t]|$)', line
-                ):
+                keyed = re.match(r'^(?:\S.*?)?:(?:[ \t]|$)', line) is not None
+                item = re.match(r'-(?:[ \t]|$)', line) is not None
+                if keyed or item:
                     return True
                 if _quote_close(value[0] + line.strip()) != -1:
                     break
@@ -1791,9 +1793,10 @@ def _field_span(frontmatter: str, key: str) -> Optional[tuple[int, int]]:
         for position, (name, line) in enumerate(keys):
             if name != key:
                 continue
-            end = (
-                keys[position + 1][1] if position + 1 < len(keys) else _end_line(lines)
-            )
+            if position + 1 < len(keys):
+                end = keys[position + 1][1]
+            else:
+                end = _end_line(lines)
             start_offset = sum(len(text) + 1 for text in lines[:line])
             end_offset = sum(len(text) + 1 for text in lines[:end])
             return start_offset, end_offset
@@ -2062,10 +2065,8 @@ def _parse_issue(error: Exception, body: str, offset: int) -> _Issue:
                 # a scalar under a key line is that key's value, so the colon
                 # on the error line is the fault; one opening the block, or
                 # following a comment or item, is a typo named on its first line
-                keyed = (above > 0) and re.match(
-                    r'^(?:\S.*?)?:(?:[ \t]|$)', lines[above - 1]
-                )
-                if not keyed:
+                opener = re.match(r'^(?:\S.*?)?:(?:[ \t]|$)', lines[above - 1])
+                if (above == 0) or (opener is None):
                     body_line = first
         line = body_line + offset + 1
     elif forbidden is not None:
@@ -2080,12 +2081,11 @@ def _parse_issue(error: Exception, body: str, offset: int) -> _Issue:
         reason = type(error).__name__
     elif context and str(reason).startswith('but '):
         reason = f'{context}, {reason}'
-    elif (
-        context and (str(reason) == 'second occurrence') and (context_mark is not None)
-    ):
+    elif context and (str(reason) == 'second occurrence') and context_mark:
         # a duplicate anchor is worded as its context plus where the first is
         first = body.count('\n', 0, context_mark.index) + offset + 1
-        reason = f'{str(context).split(";")[0]} (first at line {first})'
+        context_head = str(context).split(';')[0]
+        reason = f'{context_head} (first at line {first})'
     return line, str(reason), 'parse'
 
 

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -770,7 +770,7 @@ def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
     ``key:`` has no body. A sequence or mapping value, a block the
     parser rejects, and a body that is not a mapping fall back to the
     line grammar (:func:`_read_field_lines`), so the wiki's leniencies --
-    an unquoted ``: `` inside a one-line value, conflict markers -- read
+    an unquoted ``': '`` inside a one-line value, conflict markers -- read
     as before.
     """
     fields = _scalar_fields(frontmatter)
@@ -1132,10 +1132,10 @@ def _plain_safe(value: str) -> bool:
 
     A value containing ``': '`` (or ending with ``:``) reads as a nested
     mapping, one containing ``' #'`` loses everything from the hash (a
-    comment), one opening with an indicator character or ``- ``/``? ``/
-    ``: `` reads as structure, a node property, or a quoted scalar, and
-    leading or trailing whitespace (a tab anywhere) is dropped or
-    rejected -- so none of them may be written plain.
+    comment), one opening with an indicator character or with ``'- '``,
+    ``'? '``, or ``': '`` reads as structure, a node property, or a quoted
+    scalar, and leading or trailing whitespace (a tab anywhere) is dropped
+    or rejected -- so none of them may be written plain.
     """
     if not value:
         return True

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -413,10 +413,15 @@ def build_frontmatter(
 
     """
     # a multi-line desc writes as a literal block, unless a line holds a
-    # character no block may carry, which only a double-quoted scalar escapes
+    # character no block may carry, which only a double-quoted scalar escapes;
+    # a first content line opening with whitespace skews (a space) or refuses
+    # (a tab, to libyaml) the auto-detected indentation, so the two-space
+    # indent is pinned explicitly
     if ('\n' in desc) and not _ESCAPED_CHARS.search(desc.replace('\n', '')):
         body = '\n'.join(f'  {line}'.rstrip() for line in desc.split('\n'))
-        desc_lines = ['desc: |', *body.split('\n')]
+        content = next((line for line in desc.split('\n') if line.strip()), '')
+        indicator = '|2' if content[:1] in (' ', '\t') else '|'
+        desc_lines = [f'desc: {indicator}', *body.split('\n')]
     else:
         desc_lines = [f'desc: {quote(desc)}']
     lines = [
@@ -753,7 +758,7 @@ def replace_heading(content: str, name: str) -> str:
     return content
 
 
-def is_nonmapping_frontmatter(frontmatter: str) -> bool:
+def is_nonmapping_frontmatter(frontmatter: str, /) -> bool:
     """Return whether the block is valid YAML that is not a ``key: value`` mapping.
 
     A bare sentence or a list between the fences has no fields to read
@@ -764,7 +769,7 @@ def is_nonmapping_frontmatter(frontmatter: str) -> bool:
     return kind == 'nonmapping'
 
 
-def is_unaddressable_frontmatter(frontmatter: str) -> bool:
+def is_unaddressable_frontmatter(frontmatter: str, /) -> bool:
     """Return whether the block is a mapping whose keys no byte-level writer can reach.
 
     A flow mapping (``{name: x}``) or a mapping indented as a whole has
@@ -778,7 +783,7 @@ def is_unaddressable_frontmatter(frontmatter: str) -> bool:
 
 
 def repair_breaks_frontmatter(before: str, after: str) -> bool:
-    """Return whether a repair turned a block every strict reader accepts into one they reject, or wrote its fields where none finds them.
+    """Return whether a repair turned a block the installed strict reader accepts into one it rejects, or wrote its fields where it finds none.
 
     The byte-level repair edits by line grammar; a block it cannot
     address safely is kept as written by the planners rather than
@@ -838,8 +843,10 @@ def frontmatter_issues(frontmatter: str) -> list[_Issue]:
     Each is ``(line, reason, cause)``: the 1-based file line, the
     parser's problem or the wiki's description, and the cause -- a
     ``'parse'`` error, a ``'nonmapping'`` body, a ``'nonscalar_key'``,
-    or a ``'duplicate_key'``. An empty list is a block every strict
-    reader accepts as a mapping with unique scalar keys.
+    or a ``'duplicate_key'``. An empty list is a block the installed
+    PyYAML build accepts as a mapping with unique scalar keys -- the
+    verdict is that build's, so a pure-Python wheel rejects a tab
+    inside a plain value the C loader accepts.
     """
     _, _, issues, _, _ = _compose_fields(frontmatter)
     return list(issues)
@@ -858,7 +865,7 @@ def field_text(frontmatter: str, key: str) -> Optional[str]:
     return frontmatter[start:end]
 
 
-def is_collection_field(frontmatter: str, key: str) -> bool:
+def is_collection_field(frontmatter: str, /, key: str) -> bool:
     """Return whether ``key`` carries a sequence or mapping in a block the parser accepts."""
     fields = _scalar_fields(frontmatter)
     return bool(fields) and (key in fields) and (fields[key] is None)
@@ -1019,7 +1026,7 @@ def read_frontmatter_category(frontmatter: str) -> str:
     return join_lines(value or '')
 
 
-def field_value(line: str, key: Optional[str] = None) -> str:
+def field_value(line: str, *, key: Optional[str] = None) -> str:
     """Extract one frontmatter line's value for per-line matching.
 
     Strips a ``key:`` prefix and surrounding YAML quotes
@@ -1640,7 +1647,9 @@ def _line_value(line: str) -> str:
         return ''
     text = re.sub(r'^(?:-[ \t]+)+', '', text)
     return re.sub(
-        r'^(?:"[^"]*"|\'[^\']*\'|[^\s#"\'][^:]*)[ \t]*:(?:[ \t]+|$)', '', text
+        pattern=r'^(?:"[^"]*"|\'[^\']*\'|[^\s#"\'][^:]*)[ \t]*:(?:[ \t]+|$)',
+        repl='',
+        string=text,
     )
 
 
@@ -2262,7 +2271,7 @@ def _closing_quote(value: str, start: int = 0) -> int:
             index += 2
             continue
         if char == quote_char:
-            if (quote_char == "'") and value[index + 1 : index + 2] == "'":
+            if (quote_char == "'") and (value[index + 1 : index + 2] == "'"):
                 index += 2
                 continue
             return index
@@ -2306,7 +2315,7 @@ def _quote_close(value: str) -> int:
             index += 2
             continue
         if char == quote_char:
-            if (quote_char == "'") and value[index + 1 : index + 2] == "'":
+            if (quote_char == "'") and (value[index + 1 : index + 2] == "'"):
                 index += 2
                 continue
             if re.fullmatch(r'[ \t]*(?:#.*)?', value[index + 1 :]):
@@ -2365,7 +2374,8 @@ def _is_plain_safe(value: str) -> bool:
         return False
     # a value a strict reader resolves as a typed scalar and then cannot
     # construct -- a date no calendar has (2024-02-30), a numeral of
-    # underscores alone (0x_) -- is one it rejects
+    # underscores alone (0x_) -- is one it rejects; yaml loads here, after
+    # the cheap tests above, so the common plain value stays import-free
     import yaml
 
     resolved = yaml.resolver.Resolver().resolve(yaml.ScalarNode, value, (True, False))

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import bisect
 import functools
 import re
 import textwrap
@@ -38,8 +39,16 @@ _FRONTMATTER_TAIL = (
 
 # per-process memo of composed frontmatter blocks: an update reads each block
 # a few times and a lint a few more, and a run over a few thousand pages fits
-# one cache at about a kilobyte per block
+# one cache at about a kilobyte per block; a block past the byte bound is
+# composed on every read rather than pinned for the run
 _SCALAR_CACHE_SIZE = 4_096
+_SCALAR_CACHE_BYTES = 65_536
+
+# the deepest collection nesting handed to the composer, which recurses per
+# level: the pure loader raises RecursionError a few hundred levels down, and
+# the C loader, its recursion unchecked, overruns the C stack on older
+# interpreters -- far past any authored block either way
+_MAX_NESTING = 100
 
 # characters that open a YAML indicator (flow collection, comment, node
 # property, block scalar, quote, directive, reserved) when they lead a value
@@ -54,20 +63,69 @@ _Fields = dict[str, Optional[tuple[str, Optional[str], str]]]
 # cause one of 'parse', 'nonmapping', 'nonscalar_key', 'duplicate_key'
 _Issue = tuple[int, str, str]
 
-# characters no YAML stream may carry plain or single-quoted -- controls (a
-# tab excepted), the DEL, and the line separators NEL, LS, and PS -- plus
-# lone surrogates; a value holding one is written double-quoted with escapes
-_ESCAPED_CHARS = re.compile(r'[\x00-\x08\x0a-\x1f\x7f\x85\u2028\u2029\ud800-\udfff]')
+# the top-level keys of a block in document order, each with the 0-based line
+# of its key line within the block (a non-scalar key spells as '')
+_Keys = tuple[tuple[str, int], ...]
+
+# characters no YAML stream may carry plain or single-quoted -- the C0 and C1
+# controls (a tab excepted), the DEL, the line separators LS and PS, and the
+# noncharacters U+FFFE and U+FFFF -- plus lone surrogates; a value holding one
+# is written double-quoted with escapes
+_ESCAPED_CHARS = re.compile(
+    r'[\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029\ud800-\udfff\ufffe\uffff]'
+)
 
 # the single-character escapes of a double-quoted scalar, by the letter after
-# the backslash
-_ESCAPES = {'n': '\n', 'r': '\r', 't': '\t', '"': '"', '\\': '\\'}
+# the backslash (YAML 1.1 section 5.7)
+_ESCAPES = {
+    '0': '\x00',
+    'a': '\x07',
+    'b': '\x08',
+    't': '\t',
+    '\t': '\t',
+    'n': '\n',
+    'v': '\x0b',
+    'f': '\x0c',
+    'r': '\r',
+    'e': '\x1b',
+    ' ': ' ',
+    '"': '"',
+    '/': '/',
+    '\\': '\\',
+    'N': '\x85',
+    '_': '\xa0',
+    'L': '\u2028',
+    'P': '\u2029',
+}
 
-#: the lines continuing a frontmatter field below its key line: indented
-#: lines, blank lines, and column-0 sequence items (``- item``); read by
-#: ``Wiki._apply_plan`` for the re-stamp and mirrored, minus the trailing
-#: blanks and the items, by the merge driver's awk extent
-FIELD_EXTENT = r'(?:[ \t]+.*\n|[ \t]*\n|-(?:[ \t].*)?\n)*'
+# the characters the writer spells with a one-letter escape rather than \uXXXX
+_SHORT_ESCAPES = {
+    char: letter
+    for letter, char in _ESCAPES.items()
+    if letter not in ('\t', ' ', '"', '/', '\\')
+}
+
+# lone surrogates: text no UTF-8 writer can emit
+_SURROGATES = re.compile(r'[\ud800-\udfff]')
+
+# the line grammar's key line, the fallback for a block the parser rejects: a
+# bare or dotted key at column 0, quoted or not, behind optional node
+# properties, its colon followed by a space or the line end; _key_of names the
+# key whichever group matched
+_KEY_LINE = (
+    r'^(?:[&!]\S*[ \t]+)*(?:"([\w.-]+)"|\'([\w.-]+)\'|([\w.-]+))[ \t]*:(?:[ \t]|$)'
+)
+
+#: the lines continuing a frontmatter field below its key line under the line
+#: grammar: indented lines, blank lines, column-0 sequence items (``- item``,
+#: the value of a bare key alone -- see :func:`_field_span`), and column-0
+#: comments; mirrored, minus the trailing blanks, the items, and the comments
+#: (authored lines it merges as such), by the merge driver's awk extent
+FIELD_EXTENT = r'(?:[ \t]+.*\n|[ \t]*\n|-(?:[ \t].*)?\n|#.*\n)*'
+
+# the extent below a key line carrying a value: a column-0 item after a value
+# is text to YAML, outside the field
+_VALUED_EXTENT = r'(?:[ \t]+.*\n|[ \t]*\n|#.*\n)*'
 
 
 def extract_frontmatter(lines: list[str]) -> tuple[str, int]:
@@ -354,7 +412,9 @@ def build_frontmatter(
         Complete frontmatter block including ``---`` delimiters.
 
     """
-    if '\n' in desc:
+    # a multi-line desc writes as a literal block, unless a line holds a
+    # character no block may carry, which only a double-quoted scalar escapes
+    if ('\n' in desc) and not _ESCAPED_CHARS.search(desc.replace('\n', '')):
         body = '\n'.join(f'  {line}'.rstrip() for line in desc.split('\n'))
         desc_lines = ['desc: |', *body.split('\n')]
     else:
@@ -379,33 +439,89 @@ def strip_blank_lines(frontmatter: str) -> str:
     are repaired away -- but inside a multi-line value it is content: a
     paragraph break in a block (``|``/``>``), plain, or quoted scalar
     that spans lines. A blank run is kept whenever the value continues
-    after it (the next line stays indented), and kept at the end of a
-    keep-chomping block (``|+``/``>+``), whose trailing newlines are
-    themselves the value. Blanks re-emit verbatim, so an over-indented
-    whitespace-only body line keeps its content spaces.
+    after it (the next line stays indented, or a quoted scalar is still
+    open), and kept at the end of a keep-chomping block (``|+``/``>+``),
+    whose trailing newlines are themselves the value -- at any nesting
+    depth, so a ``- k: |+`` item keeps its blank too. Blanks re-emit
+    verbatim, so an over-indented whitespace-only body line keeps its
+    content spaces.
     """
     result = []
     pending = []  # blank lines held verbatim until the next line reveals them
+    in_block = False
+    header_indent = 0
+    block_indent = None  # the body indentation of the open block scalar, once set
     keep_chomp = False
+    quote_char = None  # the quote opening a scalar not yet closed
+    flow_depth = 0  # the brackets of a flow collection not yet closed
+    flow_quote = None  # the quote a line of the open flow collection left open
     for line in frontmatter.split('\n'):
+        # every line of an open quoted scalar or flow collection is content,
+        # blank or not, up to the line that closes it -- or, for a bracket
+        # never closed, up to the key line the line grammar reads next
+        if quote_char is not None:
+            result.extend(pending)
+            pending = []
+            result.append(line)
+            if _quote_close(quote_char + line) != -1:
+                quote_char = None
+            continue
+        if flow_depth and (_key_of(line) is None):
+            if not line.strip():
+                pending.append(line)
+                continue
+            result.extend(pending)
+            pending = []
+            result.append(line)
+            flow_depth, flow_quote = _flow_depth(line, flow_depth, flow_quote)
+            continue
+        flow_depth, flow_quote = 0, None
+        # inside a block scalar a whitespace-only line indented past the body
+        # is content (its extra spaces), so it re-emits with the blanks it ends
         if not line.strip():
-            pending.append(line)
+            if in_block and (block_indent is not None) and (len(line) > block_indent):
+                result.extend(pending)
+                pending = []
+                result.append(line)
+            else:
+                pending.append(line)
             continue
         # an indented line continues a multi-line value, so a preceding blank
         # run is a paragraph break; a keep-chomping block keeps its trailing
         # blanks even where the next line dedents to the following field
-        if line[:1] in (' ', '\t') or keep_chomp:
+        indent = len(line) - len(line.lstrip())
+        if indent or keep_chomp:
             result.extend(pending)
         pending = []
         result.append(line)
-        if line[:1] not in (' ', '\t'):
-            # only a field opening a keep-chomping block owns the blank run
-            # that trails it; every other dedent ends the value
-            key, sep, value = line.partition(':')
-            value = value.strip()
-            field = bool(sep) and not key.strip().startswith('#')
-            block = field and value[:1] in ('|', '>')
-            keep_chomp = block and '+' in value.partition('#')[0]
+        # a line inside the open block's body sets the body indentation
+        if in_block and (indent > header_indent):
+            if block_indent is None:
+                block_indent = indent
+            continue
+        # every other line ends the block; a field or sequence item at any
+        # depth may open a block scalar (only a keep-chomping one owns the
+        # blank run that trails it), a quoted scalar spanning lines, or a
+        # flow collection spanning lines -- a continuation line of a plain
+        # value opens nothing
+        in_block = False
+        keep_chomp = False
+        value = re.sub(r'^(?:[&!]\S*\s+)+', '', _line_value(line))
+        opens = (indent == 0) or (value != line.strip())
+        header = re.fullmatch(r'([|>][-+]?([0-9])?[-+]?)(?:[ \t]+#.*)?', value)
+        if not opens:
+            continue
+        if header is not None:
+            in_block = True
+            header_indent = indent
+            keep_chomp = '+' in header.group(1)
+            # an explicit indentation indicator fixes the body indentation up front
+            digit = header.group(2)
+            block_indent = header_indent + int(digit) if digit else None
+        elif (value[:1] in ('"', "'")) and (_quote_close(value) == -1):
+            quote_char = value[0]
+        elif value[:1] in ('[', '{'):
+            flow_depth, flow_quote = _flow_depth(value, 0)
     # blanks past the closing delimiter sit outside the frontmatter block
     result.extend(pending)
     return '\n'.join(result)
@@ -445,124 +561,89 @@ def repair_frontmatter(
             after all other repairs.
 
     """
+    # a BOM at column 0 is no field's text -- the C loader skips it on any
+    # line, and the line tests below would read a `# comment` behind one as
+    # content -- so it goes, as a file BOM goes on adoption, rather than ride
+    # on a key line the order pass may move
+    frontmatter = re.sub(r'^\ufeff', '', frontmatter, flags=re.MULTILINE)
     # a blank line is never frontmatter structure -- drop strays before
     # any field surgery (block-scalar bodies keep theirs)
     frontmatter = strip_blank_lines(frontmatter)
-    # update name from the path-derived name (add it if the field is
-    # missing, so frontmatter with no name: does not stay un-named)
-    name_field = re.search(r'^name[ \t]*:(.*)$', frontmatter, re.MULTILINE)
-    if name_field:
-        # the refresh spans the field's full extent, so a multi-line value's
-        # body goes with the stale value it continues; callable repls so a
-        # backslash-digit in the name is not read as a group reference
-        fresh = f'name: {quote(name)}\n'
-        value = name_field.group(1).strip()
-        if value.startswith(('|', '>')):
-            # block scalar: the whole indented body goes -- a `#` line or a
-            # blank inside it is content
-            frontmatter = re.sub(
-                pattern=rf'^name[ \t]*:.*\n{FIELD_EXTENT}',
-                repl=lambda _: fresh,
-                string=frontmatter,
-                count=1,
-                flags=re.MULTILINE,
-            )
-        else:
-            # plain value or bare key: every continuation line is value text and
-            # goes -- blank lines included, since strip_blank_lines keeps a blank
-            # whose next line stays indented and a paragraph break belongs to the
-            # stale value being replaced -- while the `# comment` lines among them
-            # re-emit under the fresh name; consuming the full extent means
-            # nothing strands as a continuation of the fresh one-liner
-            def keep_comments(match: re.Match[str]) -> str:
-                lines = match.group(1).splitlines(keepends=True)
-                comments = [line for line in lines if line.lstrip().startswith('#')]
-                return fresh + ''.join(comments)
-
-            frontmatter = re.sub(
-                pattern=rf'^name[ \t]*:.*\n({FIELD_EXTENT})',
-                repl=keep_comments,
-                string=frontmatter,
-                count=1,
-                flags=re.MULTILINE,
-            )
-    else:
-        pos = frontmatter.rfind('---')
-        frontmatter = frontmatter[:pos] + f'name: {quote(name)}\n---'
-    # add desc field if missing (after name line); restore the placeholder on
-    # a present-but-valueless key -- a bare key, a quoted-empty value, or an
-    # empty block scalar (mirrors the title branch's valueless check below),
-    # all of which read as no description; a real block-scalar body is kept
-    desc_match = re.search(
-        pattern=rf'^desc[ \t]*:.*\n{FIELD_EXTENT}',
-        string=frontmatter,
-        flags=re.MULTILINE,
-    )
-    if desc_match:
-        indicator, _, body = desc_match.group(0).partition('\n')
-        if _is_valueless(indicator, body, nulls=('', "''", '""')):
-            # the field's comments ride along with the placeholder
-            tail, comments = _field_comments(indicator, body)
-            frontmatter = (
-                frontmatter[: desc_match.start()]
-                + f'desc: ...{tail}\n{comments}'
-                + frontmatter[desc_match.end() :]
-            )
-    elif not re.search(r'^desc[ \t]*:', frontmatter, re.MULTILINE):
-        frontmatter = re.sub(
-            pattern=r'^(name[ \t]*:.*\n)',
-            repl=r'\1desc: ...\n',
-            string=frontmatter,
-            count=1,
-            flags=re.MULTILINE,
+    # refresh name: from the path-derived name (added if the field is
+    # missing, so frontmatter with no name: does not stay un-named); the
+    # whole extent goes with the stale value, so nothing strands as a
+    # continuation of the fresh one-liner -- a block scalar's indented body
+    # is content, so only a column-0 comment among its lines survives, while
+    # a plain value's continuation lines are value text, so every comment
+    # line among them re-emits under the fresh name
+    span = _field_span(frontmatter, 'name')
+    if span:
+        start, end = span
+        indicator, _, body = frontmatter[start:end].partition('\n')
+        value = _uncommented(indicator.split(':', 1)[1])
+        block = re.sub(r'^(?:[&!]\S*\s+)+', '', value).startswith(('|', '>'))
+        tail, _ = _field_comments(indicator, '')
+        fresh = f'name: {quote(name)}{tail}\n' + _comment_lines(
+            body, indented=not block
         )
+    else:
+        start = _block_end(frontmatter)
+        end = start
+        fresh = f'name: {quote(name)}\n'
+    frontmatter = frontmatter[:start] + fresh + frontmatter[end:]
+    name_end = start + len(fresh)
+    # add desc field if missing (after the name field just written -- whose
+    # span is not read back, since a refresh closing a quote left open above
+    # it can leave a strict reader no name key to find); restore the
+    # placeholder on a present-but-valueless key -- a bare key, a
+    # quoted-empty value, or an empty block scalar (mirrors the title
+    # branch's valueless check below), all of which read as no description;
+    # a real block-scalar body is kept
+    span = _field_span(frontmatter, 'desc')
+    if span:
+        start, end = span
+        indicator, _, body = frontmatter[start:end].partition('\n')
+        if _is_valueless(indicator, body, nulls=('', "''", '""')):
+            # the field's properties and comments ride along with the placeholder
+            tail, comments = _field_comments(indicator, body)
+            placeholder = f'desc: {_properties(indicator)}...{tail}\n{comments}'
+            frontmatter = frontmatter[:start] + placeholder + frontmatter[end:]
+    else:
+        frontmatter = frontmatter[:name_end] + 'desc: ...\n' + frontmatter[name_end:]
     # add created/updated if missing; stamp a present-but-valueless key in
     # place so a duplicate is never appended (created slots before updated)
     frontmatter = _fill_stamp(frontmatter, 'created', now, before='updated')
     frontmatter = _fill_stamp(frontmatter, 'updated', now, before=None)
-    # drop an unset category: absence is the canonical unset form, so a
-    # provably valueless field -- a blank value, the plain lowercase null
-    # spelling, or an empty block scalar -- removes its whole extent
-    # (indicator line plus indented/blank body, so a block scalar goes as
-    # one unit) while its comments stay behind as comment lines; a quoted
-    # or block-scalar 'null' is authored text, kept verbatim, and the field
-    # is never inserted
-    if category:
-        match = re.search(
-            pattern=rf'^category[ \t]*:.*\n{FIELD_EXTENT}',
-            string=frontmatter,
-            flags=re.MULTILINE,
-        )
-        if match:
-            indicator, _, body = match.group(0).partition('\n')
-            if _is_valueless(indicator, body, nulls=('', 'null')):
-                tail, comments = _field_comments(indicator, body)
-                kept = f'{tail.strip()}\n{comments}' if tail else comments
-                frontmatter = (
-                    frontmatter[: match.start()] + kept + frontmatter[match.end() :]
-                )
-    # drop an unset title the same way (the first occurrence wins,
-    # matching every reader); an authored title's slot under name: is
-    # the order pass's job
-    if title:
-        match = re.search(
-            pattern=rf'^title[ \t]*:.*\n{FIELD_EXTENT}',
-            string=frontmatter,
-            flags=re.MULTILINE,
-        )
-        if match:
-            indicator, _, body = match.group(0).partition('\n')
-            if _is_valueless(indicator, body, nulls=('', 'null')):
-                tail, comments = _field_comments(indicator, body)
-                kept = f'{tail.strip()}\n{comments}' if tail else comments
-                frontmatter = (
-                    frontmatter[: match.start()] + kept + frontmatter[match.end() :]
-                )
+    # drop an unset category and title: absence is the canonical unset form,
+    # so a provably valueless field -- a blank value, the plain lowercase null
+    # spelling, or an empty block scalar -- removes its whole extent while its
+    # comments stay behind at column 0, where they are comments after every
+    # neighbor (a block-scalar desc included); a quoted or block-scalar 'null'
+    # is authored text, kept verbatim, and neither field is ever inserted;
+    # every leading valueless copy goes, since the first occurrence wins for
+    # every reader and the run stops at the first copy carrying a value
+    for key, unset in (('category', category), ('title', title)):
+        if not unset:
+            continue
+        while span := _field_span(frontmatter, key):
+            start, end = span
+            indicator, _, body = frontmatter[start:end].partition('\n')
+            if not _is_valueless(indicator, body, nulls=('', 'null')):
+                break
+            tail, comments = _field_comments(indicator, body)
+            kept = [tail.strip()] if tail else []
+            kept.extend(line.lstrip() for line in comments.split('\n') if line)
+            frontmatter = (
+                frontmatter[:start]
+                + ''.join(f'{line}\n' for line in kept)
+                + frontmatter[end:]
+            )
     # enforce the canonical field order LAST: the insertions above anchor
     # on schema neighbors and authored fields start anywhere, so the full
-    # reorder must have the final word
+    # reorder must have the final word -- and a blank an open quote above it
+    # kept is a stray once the move puts the quote below it
     if order:
-        frontmatter = order_frontmatter(frontmatter)
+        frontmatter = strip_blank_lines(order_frontmatter(frontmatter))
     return frontmatter
 
 
@@ -572,25 +653,42 @@ def order_frontmatter(frontmatter: str) -> str:
     Fields land as ``name``, ``title``, ``desc``, ``category``,
     ``tags``, ``sources``, then any unrecognized authored keys in their
     original relative order, with the tool-owned ``created``/``updated``
-    tail closing the block. Each field moves as its full extent --
-    indicator line plus indented/blank body -- byte-verbatim, so a block
-    scalar never strands its continuation lines. Duplicate keys stay
-    adjacent in original order, so a first-occurrence read resolves to
-    the same value after the move. Non-field lines above the first key
-    stay above it.
+    tail closing the block. Each field moves as its full extent -- its
+    key line through the line before the next key (:func:`_field_span`)
+    -- byte-verbatim, so a block scalar, a quoted scalar continued at
+    column 0, or a flow collection spanning lines never strands its
+    continuation lines. Duplicate keys stay adjacent in original order,
+    so a first-occurrence read resolves to the same value after the
+    move. Non-field lines above the first key stay above it, and a
+    document-end ``...`` marker above the closing delimiter stays there.
+    A block carrying an alias is returned as written: an alias must
+    follow its anchor, so moving either would break the block.
     """
+    _, _, _, _, aliased = _compose_fields(frontmatter)
+    if aliased:
+        return frontmatter
     lines = frontmatter.split('\n')
+    end = _end_line(lines)
     # group the body (between the delimiters) into per-field extents: a
-    # key line opens an extent, every other line continues the open one
-    # (the field_line_ranges grammar), and lines before the first key
-    # hold as a preamble
+    # key line opens an extent, every other line continues the open one,
+    # and lines before the first key hold as a preamble
+    key_at = _key_at(frontmatter)
     extents: list[tuple[str, list[str]]] = []
     preamble = []
     current = None
-    for line in lines[1:-1]:
-        match = re.match(r'^([\w.-]+)[ \t]*:(?:[ \t]|$)', line)
-        if match:
-            current = (match.group(1), [line])
+    for index in range(1, end):
+        line = lines[index]
+        if key_at is not None:
+            key = key_at.get(index)
+            # a key spelled outside the line grammar (one with spaces, the
+            # merge driver's repair hint) rides with the field before it
+            # rather than moving as a field of its own
+            if (key is not None) and not re.fullmatch(r'[\w.-]+', key):
+                key = None
+        else:
+            key = _key_of(line)
+        if key is not None:
+            current = (key, [line])
             extents.append(current)
         elif current is not None:
             current[1].append(line)
@@ -613,20 +711,20 @@ def order_frontmatter(frontmatter: str) -> str:
     result = [lines[0], *preamble]
     for _, extent_lines in extents:
         result.extend(extent_lines)
-    result.append(lines[-1])
+    result.extend(lines[end:])
     return '\n'.join(result)
 
 
 def seed_frontmatter_title(frontmatter: str, title: Optional[str] = None) -> str:
-    """Seed a ``title:`` line directly under ``name:`` when none exists.
+    """Seed a ``title:`` line directly under the ``name:`` field when none exists.
 
     ``title`` is the value to seed -- adopting a bare page preserves its
     authored H1 this way -- and ``None`` seeds the ``title: null``
     placeholder required-titles mode demands. Frontmatter already
-    carrying a ``title:`` line is returned unchanged: the field is
+    carrying a ``title`` field is returned unchanged: the field is
     authored, so a present line is never overwritten.
     """
-    if re.search(r'^title[ \t]*:', frontmatter, re.MULTILINE):
+    if _field_span(frontmatter, 'title') is not None:
         return frontmatter
     if title is None:
         value = 'null'
@@ -634,14 +732,9 @@ def seed_frontmatter_title(frontmatter: str, title: Optional[str] = None) -> str
         # quote the reserved lowercase null spelling: an authored H1
         # reading "null" must read back as text, not the placeholder
         value = "'null'" if title == 'null' else quote(title)
-    # callable repl so a backslash-digit in the title is not read as a group reference
-    return re.sub(
-        pattern=r'^(name[ \t]*:.*\n)',
-        repl=lambda match: f'{match.group(1)}title: {value}\n',
-        string=frontmatter,
-        count=1,
-        flags=re.MULTILINE,
-    )
+    span = _field_span(frontmatter, 'name')
+    pos = span[1] if span else _block_end(frontmatter)
+    return frontmatter[:pos] + f'title: {value}\n' + frontmatter[pos:]
 
 
 def replace_heading(content: str, name: str) -> str:
@@ -667,8 +760,74 @@ def is_nonmapping_frontmatter(frontmatter: str) -> bool:
     or repair; the planners keep such a page as written and report it
     rather than append fields under the text.
     """
-    kind, _, _ = _compose_fields(frontmatter)
+    kind, _, _, _, _ = _compose_fields(frontmatter)
     return kind == 'nonmapping'
+
+
+def is_unaddressable_frontmatter(frontmatter: str) -> bool:
+    """Return whether the block is a mapping whose keys no byte-level writer can reach.
+
+    A flow mapping (``{name: x}``) or a mapping indented as a whole has
+    no column-0 ``key:`` lines for the repair to refresh, fill, or
+    reorder, so appending fields under it would break the block; the
+    planners keep such a page as written and report it, while the
+    reader still reads its fields through the parser.
+    """
+    kind, _, _, keys, _ = _compose_fields(frontmatter)
+    return (kind == 'mapping') and not keys
+
+
+def repair_breaks_frontmatter(before: str, after: str) -> bool:
+    """Return whether a repair turned a block every strict reader accepts into one they reject, or wrote its fields where none finds them.
+
+    The byte-level repair edits by line grammar; a block it cannot
+    address safely is kept as written by the planners rather than
+    rewritten into a parse error -- or, when the block it leaves
+    composes, into a scalar that swallowed the ``name``, ``desc``,
+    ``created``, or ``updated`` line the repair wrote, or an authored key
+    line the line grammar read (a quote the grammar cannot see closing
+    around them). A tool-owned field whose composed extent holds a
+    key-shaped line is refused too: the rewrite of its extent would
+    delete the line a strict reader folded into the value.
+    """
+    before_kind, _, before_issues, _, _ = _compose_fields(before)
+    kind, fields, issues, _, _ = _compose_fields(after)
+    if issues and not before_issues:
+        return True
+    if kind == 'invalid':
+        return False
+    # the repair writes every one of these keys: a block that composes without
+    # one took the write inside a scalar
+    required = {'name', 'desc', *_FRONTMATTER_TAIL}
+    if before_kind == 'mapping':
+        # a key-shaped or item-shaped line folded into a quoted tool-owned
+        # value is authored structure the extent rewrite would delete; the
+        # scan spans the open quote alone -- a comment line after the closing
+        # quote is one the repair re-emits, no reason to refuse
+        for key in ('name', *_FRONTMATTER_TAIL):
+            field = _compose_fields(before)[1].get(key)
+            if (field is None) or (field[1] not in ('"', "'")):
+                continue
+            text = field_text(before, key) or ''
+            span_lines = text.split('\n')
+            value = re.sub(
+                r'^(?:[&!]\S*(?:\s+|$))+', '', span_lines[0].split(':', 1)[1].strip()
+            )
+            if (value[:1] not in ('"', "'")) or (_quote_close(value) != -1):
+                continue
+            for line in span_lines[1:]:
+                if re.match(r'^(?:\S.*?)?:(?:[ \t]|$)', line) or re.match(
+                    r'-(?:[ \t]|$)', line
+                ):
+                    return True
+                if _quote_close(value[0] + line.strip()) != -1:
+                    break
+    else:
+        # every key the line grammar read must survive, bar the unset title
+        # and category the repair removes
+        grammar = {key for line in before.split('\n') if (key := _key_of(line))}
+        required |= grammar - {'title', 'category'}
+    return any(key not in fields for key in required)
 
 
 def frontmatter_issues(frontmatter: str) -> list[_Issue]:
@@ -680,8 +839,67 @@ def frontmatter_issues(frontmatter: str) -> list[_Issue]:
     or a ``'duplicate_key'``. An empty list is a block every strict
     reader accepts as a mapping with unique scalar keys.
     """
-    _, _, issues = _compose_fields(frontmatter)
+    _, _, issues, _, _ = _compose_fields(frontmatter)
     return list(issues)
+
+
+def field_text(frontmatter: str, key: str) -> Optional[str]:
+    """Return the raw text of ``key``'s field -- its key line and continuation lines -- or ``None``.
+
+    The extent :func:`_field_span` bounds: the composed marks' when the
+    block composes, the line grammar's otherwise.
+    """
+    span = _field_span(frontmatter, key)
+    if span is None:
+        return None
+    start, end = span
+    return frontmatter[start:end]
+
+
+def is_collection_field(frontmatter: str, key: str) -> bool:
+    """Return whether ``key`` carries a sequence or mapping in a block the parser accepts."""
+    fields = _scalar_fields(frontmatter)
+    return bool(fields) and (key in fields) and (fields[key] is None)
+
+
+def comment_cuts_desc(frontmatter: str) -> bool:
+    """Return whether a ``' #'`` comment shortened a plain ``desc`` a strict reader accepts.
+
+    Only a plain scalar loses text to a comment, and only a block the
+    parser accepts reads through the parser; the field's raw extent is
+    searched for the comment start, key line and continuation lines
+    alike.
+    """
+    fields = _scalar_fields(frontmatter)
+    if not fields or (fields.get('desc') is None):
+        return False
+    _, style, _ = fields['desc']
+    if style is not None:
+        return False
+    text = field_text(frontmatter, 'desc') or ''
+    # only a comment start after value text on a value line cuts anything
+    lines = [line for line in text.split('\n') if not line.lstrip().startswith('#')]
+    return re.search(r'\S[ \t]+#', '\n'.join(lines)) is not None
+
+
+def restamp_updated(frontmatter: str, now: str) -> str:
+    """Rewrite the ``updated`` stamp to ``now``, its comments riding along.
+
+    The field's whole extent is replaced, so a stamp continued on
+    indented lines never strands under the fresh one; the key line's
+    tail comment re-attaches after the stamp, an anchor on it stays on
+    the stamp (an alias of it elsewhere keeps resolving), and the
+    comment lines under it stay. A block without the field gains it
+    before the closing delimiter.
+    """
+    span = _field_span(frontmatter, 'updated')
+    if span is None:
+        return _fill_stamp(frontmatter, 'updated', now, before=None)
+    start, end = span
+    indicator, _, body = frontmatter[start:end].partition('\n')
+    tail, comments = _field_comments(indicator, body)
+    stamp = f'updated: {_properties(indicator)}{quote(now)}{tail}\n{comments}'
+    return frontmatter[:start] + stamp + frontmatter[end:]
 
 
 def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
@@ -693,30 +911,38 @@ def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
     wants the text, not the chomping) -- and never a coerced type: a
     stamp stays its source text. The first occurrence of a duplicated
     key wins. Returns ``None`` when the field is absent or a bare
-    ``key:`` has no body. A sequence or mapping value, a block the
-    parser rejects, and a body that is not a mapping fall back to the
-    line grammar (:func:`_read_field_lines`), so the wiki's leniencies --
-    an unquoted ``': '`` inside a one-line value, conflict markers -- still
-    read through it.
+    ``key:`` has no body. A sequence or mapping value reads as its
+    source lines joined; a body that is not a mapping has no fields; a
+    block the parser rejects falls back to the line grammar
+    (:func:`_read_field_lines`), so the wiki's leniencies -- an unquoted
+    ``': '`` inside a one-line value, conflict markers -- still read
+    through it.
     """
     fields = _scalar_fields(frontmatter)
     if fields is None:
-        return _read_field_lines(frontmatter, key)
-    if key not in fields:
-        return None
-    entry = fields[key]
-    if entry is None:
-        return _read_field_lines(frontmatter, key)
-    value, style, _ = entry
+        value = _read_field_lines(frontmatter, key)
+    elif key not in fields:
+        value = None
+    elif fields[key] is None:
+        # a sequence or mapping is never resolved: its source lines, comments
+        # dropped, join into the text the search index tokenizes (a mapping
+        # the line grammar cannot place has no lines to give)
+        text = field_text(frontmatter, key)
+        value = _collection_text(text) if text is not None else None
+    else:
+        value, style, _ = fields[key]
+        # a block scalar's final breaks are chomping, not content
+        if style in ('|', '>'):
+            value = value.rstrip('\n')
+        # a bare key with no body reads as an absent value
+        elif (style is None) and (value == ''):
+            value = None
     # a carriage return (a "\r" escape) would split the line model every
-    # consumer relies on, so it reads as the line break it is
-    value = value.replace('\r\n', '\n').replace('\r', '\n')
-    # a block scalar's final breaks are chomping, not content
-    if style in ('|', '>'):
-        return value.rstrip('\n')
-    # a bare key with no body reads as an absent value
-    if (style is None) and (value == ''):
-        return None
+    # consumer relies on, so it reads as the line break it is; a NUL (a "\0"
+    # escape) would turn every markdown surface it lands on binary to git, so
+    # it goes
+    if value is not None:
+        value = value.replace('\r\n', '\n').replace('\r', '\n').replace('\x00', '')
     return value
 
 
@@ -791,7 +1017,7 @@ def read_frontmatter_category(frontmatter: str) -> str:
     return join_lines(value or '')
 
 
-def field_value(line: str) -> str:
+def field_value(line: str, key: Optional[str] = None) -> str:
     """Extract one frontmatter line's value for per-line matching.
 
     Strips a ``key:`` prefix and surrounding YAML quotes
@@ -799,12 +1025,48 @@ def field_value(line: str) -> str:
     per-line field-mode extraction, kept beside the quoting rules it
     inverts. Unlike :func:`read_frontmatter_field`, which resolves the
     joined value of a whole field, this reads a single line so matches
-    keep their line numbers.
+    keep their line numbers. ``key`` is the composed key the line opens
+    (:func:`line_keys`), so a key spelled outside the line grammar (one
+    with spaces, one whose quotes escape or double a quote) strips too;
+    ``''`` says the composed block opens no key on the line (a quoted
+    scalar's continuation, whatever its shape), so nothing strips; ``None``
+    leaves the line grammar's key shape to strip.
     """
-    match = re.match(r'^([\w.-]+)[ \t]*:(?:[^\S\n]+|$)', line)
-    if match:
-        return unquote(line[match.end() :].strip())
-    return line.strip()
+    if key == '':
+        return line.strip()
+    if key is None:
+        opener = r'(?:"[^"]*"|\'[^\']*\'|[\w.-]+)'
+    else:
+        # the line is known to open the key: any quoted spelling at its
+        # start is that key, however the quotes decode
+        spelled = re.escape(key)
+        opener = (
+            rf'(?:"{spelled}"|\'{spelled}\'|{spelled}'
+            r'|"(?:[^"\\]|\\.)*"|\'(?:[^\']|\'\')*\')'
+        )
+    match = re.match(rf'^(?:[&!]\S*[ \t]+)*{opener}[ \t]*:(?:[^\S\n]+|$)', line)
+    if not match:
+        return line.strip()
+    # a node property is not the value, and neither is a comment after it:
+    # past the closing quote of a quoted one, from the ' #' of a plain one
+    value = re.sub(r'^(?:[&!]\S*[ \t]+)+', '', line[match.end() :].strip())
+    if value[:1] in ('"', "'"):
+        # a quote closing on a later line: the opening quote is not value
+        # text; one mid-text (an apostrophe) is content
+        close = _quote_close(value)
+        return unquote(value + value[0] if close == -1 else value[: close + 1])
+    return unquote(_uncommented(value))
+
+
+def line_keys(frontmatter: str) -> dict[int, str]:
+    """Return the composed key opening each 1-based file line of the block.
+
+    The block opens the file, so its line ``n`` is file line ``n + 1``;
+    a block the parser rejects, or one whose keys the line grammar
+    cannot place, names no key here and reads through the line grammar.
+    """
+    key_at = _key_at(frontmatter) or {}
+    return {line + 1: key for line, key in key_at.items()}
 
 
 def body_words(text: str) -> int:
@@ -828,7 +1090,9 @@ def field_line_ranges(
 
     Walks the frontmatter region of ``lines`` and collects line
     numbers for each field key line and its continuation lines
-    (multi-line block scalars).
+    (multi-line block scalars). The composed marks say which lines
+    open a field when the block composes; the line grammar does
+    otherwise.
 
     Args:
         frontmatter: Parsed frontmatter string (including delimiters).
@@ -838,30 +1102,34 @@ def field_line_ranges(
     """
     # initialize result
     result = set()
-    frontmatter_end = len(frontmatter.split('\n'))
+    end = _end_line(frontmatter.split('\n'))
+    key_at = _key_at(frontmatter)
     current_field = None
-    for lineno, line in enumerate(lines, 1):
-        if lineno >= frontmatter_end:
-            break
+    for index in range(1, end):
+        line = lines[index]
+        lineno = index + 1
         # check for field key
-        match = re.match(r'^([\w.-]+)[ \t]*:(?:[ \t]|$)', line)
-        if match:
-            current_field = match.group(1)
+        if key_at is not None:
+            key = key_at.get(index)
+        else:
+            key = _key_of(line)
+        if key is not None:
+            current_field = key
             if current_field in fields:
                 result.add(lineno)
             continue
-        # a dedented field line whose key sits outside the key grammar (e.g.
-        # one with spaces) still ends the current field -- its line and block
-        # body must not attribute to the preceding field -- while a dedented
-        # sequence item (`- https://...`) or a flow continuation (`https://b]`)
-        # continues it, colon and all: only a colon followed by a space or
-        # the line end makes a key
-        dedented = line[:1] not in (' ', '\t')
-        item = re.match(r'-(?:[ \t]|$)', line) is not None
-        keyed = re.search(r':(?:[ \t]|$)', line) is not None
-        if dedented and keyed and not line.startswith('#') and not item:
-            current_field = None
-            continue
+        # under the line grammar a dedented field line whose key sits outside
+        # the key grammar (e.g. one with spaces) still ends the current field
+        # -- its line and block body must not attribute to the preceding
+        # field -- while a dedented sequence item (`- https://...`) or a flow
+        # continuation (`https://b]`) continues it, colon and all: only a
+        # colon followed by a space or the line end makes a key
+        if key_at is None:
+            dedented = line[:1] not in (' ', '\t')
+            item = re.match(r'-(?:[ \t]|$)', line) is not None
+            if dedented and line.strip() and not line.startswith('#') and not item:
+                current_field = None
+                continue
         # continuation line of current field
         if current_field in fields:
             result.add(lineno)
@@ -1006,10 +1274,7 @@ def quote(value: str) -> str:
     """
     if _ESCAPED_CHARS.search(value):
         escaped = value.replace('\\', '\\\\').replace('"', '\\"')
-        escaped = _ESCAPED_CHARS.sub(
-            repl=lambda match: f'\\u{ord(match.group(0)):04x}',
-            string=escaped,
-        )
+        escaped = _ESCAPED_CHARS.sub(repl=_escape, string=escaped)
         return f'"{escaped}"'
     if not _is_plain_safe(value):
         escaped = value.replace("'", "''")
@@ -1030,7 +1295,7 @@ def unquote(value: str) -> str:
         body = value[1:-1]
         if value[0] == '"':
             return re.sub(
-                pattern=r'\\(?:u([0-9a-fA-F]{4})|x([0-9a-fA-F]{2})|(.))',
+                pattern=r'\\(?:U([0-9a-fA-F]{8})|u([0-9a-fA-F]{4})|x([0-9a-fA-F]{2})|(.))',
                 repl=_unescape,
                 string=body,
             )
@@ -1209,9 +1474,172 @@ def wrapped_marker_lines(masked: str, text: str) -> list[int]:
 # ------ helper functions
 
 
-def _uncommented(text: str) -> str:
-    """Return ``text`` without a ``# comment`` -- one leading it or following whitespace."""
-    return re.sub(r'(?:^|\s)#.*', '', text).strip()
+def _uncommented(text: str, quote: Optional[str] = None) -> str:
+    """Return ``text`` without a ``# comment`` -- one leading it or following whitespace.
+
+    A ``#`` inside a quoted scalar (one opening where a value starts, closed
+    or not) is text; a quote inside a plain value (``rock 'n roll``) opens
+    nothing. ``quote`` carries a span a previous line left open -- its
+    content, ``#`` included, is text up to the closing quote.
+    """
+    index = 0
+    prev = None  # the last non-whitespace character; None where a value starts
+    if quote is not None:
+        close = _flow_close(quote + text)
+        if close == -1:
+            return text.strip()
+        index = close
+        prev = quote
+    while index < len(text):
+        char = text[index]
+        if (char in ('"', "'")) and ((prev is None) or (prev in '[{,:-?')):
+            close = _flow_close(text, index)
+            if close == -1:
+                break
+            index = close + 1
+            prev = char
+            continue
+        if (char == '#') and ((index == 0) or text[index - 1].isspace()):
+            return text[:index].strip()
+        if not char.isspace():
+            prev = char
+        index += 1
+    return text.strip()
+
+
+def _properties(indicator: str) -> str:
+    """Return the ``&anchor``/``!tag`` properties leading a key line's value, trailing space included."""
+    match = re.match(r'\s*((?:[&!]\S*\s*)+)', indicator.split(':', 1)[1])
+    if match is None:
+        return ''
+    return ' '.join(match.group(1).split()) + ' '
+
+
+def _flow_depth(
+    text: str,
+    depth: int,
+    quote: Optional[str] = None,
+    *,
+    bound: Optional[int] = None,
+) -> tuple[int, Optional[str]]:
+    """Return the flow-collection nesting depth after ``text`` and the quote it leaves open.
+
+    ``[`` and ``{`` open a level, ``]`` and ``}`` close one; a quoted
+    scalar -- one opening where a value starts on this line (the line
+    start, or after ``[``, ``{``, ``,``, ``:``, ``-``, ``?``), or
+    ``quote`` left open by the line above -- is text up to its closing
+    quote, and a ``#`` after whitespace ends the line as a comment. With
+    ``bound`` the walk stops at the first bracket nesting past it, depth
+    past the bound returned.
+    """
+    index = 0
+    prev = None  # the last non-whitespace character; None where a value starts
+    if quote is not None:
+        close = _flow_close(quote + text)
+        if close == -1:
+            return depth, quote
+        index = close
+        prev = quote
+    while index < len(text):
+        char = text[index]
+        if (char in ('"', "'")) and ((prev is None) or (prev in '[{,:-?')):
+            close = _flow_close(text, index)
+            if close == -1:
+                return depth, char
+            index = close + 1
+            prev = char
+            continue
+        if (char == '#') and ((index == 0) or text[index - 1].isspace()):
+            return depth, None
+        if char in ('[', '{'):
+            depth += 1
+            if (bound is not None) and (depth > bound):
+                return depth, None
+        elif char in (']', '}'):
+            depth = max(depth - 1, 0)
+        if not char.isspace():
+            prev = char
+        index += 1
+    return depth, None
+
+
+def _nested_too_deep(body: str) -> Optional[int]:
+    """Return the body line where collections nest past :data:`_MAX_NESTING`, or ``None``.
+
+    Flow brackets nest from a value opening with one, across the lines
+    that continue it (quoted spans and comments skipped); a run of
+    ``- ``/``? `` indicators opening a line nests within it. A block
+    scalar's body and the continuation lines of a plain or quoted value
+    are text, whatever they hold.
+    """
+    depth = 0
+    quote = None
+    body_indent = None  # the header indentation of an open block scalar
+    value_indent = None  # the indentation of a key whose value continues below
+    for lineno, line in enumerate(body.split('\n')):
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if (body_indent is not None) and (indent > body_indent):
+            continue
+        body_indent = None
+        if (value_indent is not None) and (indent > value_indent):
+            continue
+        value_indent = None
+        # inside an open flow collection every line continues it
+        if depth:
+            depth, quote = _flow_depth(line, depth, quote, bound=_MAX_NESTING)
+            if depth > _MAX_NESTING:
+                return lineno
+            continue
+        chain = re.match(r'\s*((?:[-?]\s+)*)', line)
+        if len(chain.group(1).split()) > _MAX_NESTING:
+            return lineno
+        value = re.sub(r'^(?:[&!]\S*(?:\s+|$))+', '', _line_value(line))
+        if re.fullmatch(r'[|>][-+0-9]*(?:[ \t]+#.*)?', value):
+            body_indent = indent
+        elif value[:1] in ('[', '{'):
+            depth, quote = _flow_depth(value, 0, bound=_MAX_NESTING)
+            if depth > _MAX_NESTING:
+                return lineno
+        elif value:
+            value_indent = indent
+    return None
+
+
+def _collection_text(text: str) -> Optional[str]:
+    """Join a collection field's source lines into one text: the key line's value, then the lines under it.
+
+    Comment lines and ``' #'`` tails drop (a ``#`` inside a quoted item
+    stays, the quote carried across the lines it wraps over), as do the
+    node properties before the collection; the rest joins with single
+    spaces, so the search index tokenizes every item wherever the
+    collection's lines break.
+    """
+    key_line, _, body = text.partition('\n')
+    value = re.sub(r'^(?:[&!]\S*(?:\s+|$))+', '', key_line.split(':', 1)[1].strip())
+    kept = []
+    quote = None
+    for line in (value, *body.split('\n')):
+        if (quote is None) and line.lstrip().startswith('#'):
+            continue
+        kept.append(_uncommented(line, quote))
+        _, quote = _flow_depth(line, 0, quote)
+    return ' '.join(line for line in kept if line) or None
+
+
+def _line_value(line: str) -> str:
+    """Return the value text a frontmatter line opens: past its ``- `` markers and its ``key: ``.
+
+    A comment line opens nothing.
+    """
+    text = line.strip()
+    if text.startswith('#'):
+        return ''
+    text = re.sub(r'^(?:-[ \t]+)+', '', text)
+    return re.sub(
+        r'^(?:"[^"]*"|\'[^\']*\'|[^\s#"\'][^:]*)[ \t]*:(?:[ \t]+|$)', '', text
+    )
 
 
 def _is_valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
@@ -1219,16 +1647,43 @@ def _is_valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
 
     Comments are not a value: ``null # why`` resets like ``null``,
     ``| # note`` is an empty block like ``|``, and a body of comment lines
-    is no body. The field is valueless when what remains -- on the
-    indicator line, or continued in the body -- is one of the ``nulls``
-    spellings, or a bare block header over no body at all (a block's body
-    is content, comment-shaped lines included).
+    is no body; neither is a node property over nothing (``&c`` alone
+    anchors a null, ``!!str`` alone tags an empty string), while a tag
+    over a spelled value types it as text (``!!str null`` is the word).
+    The field is valueless when what remains -- on the indicator line, or
+    continued in the body -- is one of the ``nulls`` spellings, or a bare
+    block header over no body at all (a block's indented body is content,
+    comment-shaped lines included; a column-0 comment ends the block).
     """
+    properties = _properties(indicator)
     value = _uncommented(indicator.split(':', 1)[1])
+    value = re.sub(r'^(?:[&!]\S*(?:\s+|$))+', '', value)
     if re.fullmatch(r'[|>][-+0-9]*', value):
-        return not body.strip()
+        content = [line for line in body.split('\n') if not line.startswith('#')]
+        return not ''.join(content).strip()
+    if ('!' in properties) and (value not in ('', "''", '""')):
+        return False
+    # the indicator's text and the body fold into one plain scalar, so
+    # `null` over `null` is the text "null null", not the idiom
     content = ' '.join(_uncommented(line) for line in body.split('\n')).strip()
-    return (value in nulls) and (content in nulls)
+    folded = ' '.join(part for part in (value, content) if part)
+    return folded in nulls
+
+
+def _comment_lines(body: str, *, indented: bool = True) -> str:
+    """Return the comment lines of a field body, newline-terminated and in order.
+
+    Beside a plain or quoted value every line opening with ``#`` after
+    optional indentation is a comment; inside a block scalar an indented
+    one is content, so ``indented=False`` keeps the column-0 ones alone.
+    Lines split on newlines only: a Unicode line separator inside a
+    comment is comment text.
+    """
+    lines = body.split('\n')
+    comments = [line for line in lines if line.lstrip().startswith('#')]
+    if not indented:
+        comments = [line for line in comments if line.startswith('#')]
+    return ''.join(f'{line}\n' for line in comments)
 
 
 def _field_comments(indicator: str, body: str) -> tuple[str, str]:
@@ -1236,12 +1691,20 @@ def _field_comments(indicator: str, body: str) -> tuple[str, str]:
 
     The tail keeps a leading space so it re-attaches after a written value;
     the lines keep their indentation and breaks so they re-emit under it.
+    A ``#`` inside a quoted value is text: the tail starts past the
+    closing quote.
     """
-    match = re.search(r'(?:^|\s)(#.*)$', indicator.split(':', 1)[1])
+    value = indicator.split(':', 1)[1]
+    # the quote test looks past the node properties leading the value
+    stripped = re.sub(r'^(?:[&!]\S*\s+)+', '', value.lstrip())
+    start = 0
+    if stripped[:1] in ('"', "'"):
+        close = _quote_close(stripped)
+        if close != -1:
+            start = len(value) - len(stripped) + close + 1
+    match = re.search(r'(?:^|\s)(#.*)$', value[start:])
     tail = f' {match.group(1)}' if match else ''
-    lines = body.splitlines(keepends=True)
-    comments = ''.join(line for line in lines if line.lstrip().startswith('#'))
-    return tail, comments
+    return tail, _comment_lines(body)
 
 
 def _fill_stamp(frontmatter: str, key: str, now: str, *, before: Optional[str]) -> str:
@@ -1251,128 +1714,402 @@ def _fill_stamp(frontmatter: str, key: str, now: str, *, before: Optional[str]) 
     -- when its value is blank, quoted-empty, or comments only, and the
     comments ride along; a key over a real value (a stamp continued on an
     indented line, a sequence) stays for lint to judge. A missing key is
-    inserted before ``before`` when that key is present, else before the
-    closing delimiter. ``now`` is quoted whenever a plain scalar would
-    misread it, and spliced rather than substituted so a backslash in a
-    user ``timestamp.format`` is emitted verbatim.
+    inserted before ``before`` when that key is present, else at the
+    block's end. ``now`` is quoted whenever a plain scalar would misread
+    it, and spliced rather than substituted so a backslash in a user
+    ``timestamp.format`` is emitted verbatim; an anchor on the key line
+    stays on the stamp, so an alias of it elsewhere keeps resolving.
     """
-    match = re.search(
-        pattern=rf'^{key}[ \t]*:(.*)\n({FIELD_EXTENT})',
-        string=frontmatter,
-        flags=re.MULTILINE,
-    )
     # stamp a present-but-valueless key in place
-    if match:
-        indicator, _, body = match.group(0).partition('\n')
+    span = _field_span(frontmatter, key)
+    if span:
+        start, end = span
+        indicator, _, body = frontmatter[start:end].partition('\n')
         if _is_valueless(indicator, body, nulls=('', "''", '""')):
             tail, comments = _field_comments(indicator, body)
-            stamp = f'{key}: {quote(now)}{tail}\n{comments}'
-            frontmatter = (
-                frontmatter[: match.start()] + stamp + frontmatter[match.end() :]
-            )
+            stamp = f'{key}: {_properties(indicator)}{quote(now)}{tail}\n{comments}'
+            frontmatter = frontmatter[:start] + stamp + frontmatter[end:]
         return frontmatter
-    # insert a missing key before its schema neighbor, else the closing delimiter
-    anchor = None
-    if before is not None:
-        anchor = re.search(rf'^{before}[ \t]*:', frontmatter, re.MULTILINE)
-    pos = anchor.start() if anchor else frontmatter.rfind('---')
+    # insert a missing key before its schema neighbor, else at the block's end
+    anchor = _field_span(frontmatter, before) if before is not None else None
+    pos = anchor[0] if anchor else _block_end(frontmatter)
     return frontmatter[:pos] + f'{key}: {quote(now)}\n' + frontmatter[pos:]
 
 
+def _key_at(frontmatter: str) -> Optional[dict[int, str]]:
+    """Map each key line's 0-based block line to its key, or ``None`` to defer to the line grammar.
+
+    The composed marks partition a block that composes as a mapping the
+    writers can address; a block the parser rejects and a mapping with no
+    column-0 keys read through the line grammar, while a body that is not
+    a mapping has no key lines at all.
+    """
+    kind, _, _, keys, _ = _compose_fields(frontmatter)
+    if kind == 'nonmapping':
+        return {}
+    if (kind != 'mapping') or not keys:
+        return None
+    return {line: key for key, line in keys}
+
+
+def _end_line(lines: list[str]) -> int:
+    """Return the block line where appended fields go: the closing fence, or the epilogue above it.
+
+    A ``...`` document-end marker (a comment after it allowed) and the
+    comment lines below it stay the block's last lines, outside every
+    field.
+    """
+    end = len(lines) - 1
+    index = end - 1
+    while (index > 0) and re.match(r'[ \t]*#', lines[index]):
+        index -= 1
+    if (index > 0) and re.fullmatch(r'\.\.\.(?:[ \t]+#.*)?[ \t]*', lines[index]):
+        return index
+    return end
+
+
+def _block_end(frontmatter: str) -> int:
+    """Return the character offset of :func:`_end_line`."""
+    lines = frontmatter.split('\n')
+    return sum(len(line) + 1 for line in lines[: _end_line(lines)])
+
+
+def _field_span(frontmatter: str, key: str) -> Optional[tuple[int, int]]:
+    """Return the character span of ``key``'s first field, or ``None`` when absent.
+
+    A field is its key line through the line before the next key. The
+    composed marks bound it when the block composes as a mapping the
+    writers can address, so a quoted key, a quoted scalar continued at
+    column 0, and a flow collection spanning lines each stay one field;
+    otherwise the line grammar does -- the key line plus its
+    :data:`FIELD_EXTENT`. The last field runs to the block's end, a
+    trailing document-end marker excluded.
+    """
+    kind, _, _, keys, _ = _compose_fields(frontmatter)
+    if (kind == 'mapping') and keys:
+        lines = frontmatter.split('\n')
+        for position, (name, line) in enumerate(keys):
+            if name != key:
+                continue
+            end = (
+                keys[position + 1][1] if position + 1 < len(keys) else _end_line(lines)
+            )
+            start_offset = sum(len(text) + 1 for text in lines[:line])
+            end_offset = sum(len(text) + 1 for text in lines[:end])
+            return start_offset, end_offset
+        return None
+    match = re.search(
+        pattern=rf'{_key_pattern(key)}(.*)\n{FIELD_EXTENT}',
+        string=frontmatter,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        return None
+    # a column-0 item is the value of a bare key alone (properties and a
+    # comment aside): after a value on the key line it is text, outside the field
+    value = re.sub(r'^(?:[&!]\S*(?:\s+|$))+', '', _uncommented(match.group(1)))
+    if value:
+        match = re.search(
+            pattern=rf'{_key_pattern(key)}.*\n{_VALUED_EXTENT}',
+            string=frontmatter,
+            flags=re.MULTILINE,
+        )
+    return match.span()
+
+
+def _key_pattern(key: str) -> str:
+    """Return the line grammar's regex for ``key``'s key line, quoted or not, up to its colon."""
+    spelled = re.escape(key)
+    return (
+        rf'^(?:[&!]\S*[ \t]+)*(?:"{spelled}"|\'{spelled}\'|{spelled})[ \t]*:(?=[ \t]|$)'
+    )
+
+
+def _key_of(line: str) -> Optional[str]:
+    """Return the key a line opens under the line grammar, or ``None``."""
+    match = re.match(_KEY_LINE, line)
+    if match is None:
+        return None
+    return next(group for group in match.groups() if group is not None)
+
+
+def _compose_fields(
+    frontmatter: str,
+) -> tuple[str, _Fields, tuple[_Issue, ...], _Keys, bool]:
+    """Compose a frontmatter block, through the memo for a block of ordinary size.
+
+    See :func:`_compose_cached` for the result; a block past
+    :data:`_SCALAR_CACHE_BYTES` composes on every read rather than pin
+    its text in the memo for the run.
+    """
+    if len(frontmatter) > _SCALAR_CACHE_BYTES:
+        return _compose_cached.__wrapped__(frontmatter)
+    return _compose_cached(frontmatter)
+
+
 @functools.lru_cache(maxsize=_SCALAR_CACHE_SIZE)
-def _compose_fields(frontmatter: str) -> tuple[str, _Fields, tuple[_Issue, ...]]:
+def _compose_cached(
+    frontmatter: str,
+) -> tuple[str, _Fields, tuple[_Issue, ...], _Keys, bool]:
     """Compose a frontmatter block into its top-level scalar fields.
 
-    Returns ``(kind, fields, issues)``. ``kind`` is ``'mapping'`` when
-    the body is a YAML mapping -- ``fields`` then maps each key, first
-    occurrence winning, to its scalar text, style (``None`` for plain,
-    else the quote or block indicator), and resolved tag, or to ``None``
-    for a sequence or mapping value -- ``'empty'`` for a body with no
-    content, ``'nonmapping'`` for valid YAML that is not a mapping, and
-    ``'invalid'`` when the parser rejects the body or a key is not a
-    scalar. ``issues`` are the findings a strict reader raises -- the
-    parse error, the non-mapping body, each non-scalar key, each
-    duplicate key -- as ``(line, reason, cause)`` with 1-based file
-    lines. Only the body between the fences reaches the parser: the
-    fences are the wiki's grammar and document markers to YAML. The node
-    graph is composed, never constructed, so a stamp stays its source
-    text and a typed-looking title stays a string.
+    Returns ``(kind, fields, issues, keys, aliased)``. ``kind`` is
+    ``'mapping'`` when the body is a YAML mapping -- ``fields`` then
+    maps each key, first occurrence winning, to its scalar text, style
+    (``None`` for plain, else the quote or block indicator), and
+    resolved tag, or to ``None`` for a sequence or mapping value --
+    ``'empty'`` for a body with no content, ``'nonmapping'`` for valid
+    YAML that is not a mapping, and ``'invalid'`` when the parser
+    rejects the body or a key is not a scalar. ``issues`` are the
+    findings a strict reader raises -- the parse error, the non-mapping
+    body, each non-scalar key, each duplicate key -- as ``(line, reason,
+    cause)`` with 1-based file lines. ``keys`` are the top-level keys in
+    document order with the block line of each key line, empty unless
+    the root is a block mapping whose keys all open at column 0 -- the
+    lines the byte-level writers can address. ``aliased`` is whether the
+    graph reaches a node twice (an alias), which pins its lines' order.
+    Only the body between the fences reaches the parser: the fences are
+    the wiki's grammar and document markers to YAML. The node graph is
+    composed, never constructed, so a stamp stays its source text and a
+    typed-looking title stays a string.
     """
     import yaml
 
     # feed the parser the body between the fences (a fenceless body reads as is)
     lines = frontmatter.split('\n')
+    offset = 0
     if lines and (lines[0].lstrip('\ufeff').strip() == '---'):
         lines = lines[1:]
+        offset = 1
     if lines and (lines[-1].rstrip() == '---'):
         lines = lines[:-1]
-    body = '\n'.join(lines) + '\n'
+    # a BOM at column 0 is skipped by the C loader on any line but by the pure
+    # reader only at the stream start, so they go before the parse and both
+    # loaders mark the same stream (a line count the marks index by)
+    body = re.sub(r'^\ufeff', '', '\n'.join(lines) + '\n', flags=re.MULTILINE)
+    # nesting past the bound is refused before it reaches either loader's
+    # recursion (see _MAX_NESTING), on the line that passes it
+    deep = _nested_too_deep(body)
+    if deep is not None:
+        reason = f'collections nested deeper than {_MAX_NESTING} levels'
+        return 'invalid', {}, ((deep + offset + 1, reason, 'parse'),), (), False
     # the C loader is a build-time option of the PyYAML wheel; values and
     # styles match the pure loader's, which raises RecursionError on nesting
     # the C loader composes, while the C loader raises UnicodeEncodeError,
-    # not a YAML error, encoding a lone surrogate for libyaml
+    # not a YAML error, encoding a lone surrogate for libyaml, and an escape
+    # past U+10FFFF raises ValueError from the pure loader's chr()
     loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
     try:
         root = yaml.compose(body, Loader=loader)
-    except (yaml.YAMLError, RecursionError, UnicodeEncodeError) as e:
-        # body line 0 is file line 2 (the opening fence); an error without a
-        # mark (a character YAML forbids, the recursion limit) locates by the
-        # first forbidden character, else names the block's first line
-        mark = getattr(e, 'problem_mark', None)
-        forbidden = yaml.reader.Reader.NON_PRINTABLE.search(body)
-        if mark is not None:
-            line = mark.line + 2
-        elif forbidden is not None:
-            line = body.count('\n', 0, forbidden.start()) + 2
-        else:
-            line = 1
-        reason = getattr(e, 'problem', None)
-        if reason is None:
-            reason = getattr(e, 'reason', None)
-        if reason is None:
-            reason = type(e).__name__
-        return 'invalid', {}, ((line, str(reason), 'parse'),)
+    except (yaml.YAMLError, RecursionError, UnicodeEncodeError, ValueError) as e:
+        return 'invalid', {}, (_parse_issue(e, body, offset),), (), False
     if root is None:
-        return 'empty', {}, ()
+        return 'empty', {}, (), (), False
     if not isinstance(root, yaml.MappingNode):
-        return 'nonmapping', {}, ((1, 'frontmatter is not a mapping', 'nonmapping'),)
+        issue = (1, 'frontmatter is not a mapping', 'nonmapping')
+        return 'nonmapping', {}, (issue,), (), False
     # walk the pairs in order: the first occurrence of a key wins, and a
-    # repeat or a non-scalar key is a strict-reader finding
+    # repeat or a non-scalar key is a strict-reader finding; a key's line
+    # comes from its mark's character offset, since a mark's own line count
+    # treats NEL, LS, and PS as line breaks
     kind = 'mapping'
     fields: _Fields = {}
     issues: list[_Issue] = []
+    keys: list[tuple[str, int]] = []
     seen: dict[str, int] = {}
+    addressable = not root.flow_style
+    starts = [0, *(match.end() for match in re.finditer('\n', body))]
+    reached: set[int] = set()
     for key_node, value_node in root.value:
-        line = key_node.start_mark.line + 2
-        if not isinstance(key_node, yaml.ScalarNode):
-            issues.append((line, 'a key is not a scalar', 'nonscalar_key'))
+        scalar_key = isinstance(key_node, yaml.ScalarNode)
+        key = key_node.value if scalar_key else ''
+        # an alias key is the anchored node reached again: its own position is
+        # not the composer's to give, so no writer can address the block, and
+        # the value's mark names its line
+        if id(key_node) in reached:
+            alias_line = (
+                bisect.bisect_right(starts, value_node.start_mark.index) + offset
+            )
+            anchor_line = (
+                bisect.bisect_right(starts, key_node.start_mark.index) + offset
+            )
+            reason = f'key {key!r} is an alias of the node at line {anchor_line}'
+            issues.append((alias_line, reason, 'duplicate_key'))
+            addressable = False
+            continue
+        # every node of the pair, nested ones included, may be aliased later;
+        # a node reached twice within the pair is an alias, walked once
+        subtree = [key_node, value_node]
+        while subtree:
+            node = subtree.pop()
+            if id(node) in reached:
+                continue
+            reached.add(id(node))
+            if isinstance(node, yaml.SequenceNode):
+                subtree.extend(node.value)
+            elif isinstance(node, yaml.MappingNode):
+                for nested_key, nested_value in node.value:
+                    subtree.extend((nested_key, nested_value))
+        line = bisect.bisect_right(starts, key_node.start_mark.index) - 1 + offset
+        file_line = line + 1
+        # a merge key folds another mapping in, and two keys on one line (a
+        # NEL, LS, or PS the parser breaks on) share the line: neither leaves
+        # a key line of its own for the writers to address
+        merge_key = scalar_key and (key_node.tag == 'tag:yaml.org,2002:merge')
+        shared_line = bool(keys) and (keys[-1][1] == line)
+        if merge_key or shared_line or (key_node.start_mark.column != 0):
+            addressable = False
+        keys.append((key, line))
+        if not scalar_key:
+            issues.append((file_line, 'a key is not a scalar', 'nonscalar_key'))
             kind = 'invalid'
             continue
-        key = key_node.value
         if key in seen:
             reason = f'duplicate key {key!r} (first at line {seen[key]})'
-            issues.append((line, reason, 'duplicate_key'))
+            issues.append((file_line, reason, 'duplicate_key'))
             continue
-        seen[key] = line
+        seen[key] = file_line
         if isinstance(value_node, yaml.ScalarNode):
             # the C loader reports a plain style as '', the pure loader as None
             fields[key] = (value_node.value, value_node.style or None, value_node.tag)
+            # a lone surrogate the pure loader lets through an escape is text no
+            # writer can emit, so the block reads as the C loader rejects it
+            if _SURROGATES.search(value_node.value):
+                reason = 'found invalid Unicode character escape code'
+                return 'invalid', {}, ((file_line, reason, 'parse'),), (), False
         else:
             fields[key] = None
-    return kind, fields, tuple(issues)
+    # an alias composes as the anchored node object reached a second time; a
+    # duplicate key inside a nested mapping is a strict-reader finding too
+    visited: set[int] = set()
+    pending = [root]
+    aliased = False
+    while pending:
+        node = pending.pop()
+        if id(node) in visited:
+            aliased = True
+            continue
+        visited.add(id(node))
+        if isinstance(node, yaml.SequenceNode):
+            pending.extend(node.value)
+        elif isinstance(node, yaml.MappingNode):
+            nested: set[str] = set()
+            for key_node, value_node in node.value:
+                pending.extend((key_node, value_node))
+                if (node is root) or not isinstance(key_node, yaml.ScalarNode):
+                    continue
+                if key_node.value in nested:
+                    nested_line = (
+                        bisect.bisect_right(starts, key_node.start_mark.index) + offset
+                    )
+                    reason = f'duplicate key {key_node.value!r} in a nested mapping'
+                    issues.append((nested_line, reason, 'duplicate_key'))
+                nested.add(key_node.value)
+    issues.sort(key=lambda issue: issue[0])
+    return kind, fields, tuple(issues), tuple(keys) if addressable else (), aliased
+
+
+def _parse_issue(error: Exception, body: str, offset: int) -> _Issue:
+    """Locate and word a parser error as a strict-reader finding on the file's lines.
+
+    A mark's character offset locates its line (a mark's own line count
+    treats NEL, LS, and PS as line breaks); an error at the end of the
+    stream, or one raised while scanning a key, points past the construct
+    at fault, so its context mark names the offending line instead; an
+    error without a mark (a character YAML forbids, the recursion limit)
+    locates by the first forbidden character, else names the block's
+    first line. A problem worded as a fragment ("but found another
+    document") keeps the context it continues.
+    """
+    import yaml
+
+    mark = getattr(error, 'problem_mark', None)
+    context = getattr(error, 'context', None)
+    context_mark = getattr(error, 'context_mark', None)
+    if (mark is not None) and (context_mark is not None):
+        past_end = mark.index >= len(body.rstrip('\n'))
+        opened = str(context).startswith(
+            ('while scanning a simple key', 'while parsing a flow')
+        )
+        if past_end or opened:
+            mark = context_mark
+    forbidden = yaml.reader.Reader.NON_PRINTABLE.search(body)
+    reason = getattr(error, 'problem', None)
+    if mark is not None:
+        # a mark still past the end (an unclosed flow collection with no
+        # context) names the last line holding content; one on a trailing
+        # whitespace-only line (a tab there) stays on that line
+        if mark.index < len(body.rstrip('\n')):
+            index = mark.index
+        else:
+            index = len(body.rstrip())
+        body_line = body.count('\n', 0, index)
+        # a colon the parser finds inside a plain scalar it is still reading
+        # points at the line where the scalar started: a `key:value` typo
+        # above, whose lines are neither key lines, items, nor comments (the
+        # blank lines between fold in) -- unless a key on the error line
+        # itself opened the scalar
+        if str(reason).startswith('mapping values are not allowed'):
+            lines = body.split('\n')
+            before = body[body.rfind('\n', 0, index) + 1 : index]
+            if re.match(r'^(?:\S.*?)?:(?:[ \t]|$)', before) is None:
+                above = body_line
+                first = body_line
+                while (above > 0) and _continues_a_scalar(lines[above - 1]):
+                    above -= 1
+                    if lines[above].strip():
+                        first = above
+                # a scalar under a key line is that key's value, so the colon
+                # on the error line is the fault; one opening the block, or
+                # following a comment or item, is a typo named on its first line
+                keyed = (above > 0) and re.match(
+                    r'^(?:\S.*?)?:(?:[ \t]|$)', lines[above - 1]
+                )
+                if not keyed:
+                    body_line = first
+        line = body_line + offset + 1
+    elif forbidden is not None:
+        line = body.count('\n', 0, forbidden.start()) + offset + 1
+    else:
+        line = 1
+    if reason is None:
+        reason = getattr(error, 'reason', None)
+    if isinstance(error, RecursionError):
+        reason = 'collections nested too deep to read'
+    elif reason is None:
+        reason = type(error).__name__
+    elif context and str(reason).startswith('but '):
+        reason = f'{context}, {reason}'
+    elif (
+        context and (str(reason) == 'second occurrence') and (context_mark is not None)
+    ):
+        # a duplicate anchor is worded as its context plus where the first is
+        first = body.count('\n', 0, context_mark.index) + offset + 1
+        reason = f'{str(context).split(";")[0]} (first at line {first})'
+    return line, str(reason), 'parse'
+
+
+def _continues_a_scalar(line: str) -> bool:
+    """Return whether a body line can only be the inside of a plain scalar: a blank, or no key, item, comment, or marker."""
+    if not line.strip():
+        return True
+    if line.startswith(('#', '-', '---', '...')):
+        return False
+    return re.match(r'^(?:\S.*?)?:(?:[ \t]|$)', line) is None
 
 
 def _scalar_fields(frontmatter: str) -> Optional[_Fields]:
     """Return the block's scalar fields, or ``None`` to defer to the line grammar.
 
-    A block the parser rejects, a body that is not a mapping, and a
-    non-scalar key all read through the line grammar, so the reader
-    never fails on input the writer tolerates.
+    A block the parser rejects and a non-scalar key read through the line
+    grammar, so the reader never fails on input the writer tolerates; a
+    body with no content, or one that is not a mapping, has no fields at
+    all -- a ``key:`` spelled inside a list is list text.
     """
-    kind, fields, _ = _compose_fields(frontmatter)
+    kind, fields, _, _, _ = _compose_fields(frontmatter)
     if kind == 'mapping':
         return fields
-    if kind == 'empty':
+    if kind in ('empty', 'nonmapping'):
         return {}
     return None
 
@@ -1393,43 +2130,189 @@ def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
     same way ``>`` does. Returns ``None`` if the field is absent; an
     empty block body resolves to an empty string.
     """
-    # single-line value
-    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.+)$', frontmatter, re.MULTILINE)
-    if match:
-        value = match.group(1).strip()
-        if not value.startswith(('|', '>')):
-            return unquote(value)
-    else:
-        # bare key: an indented body is a plain multi-line scalar, folded
-        # per the YAML plain-scalar rule; no body reads as an absent value
-        match = re.search(
-            pattern=rf'^{key}[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+    # the key line: its colon followed by a space or the line end, as the
+    # whole line grammar has it
+    key_line = _key_pattern(key)
+    match = re.search(rf'{key_line}[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
+    if match is None:
+        return None
+    # node properties are not the value
+    value = re.sub(r'^(?:[&!]\S*(?:[ \t]+|$))+', '', match.group(1).strip())
+    lines = frontmatter.split('\n')
+    first = frontmatter.count('\n', 0, match.start()) + 1
+    # a quoted value: a comment after it starts past its closing quote (a
+    # quote mid-text, an apostrophe, is content); a quote closing on a later
+    # line folds the lines up to it like a plain value's, stopping at the
+    # next key line or the block's end
+    if value.startswith(("'", '"')):
+        close = _quote_close(value)
+        if close != -1:
+            return unquote(value[: close + 1])
+        parts = [value]
+        for line in lines[first : _end_line(lines)]:
+            if _key_of(line) is not None:
+                break
+            text = line.strip()
+            close = _quote_close(value[0] + text)
+            if close != -1:
+                parts.append(text[:close])
+                break
+            parts.append(text)
+        return unquote(fold_lines('\n'.join(parts)))
+    # a flow collection: its source text up to the closing bracket, a ' #'
+    # inside its quotes included and the comment tails outside them dropped;
+    # a bracket never closed reads to the next key line or the block's end,
+    # where the line grammar places the lines
+    if value[:1] in ('[', '{'):
+        depth, quote = _flow_depth(value, 0)
+        parts = [_uncommented(value)]
+        for line in lines[first : _end_line(lines)]:
+            if (depth == 0) or (_key_of(line) is not None):
+                break
+            parts.append(_uncommented(line, quote))
+            depth, quote = _flow_depth(line, depth, quote)
+        return ' '.join(part for part in parts if part)
+    if not value.startswith(('|', '>')):
+        # a plain value, on the key line, continued on indented lines, or under
+        # a bare key -- whose column-0 items are its value, as the composed
+        # path reads them: the lines fold per the YAML plain-scalar rule,
+        # comment lines and ' #' tails (outside quotes) dropped; nothing left
+        # reads as an absent value, and a bare key over a quoted body reads
+        # the quoted scalar, as the key-line spelling does
+        items = r'|-(?:[ \t].*)?\n' if not value else ''
+        body_match = re.search(
+            pattern=rf'{key_line}[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n|#.*\n{items})*)',
             string=frontmatter,
             flags=re.MULTILINE,
         )
-        if match and match.group(1).strip():
-            return fold_lines(match.group(1))
-        return None
-    # block scalar: tolerate any header (chomping/indentation indicators
-    # |- |+ >- |2 ...) plus trailing inline text, then capture the indented
-    # body (blank lines inside the block are kept so a folded break survives)
+        body = body_match.group(2) if body_match else ''
+        kept = []
+        span = None  # the quote a line leaves open: its lines are content
+        for line in (value, *body.split('\n')):
+            if (span is None) and line.lstrip().startswith('#'):
+                continue
+            kept.append(_uncommented(line, span))
+            _, span = _flow_depth(line, 0, span)
+        text = '\n'.join(kept)
+        if not text.strip():
+            return None
+        if not value and (text.lstrip()[:1] in ('"', "'")):
+            # the close counts only at a line's end (a quote mid-text, an
+            # apostrophe, is content), walked line by line as the key-line
+            # quoted branch walks its continuations
+            quote_lines = text.lstrip().split('\n')
+            parts = []
+            for index, quoted in enumerate(quote_lines):
+                opened = quoted if index == 0 else quote_lines[0][0] + quoted
+                close = _quote_close(opened)
+                if close != -1:
+                    parts.append(opened[: close + 1] if index == 0 else quoted[:close])
+                    break
+                parts.append(quoted)
+            return unquote(fold_lines('\n'.join(parts)))
+        return fold_lines(text)
+    # block scalar: tolerate any header (node properties, chomping/indentation
+    # indicators |- |+ >- |2 ...) plus trailing inline text, then capture the
+    # indented body (blank lines inside the block are kept so a folded break
+    # survives)
     match = re.search(
-        pattern=rf'^{key}[ \t]*:[^\S\n]*([|>])[-+0-9]*[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        pattern=rf'{key_line}[^\S\n]*(?:[&!]\S*[ \t]+)*([|>])([-+0-9]*)[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n)*)',
         string=frontmatter,
         flags=re.MULTILINE,
     )
     if not match:
         return None
-    indicator, inline, body = match.group(1), match.group(2), match.group(3)
+    indicator, header, inline, body = match.groups()
     # no indented body: the inline text on the header line is the value,
     # unless it is a comment
     if not body:
         return '' if inline.strip().startswith('#') else inline.strip()
-    body = textwrap.dedent(body)
+    # the block ends at the first line indented less than its body -- the
+    # explicit indentation indicator's depth, else the first content line's
+    lines = body.split('\n')
+    digit = re.search(r'[0-9]', header)
+    content = [line for line in lines if line.strip()]
+    if digit is not None:
+        indent = int(digit.group())
+    else:
+        indent = len(content[0]) - len(content[0].lstrip()) if content else 0
+    kept = []
+    for line in lines:
+        if line.strip() and (len(line) - len(line.lstrip()) < indent):
+            break
+        kept.append(line)
+    body = textwrap.dedent('\n'.join(kept))
     # folded scalar (>): join non-empty lines with a space, blank line breaks
     if indicator == '>':
         return fold_lines(body)
     return body.strip()
+
+
+def _closing_quote(value: str, start: int = 0) -> int:
+    """Return the index of the quote closing the quoted scalar opening at ``start``, or ``-1`` when it never closes.
+
+    A doubled ``''`` inside a single-quoted scalar and a backslash-escaped
+    character inside a double-quoted one are content, not the close.
+    """
+    quote_char = value[start]
+    index = start + 1
+    while index < len(value):
+        char = value[index]
+        if (quote_char == '"') and (char == '\\'):
+            index += 2
+            continue
+        if char == quote_char:
+            if (quote_char == "'") and value[index + 1 : index + 2] == "'":
+                index += 2
+                continue
+            return index
+        index += 1
+    return -1
+
+
+def _flow_close(value: str, start: int = 0) -> int:
+    """Return the index closing the quoted span opening at ``start`` of flow text, or ``-1``.
+
+    Inside a flow collection a close is followed by the end, whitespace,
+    ``,``, ``]``, ``}``, or ``:``; a quote followed by more text (an
+    apostrophe in ``'Bob's #1 hit'``) is content, so the ``#`` after it
+    never starts a comment.
+    """
+    index = start
+    while True:
+        close = _closing_quote(value, index)
+        if close == -1:
+            return -1
+        if value[close + 1 : close + 2] in ('', ' ', '\t', ',', ']', '}', ':'):
+            return close
+        index = close
+
+
+def _quote_close(value: str) -> int:
+    """Return the index of the quote closing the scalar opening ``value``, or ``-1``.
+
+    A candidate close counts only when nothing but whitespace or a
+    ``' #'`` comment follows it on the line -- no reading closes a quoted
+    scalar mid-text, so the apostrophe in ``'Bob's Page'`` is content and
+    the final quote is the close. Doubled ``''`` and backslash escapes
+    are content, as in :func:`_closing_quote`.
+    """
+    quote_char = value[0]
+    index = 1
+    close = -1
+    while index < len(value):
+        char = value[index]
+        if (quote_char == '"') and (char == '\\'):
+            index += 2
+            continue
+        if char == quote_char:
+            if (quote_char == "'") and value[index + 1 : index + 2] == "'":
+                index += 2
+                continue
+            if re.fullmatch(r'[ \t]*(?:#.*)?', value[index + 1 :]):
+                close = index
+        index += 1
+    return close
 
 
 def _is_unset_field(frontmatter: str, key: str) -> bool:
@@ -1437,9 +2320,9 @@ def _is_unset_field(frontmatter: str, key: str) -> bool:
 
     A plain lowercase ``null`` -- with or without a trailing comment --
     is the one reset spelling; a quoted or block-scalar ``null`` is
-    authored text. Under the line grammar the check reads the raw
-    spelling, since unquoting first would collapse an authored
-    ``'null'`` into the idiom.
+    authored text. Under the line grammar the check is the repair's own
+    valueless test on the raw field, since unquoting first would
+    collapse an authored ``'null'`` into the idiom.
     """
     fields = _scalar_fields(frontmatter)
     if fields is not None:
@@ -1451,8 +2334,11 @@ def _is_unset_field(frontmatter: str, key: str) -> bool:
         value, style, tag = entry
         # plain and resolved as null: an explicit !!str tag makes it text
         return (value == 'null') and (style is None) and tag.endswith(':null')
-    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
-    return (match is None) or (match.group(1).strip() == 'null')
+    text = field_text(frontmatter, key)
+    if text is None:
+        return True
+    indicator, _, body = text.partition('\n')
+    return _is_valueless(indicator, body, nulls=('', 'null'))
 
 
 def _is_plain_safe(value: str) -> bool:
@@ -1475,14 +2361,40 @@ def _is_plain_safe(value: str) -> bool:
         return False
     if value[0] in _INDICATOR_CHARS:
         return False
-    if (value in ('-', '?', ':')) or (value[:2] in ('- ', '? ', ': ')):
+    if (value in ('-', '?', ':', '<<', '=')) or (value[:2] in ('- ', '? ', ': ')):
         return False
+    # a value a strict reader resolves as a typed scalar and then cannot
+    # construct -- a date no calendar has (2024-02-30), a numeral of
+    # underscores alone (0x_) -- is one it rejects
+    import yaml
+
+    resolved = yaml.resolver.Resolver().resolve(yaml.ScalarNode, value, (True, False))
+    if resolved != 'tag:yaml.org,2002:str':
+        try:
+            yaml.safe_load(f'k: {value}\n')
+        except (yaml.YAMLError, ValueError):
+            return False
     return True
 
 
+def _escape(match: re.Match[str]) -> str:
+    """Spell one character no stream may carry as its double-quoted escape."""
+    char = match.group(0)
+    if char in _SHORT_ESCAPES:
+        return f'\\{_SHORT_ESCAPES[char]}'
+    return f'\\u{ord(char):04x}'
+
+
 def _unescape(match: re.Match[str]) -> str:
-    """Resolve one double-quoted YAML escape; an unknown one stays verbatim."""
-    code, byte, char = match.groups()
-    if code or byte:
-        return chr(int(code or byte, 16))
+    """Resolve one double-quoted YAML escape; an unknown one stays verbatim.
+
+    A code point past U+10FFFF or inside the surrogate range is no
+    character, so its escape stays verbatim too, as libyaml reads it.
+    """
+    wide, code, byte, char = match.groups()
+    if wide or code or byte:
+        code_point = int(wide or code or byte, 16)
+        if (code_point > 0x10FFFF) or (0xD800 <= code_point <= 0xDFFF):
+            return match.group(0)
+        return chr(code_point)
     return _ESCAPES.get(char, f'\\{char}')

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -447,7 +447,7 @@ def repair_frontmatter(
     frontmatter = strip_blank_lines(frontmatter)
     # update name from the path-derived name (add it if the field is
     # missing, so frontmatter with no name: does not stay un-named)
-    name_field = re.search(r'^name:(.*)$', frontmatter, re.MULTILINE)
+    name_field = re.search(r'^name[ \t]*:(.*)$', frontmatter, re.MULTILINE)
     if name_field:
         # the refresh spans the field's full extent, so a multi-line value's
         # body goes with the stale value it continues; callable repls so a
@@ -458,7 +458,7 @@ def repair_frontmatter(
             # block scalar: the whole indented body goes -- a `#` line or a
             # blank inside it is content
             frontmatter = re.sub(
-                pattern=r'^name:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+                pattern=r'^name[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
                 repl=lambda _: fresh,
                 string=frontmatter,
                 count=1,
@@ -477,7 +477,7 @@ def repair_frontmatter(
                 return fresh + ''.join(comments)
 
             frontmatter = re.sub(
-                pattern=r'^name:.*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+                pattern=r'^name[ \t]*:.*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
                 repl=keep_comments,
                 string=frontmatter,
                 count=1,
@@ -491,7 +491,7 @@ def repair_frontmatter(
     # empty block scalar (mirrors the title branch's valueless check below),
     # all of which read as no description; a real block-scalar body is kept
     desc_match = re.search(
-        pattern=r'^desc:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+        pattern=r'^desc[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
         string=frontmatter,
         flags=re.MULTILINE,
     )
@@ -503,9 +503,9 @@ def repair_frontmatter(
                 + 'desc: ...\n'
                 + frontmatter[desc_match.end() :]
             )
-    elif not re.search(r'^desc:', frontmatter, re.MULTILINE):
+    elif not re.search(r'^desc[ \t]*:', frontmatter, re.MULTILINE):
         frontmatter = re.sub(
-            pattern=r'^(name:.*\n)',
+            pattern=r'^(name[ \t]*:.*\n)',
             repl=r'\1desc: ...\n',
             string=frontmatter,
             count=1,
@@ -515,13 +515,13 @@ def repair_frontmatter(
     # place so a duplicate is never appended -- a bare key over an indented
     # body is a value (lint judges it), never a blank to stamp over
     created = re.search(
-        pattern=r'^created:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        pattern=r'^created[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
         string=frontmatter,
         flags=re.MULTILINE,
     )
     if created and not created.group(1).strip():
         frontmatter = re.sub(
-            pattern=r'^created:[^\S\n]*$',
+            pattern=r'^created[ \t]*:[^\S\n]*$',
             # a callable repl, so a backslash in a user timestamp.format is
             # emitted verbatim, not parsed as a group reference
             repl=lambda _: f'created: {now}',
@@ -529,24 +529,24 @@ def repair_frontmatter(
             count=1,
             flags=re.MULTILINE,
         )
-    elif not re.search(r'^created:', frontmatter, re.MULTILINE):
-        match = re.search(r'^updated:', frontmatter, re.MULTILINE)
+    elif not re.search(r'^created[ \t]*:', frontmatter, re.MULTILINE):
+        match = re.search(r'^updated[ \t]*:', frontmatter, re.MULTILINE)
         pos = match.start() if match else frontmatter.rfind('---')
         frontmatter = frontmatter[:pos] + f'created: {now}\n' + frontmatter[pos:]
     updated = re.search(
-        pattern=r'^updated:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        pattern=r'^updated[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
         string=frontmatter,
         flags=re.MULTILINE,
     )
     if updated and not updated.group(1).strip():
         frontmatter = re.sub(
-            pattern=r'^updated:[^\S\n]*$',
+            pattern=r'^updated[ \t]*:[^\S\n]*$',
             repl=lambda _: f'updated: {now}',
             string=frontmatter,
             count=1,
             flags=re.MULTILINE,
         )
-    elif not re.search(r'^updated:', frontmatter, re.MULTILINE):
+    elif not re.search(r'^updated[ \t]*:', frontmatter, re.MULTILINE):
         pos = frontmatter.rfind('---')
         frontmatter = frontmatter[:pos] + f'updated: {now}\n' + frontmatter[pos:]
     # drop an unset category: absence is the canonical unset form, so a
@@ -557,7 +557,7 @@ def repair_frontmatter(
     # verbatim, and the field is never inserted
     if category:
         match = re.search(
-            pattern=r'^category:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+            pattern=r'^category[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
             string=frontmatter,
             flags=re.MULTILINE,
         )
@@ -570,7 +570,7 @@ def repair_frontmatter(
     # the order pass's job
     if title:
         match = re.search(
-            pattern=r'^title:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+            pattern=r'^title[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
             string=frontmatter,
             flags=re.MULTILINE,
         )
@@ -608,7 +608,7 @@ def order_frontmatter(frontmatter: str) -> str:
     preamble = []
     current = None
     for line in lines[1:-1]:
-        match = re.match(r'^([\w-]+):', line)
+        match = re.match(r'^([\w.-]+)[ \t]*:', line)
         if match:
             current = (match.group(1), [line])
             extents.append(current)
@@ -646,7 +646,7 @@ def seed_frontmatter_title(frontmatter: str, title: Optional[str] = None) -> str
     carrying a ``title:`` line is returned unchanged: the field is
     authored, so a present line is never overwritten.
     """
-    if re.search(r'^title:', frontmatter, re.MULTILINE):
+    if re.search(r'^title[ \t]*:', frontmatter, re.MULTILINE):
         return frontmatter
     if title is None:
         value = 'null'
@@ -656,7 +656,7 @@ def seed_frontmatter_title(frontmatter: str, title: Optional[str] = None) -> str
         value = "'null'" if title == 'null' else quote(title)
     # callable repl so a backslash-digit in the title is not read as a group reference
     return re.sub(
-        pattern=r'^(name:.*\n)',
+        pattern=r'^(name[ \t]*:.*\n)',
         repl=lambda match: f'{match.group(1)}title: {value}\n',
         string=frontmatter,
         count=1,
@@ -808,7 +808,7 @@ def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
     empty block body resolves to an empty string.
     """
     # single-line value
-    match = re.search(rf'^{key}:[^\S\n]*(.+)$', frontmatter, re.MULTILINE)
+    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.+)$', frontmatter, re.MULTILINE)
     if match:
         value = match.group(1).strip()
         if not value.startswith(('|', '>')):
@@ -817,7 +817,7 @@ def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
         # bare key: an indented body is a plain multi-line scalar, folded
         # per the YAML plain-scalar rule; no body reads as an absent value
         match = re.search(
-            pattern=rf'^{key}:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+            pattern=rf'^{key}[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
             string=frontmatter,
             flags=re.MULTILINE,
         )
@@ -828,7 +828,7 @@ def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
     # |- |+ >- |2 ...) plus trailing inline text, then capture the indented
     # body (blank lines inside the block are kept so a folded break survives)
     match = re.search(
-        pattern=rf'^{key}:[^\S\n]*([|>])[-+0-9]*[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        pattern=rf'^{key}[ \t]*:[^\S\n]*([|>])[-+0-9]*[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n)*)',
         string=frontmatter,
         flags=re.MULTILINE,
     )
@@ -877,7 +877,7 @@ def _unset_field(frontmatter: str, key: str) -> bool:
     fields = _scalar_fields(frontmatter)
     if fields is not None:
         return (key not in fields) or (fields[key] == ('null', None))
-    match = re.search(rf'^{key}:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
+    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
     return (match is None) or (match.group(1).strip() == 'null')
 
 
@@ -942,7 +942,7 @@ def field_value(line: str) -> str:
     joined value of a whole field, this reads a single line so matches
     keep their line numbers.
     """
-    match = re.match(r'^([\w-]+):[^\S\n]*', line)
+    match = re.match(r'^([\w.-]+)[ \t]*:[^\S\n]*', line)
     if match:
         return unquote(line[match.end() :].strip())
     return line.strip()
@@ -985,17 +985,19 @@ def field_line_ranges(
         if lineno >= frontmatter_end:
             break
         # check for field key
-        match = re.match(r'^([\w-]+):', line)
+        match = re.match(r'^([\w.-]+)[ \t]*:', line)
         if match:
             current_field = match.group(1)
             if current_field in fields:
                 result.add(lineno)
             continue
-        # a dedented field line whose key sits outside the [\w-]+ grammar
-        # (e.g. dotted) still ends the current field -- its line and block
-        # body must not attribute to the preceding field
+        # a dedented field line whose key sits outside the key grammar (e.g.
+        # one with spaces) still ends the current field -- its line and block
+        # body must not attribute to the preceding field -- while a dedented
+        # sequence item (`- https://...`) continues it, colon and all
         dedented = line[:1] not in (' ', '\t')
-        if dedented and ':' in line and not line.startswith('#'):
+        item = re.match(r'-(?:[ \t]|$)', line) is not None
+        if dedented and (':' in line) and not line.startswith('#') and not item:
             current_field = None
             continue
         # continuation line of current field

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -700,7 +700,7 @@ def _compose_fields(frontmatter: str) -> tuple[str, _Fields]:
 
     # feed the parser the body between the fences (a fenceless body reads as is)
     lines = frontmatter.split('\n')
-    if lines and (lines[0].lstrip('﻿').strip() == '---'):
+    if lines and (lines[0].lstrip('\ufeff').strip() == '---'):
         lines = lines[1:]
     if lines and (lines[-1].rstrip() == '---'):
         lines = lines[:-1]

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -39,7 +39,7 @@ _FRONTMATTER_TAIL = (
 # per-process memo of composed frontmatter blocks: an update reads each block
 # a few times and a lint a few more, and a run over a few thousand pages fits
 # one cache at about a kilobyte per block
-_SCALAR_CACHE_SIZE = 4096
+_SCALAR_CACHE_SIZE = 4_096
 
 # characters that open a YAML indicator (flow collection, comment, node
 # property, block scalar, quote, directive, reserved) when they lead a value
@@ -59,8 +59,14 @@ _Issue = tuple[int, str, str]
 # lone surrogates; a value holding one is written double-quoted with escapes
 _ESCAPED_CHARS = re.compile(r'[\x00-\x08\x0a-\x1f\x7f\x85\u2028\u2029\ud800-\udfff]')
 
+# the single-character escapes of a double-quoted scalar, by the letter after
+# the backslash
+_ESCAPES = {'n': '\n', 'r': '\r', 't': '\t', '"': '"', '\\': '\\'}
+
 #: the lines continuing a frontmatter field below its key line: indented
-#: lines, blank lines, and column-0 sequence items (``- item``)
+#: lines, blank lines, and column-0 sequence items (``- item``); read by
+#: ``Wiki._apply_plan`` for the re-stamp and mirrored, minus the trailing
+#: blanks and the items, by the merge driver's awk extent
 FIELD_EXTENT = r'(?:[ \t]+.*\n|[ \t]*\n|-(?:[ \t].*)?\n)*'
 
 
@@ -359,8 +365,8 @@ def build_frontmatter(
         *desc_lines,
         'tags: []',
         'sources: []',
-        f'created: {created}',
-        f'updated: {updated}',
+        f'created: {quote(created)}',
+        f'updated: {quote(updated)}',
         '---',
     ]
     return '\n'.join(lines)
@@ -403,74 +409,6 @@ def strip_blank_lines(frontmatter: str) -> str:
     # blanks past the closing delimiter sit outside the frontmatter block
     result.extend(pending)
     return '\n'.join(result)
-
-
-def _uncommented(text: str) -> str:
-    """Return ``text`` without a ``# comment`` -- one leading it or following whitespace."""
-    return re.sub(r'(?:^|\s)#.*', '', text).strip()
-
-
-def _valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
-    """Return whether a field's ``indicator`` line and ``body`` carry no value.
-
-    Comments are not a value: ``null # why`` resets like ``null``,
-    ``| # note`` is an empty block like ``|``, and a body of comment lines
-    is no body. The field is valueless when what remains -- on the
-    indicator line, or continued in the body -- is one of the ``nulls``
-    spellings, or a bare block header over no body at all (a block's body
-    is content, comment-shaped lines included).
-    """
-    value = _uncommented(indicator.split(':', 1)[1])
-    if re.fullmatch(r'[|>][-+0-9]*', value):
-        return not body.strip()
-    content = ' '.join(_uncommented(line) for line in body.split('\n')).strip()
-    return (value in nulls) and (content in nulls)
-
-
-def _field_comments(indicator: str, body: str) -> tuple[str, str]:
-    """Return the comments a valueless field carries: the indicator's tail, the body's lines.
-
-    The tail keeps a leading space so it re-attaches after a written value;
-    the lines keep their indentation and breaks so they re-emit under it.
-    """
-    match = re.search(r'(?:^|\s)(#.*)$', indicator.split(':', 1)[1])
-    tail = f' {match.group(1)}' if match else ''
-    lines = body.splitlines(keepends=True)
-    comments = ''.join(line for line in lines if line.lstrip().startswith('#'))
-    return tail, comments
-
-
-def _fill_stamp(frontmatter: str, key: str, now: str, *, before: Optional[str]) -> str:
-    """Stamp a missing or valueless ``key`` with ``now``.
-
-    A present key is stamped in place -- so a duplicate is never appended
-    -- when its value is blank, quoted-empty, or comments only, and the
-    comments ride along; a key over a real value (a stamp continued on an
-    indented line, a sequence) stays for lint to judge. A missing key is
-    inserted before ``before`` when that key is present, else before the
-    closing delimiter. ``now`` is quoted whenever a plain scalar would
-    misread it, and spliced rather than substituted so a backslash in a
-    user ``timestamp.format`` is emitted verbatim.
-    """
-    match = re.search(
-        pattern=rf'^{key}[ \t]*:(.*)\n({FIELD_EXTENT})',
-        string=frontmatter,
-        flags=re.MULTILINE,
-    )
-    if match:
-        indicator, _, body = match.group(0).partition('\n')
-        if _valueless(indicator, body, nulls=('', "''", '""')):
-            tail, comments = _field_comments(indicator, body)
-            stamp = f'{key}: {quote(now)}{tail}\n{comments}'
-            frontmatter = (
-                frontmatter[: match.start()] + stamp + frontmatter[match.end() :]
-            )
-        return frontmatter
-    anchor = None
-    if before is not None:
-        anchor = re.search(rf'^{before}[ \t]*:', frontmatter, re.MULTILINE)
-    pos = anchor.start() if anchor else frontmatter.rfind('---')
-    return frontmatter[:pos] + f'{key}: {quote(now)}\n' + frontmatter[pos:]
 
 
 def repair_frontmatter(
@@ -562,10 +500,8 @@ def repair_frontmatter(
     )
     if desc_match:
         indicator, _, body = desc_match.group(0).partition('\n')
-        if _valueless(indicator, body, nulls=('', "''", '""')):
-            # the comments the valueless field carried ride along with the
-            # placeholder: the indicator's tail after it, the body's lines
-            # under it
+        if _is_valueless(indicator, body, nulls=('', "''", '""')):
+            # the field's comments ride along with the placeholder
             tail, comments = _field_comments(indicator, body)
             frontmatter = (
                 frontmatter[: desc_match.start()]
@@ -599,7 +535,7 @@ def repair_frontmatter(
         )
         if match:
             indicator, _, body = match.group(0).partition('\n')
-            if _valueless(indicator, body, nulls=('', 'null')):
+            if _is_valueless(indicator, body, nulls=('', 'null')):
                 tail, comments = _field_comments(indicator, body)
                 kept = f'{tail.strip()}\n{comments}' if tail else comments
                 frontmatter = (
@@ -616,7 +552,7 @@ def repair_frontmatter(
         )
         if match:
             indicator, _, body = match.group(0).partition('\n')
-            if _valueless(indicator, body, nulls=('', 'null')):
+            if _is_valueless(indicator, body, nulls=('', 'null')):
                 tail, comments = _field_comments(indicator, body)
                 kept = f'{tail.strip()}\n{comments}' if tail else comments
                 frontmatter = (
@@ -724,116 +660,12 @@ def replace_heading(content: str, name: str) -> str:
     return content
 
 
-@functools.lru_cache(maxsize=_SCALAR_CACHE_SIZE)
-def _compose_fields(frontmatter: str) -> tuple[str, _Fields, tuple[_Issue, ...]]:
-    """Compose a frontmatter block into its top-level scalar fields.
-
-    Returns ``(kind, fields, issues)``. ``kind`` is ``'mapping'`` when
-    the body is a YAML mapping -- ``fields`` then maps each key, first
-    occurrence winning, to its scalar text, style (``None`` for plain,
-    else the quote or block indicator), and resolved tag, or to ``None``
-    for a sequence or mapping value -- ``'empty'`` for a body with no
-    content, ``'nonmapping'`` for valid YAML that is not a mapping and
-    holds no ``key:`` line, and ``'invalid'`` when the parser rejects
-    the body, a key is not a scalar, or a non-mapping body still carries
-    ``key:`` lines (a colon missing its space), which the line grammar
-    reads and the repair fixes. ``issues`` are the findings a strict
-    reader raises -- the parse error, the non-mapping body, each
-    non-scalar key, each duplicate key -- as ``(line, reason, cause)``
-    with 1-based file lines. Only the body between the fences reaches
-    the parser: the fences are the wiki's grammar and document markers
-    to YAML. The node graph is composed, never constructed, so a stamp
-    stays its source text and a typed-looking title stays a string.
-    """
-    import yaml
-
-    # feed the parser the body between the fences (a fenceless body reads as is)
-    lines = frontmatter.split('\n')
-    if lines and (lines[0].lstrip('\ufeff').strip() == '---'):
-        lines = lines[1:]
-    if lines and (lines[-1].rstrip() == '---'):
-        lines = lines[:-1]
-    body = '\n'.join(lines) + '\n'
-    # the C loader is a build-time option of the PyYAML wheel; values and
-    # styles match the pure loader's, which raises RecursionError on nesting
-    # the C loader composes, and either raises UnicodeError, not a YAML
-    # error, on a lone surrogate
-    loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
-    try:
-        root = yaml.compose(body, Loader=loader)
-    except (yaml.YAMLError, RecursionError, UnicodeError) as error:
-        # body line 0 is file line 2 (the opening fence); an error without a
-        # mark (a character YAML forbids, the recursion limit) locates by the
-        # first forbidden character, else names the block's first line
-        mark = getattr(error, 'problem_mark', None)
-        forbidden = yaml.reader.Reader.NON_PRINTABLE.search(body)
-        if mark is not None:
-            line = mark.line + 2
-        elif forbidden is not None:
-            line = body.count('\n', 0, forbidden.start()) + 2
-        else:
-            line = 1
-        reason = getattr(error, 'problem', None) or getattr(error, 'reason', None)
-        reason = str(reason or type(error).__name__)
-        return 'invalid', {}, ((line, reason, 'parse'),)
-    if root is None:
-        return 'empty', {}, ()
-    if not isinstance(root, yaml.MappingNode):
-        issue = (1, 'frontmatter is not a mapping', 'nonmapping')
-        # a scalar body holding key: lines is a mapping missing the space
-        # after a colon, which the line grammar reads and the repair fixes
-        if re.search(r'^[\w.-]+[ \t]*:', body, re.MULTILINE):
-            return 'invalid', {}, (issue,)
-        return 'nonmapping', {}, (issue,)
-    # walk the pairs in order: the first occurrence of a key wins, and a
-    # repeat or a non-scalar key is a strict-reader finding
-    kind = 'mapping'
-    fields: _Fields = {}
-    issues: list[_Issue] = []
-    seen: dict[str, int] = {}
-    for key_node, value_node in root.value:
-        line = key_node.start_mark.line + 2
-        if not isinstance(key_node, yaml.ScalarNode):
-            issues.append((line, 'a key is not a scalar', 'nonscalar_key'))
-            kind = 'invalid'
-            continue
-        key = key_node.value
-        if key in seen:
-            reason = f'duplicate key {key!r} (first at line {seen[key]})'
-            issues.append((line, reason, 'duplicate_key'))
-            continue
-        seen[key] = line
-        if isinstance(value_node, yaml.ScalarNode):
-            # the C loader reports a plain style as '', the pure loader as None
-            fields[key] = (value_node.value, value_node.style or None, value_node.tag)
-        else:
-            fields[key] = None
-    return kind, fields, tuple(issues)
-
-
-def _scalar_fields(frontmatter: str) -> Optional[_Fields]:
-    """Return the block's scalar fields, or ``None`` to defer to the line grammar.
-
-    A block the parser rejects, a body that is not a mapping, and a
-    non-scalar key all read through the line grammar, so the reader
-    never fails on input the writer tolerates.
-    """
-    kind, fields, _ = _compose_fields(frontmatter)
-    if kind == 'mapping':
-        return fields
-    if kind == 'empty':
-        return {}
-    return None
-
-
-def nonmapping_frontmatter(frontmatter: str) -> bool:
+def is_nonmapping_frontmatter(frontmatter: str) -> bool:
     """Return whether the block is valid YAML that is not a ``key: value`` mapping.
 
     A bare sentence or a list between the fences has no fields to read
     or repair; the planners keep such a page as written and report it
-    rather than append fields under the text. A scalar body that still
-    holds ``key:`` lines is a colon missing its space, not prose, and
-    reads through the line grammar instead.
+    rather than append fields under the text.
     """
     kind, _, _ = _compose_fields(frontmatter)
     return kind == 'nonmapping'
@@ -864,8 +696,8 @@ def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
     ``key:`` has no body. A sequence or mapping value, a block the
     parser rejects, and a body that is not a mapping fall back to the
     line grammar (:func:`_read_field_lines`), so the wiki's leniencies --
-    an unquoted ``': '`` inside a one-line value, conflict markers -- read
-    as before.
+    an unquoted ``': '`` inside a one-line value, conflict markers -- still
+    read through it.
     """
     fields = _scalar_fields(frontmatter)
     if fields is None:
@@ -888,61 +720,6 @@ def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
     return value
 
 
-def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
-    """Read a scalar frontmatter ``key`` with the line grammar.
-
-    The fallback behind :func:`read_frontmatter_field` for a block a
-    strict parser rejects. A plain ``key: value`` returns the stripped
-    value, with one pair of matching surrounding YAML quotes stripped. A
-    block scalar (``|``/``>`` with optional chomping/indentation
-    indicators, e.g. ``|-``, ``>+``, ``|2``) resolves to its body: a
-    literal ``|`` keeps line breaks, a folded ``>`` joins consecutive
-    non-empty lines with a single space (a blank line is a paragraph
-    break). Inline text on the indicator line (``key: > one liner.``) is
-    taken as the value when no indented body follows. A bare ``key:``
-    over an indented body is a plain multi-line scalar and folds the
-    same way ``>`` does. Returns ``None`` if the field is absent; an
-    empty block body resolves to an empty string.
-    """
-    # single-line value
-    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.+)$', frontmatter, re.MULTILINE)
-    if match:
-        value = match.group(1).strip()
-        if not value.startswith(('|', '>')):
-            return unquote(value)
-    else:
-        # bare key: an indented body is a plain multi-line scalar, folded
-        # per the YAML plain-scalar rule; no body reads as an absent value
-        match = re.search(
-            pattern=rf'^{key}[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
-            string=frontmatter,
-            flags=re.MULTILINE,
-        )
-        if match and match.group(1).strip():
-            return fold_lines(match.group(1))
-        return None
-    # block scalar: tolerate any header (chomping/indentation indicators
-    # |- |+ >- |2 ...) plus trailing inline text, then capture the indented
-    # body (blank lines inside the block are kept so a folded break survives)
-    match = re.search(
-        pattern=rf'^{key}[ \t]*:[^\S\n]*([|>])[-+0-9]*[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n)*)',
-        string=frontmatter,
-        flags=re.MULTILINE,
-    )
-    if not match:
-        return None
-    indicator, inline, body = match.group(1), match.group(2), match.group(3)
-    # no indented body: the inline text on the header line is the value,
-    # unless it is a comment
-    if not body:
-        return '' if inline.strip().startswith('#') else inline.strip()
-    body = textwrap.dedent(body)
-    # folded scalar (>): join non-empty lines with a space, blank line breaks
-    if indicator == '>':
-        return fold_lines(body)
-    return body.strip()
-
-
 def read_frontmatter_name(frontmatter: str) -> Optional[str]:
     """Return the ``name`` field from frontmatter text.
 
@@ -963,29 +740,6 @@ def read_frontmatter_name(frontmatter: str) -> Optional[str]:
     return join_lines(value)
 
 
-def _unset_field(frontmatter: str, key: str) -> bool:
-    """Return whether ``key`` is absent or carries the plain ``null`` reset idiom.
-
-    A plain lowercase ``null`` -- with or without a trailing comment --
-    is the one reset spelling; a quoted or block-scalar ``null`` is
-    authored text. Under the line grammar the check reads the raw
-    spelling, since unquoting first would collapse an authored
-    ``'null'`` into the idiom.
-    """
-    fields = _scalar_fields(frontmatter)
-    if fields is not None:
-        if key not in fields:
-            return True
-        entry = fields[key]
-        if entry is None:
-            return False
-        value, style, tag = entry
-        # plain and resolved as null: an explicit !!str tag makes it text
-        return (value == 'null') and (style is None) and tag.endswith(':null')
-    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
-    return (match is None) or (match.group(1).strip() == 'null')
-
-
 def read_frontmatter_title(frontmatter: str) -> str:
     """Return the ``title`` field from frontmatter text.
 
@@ -1001,7 +755,7 @@ def read_frontmatter_title(frontmatter: str) -> str:
     """
     # a bare 'title:' defers to the delegate, which resolves an indented
     # body as a plain multi-line scalar and no body as an absent value
-    if _unset_field(frontmatter, 'title'):
+    if _is_unset_field(frontmatter, 'title'):
         return ''
     value = read_frontmatter_field(frontmatter, 'title')
     return join_lines(value or '')
@@ -1031,7 +785,7 @@ def read_frontmatter_category(frontmatter: str) -> str:
     """
     # a bare 'category:' defers to the delegate, which resolves an indented
     # body as a plain multi-line scalar and no body as an absent value
-    if _unset_field(frontmatter, 'category'):
+    if _is_unset_field(frontmatter, 'category'):
         return ''
     value = read_frontmatter_field(frontmatter, 'category')
     return join_lines(value or '')
@@ -1237,36 +991,11 @@ def fold_lines(text: str) -> str:
     return '\n'.join(paragraphs)
 
 
-def _plain_safe(value: str) -> bool:
-    """Return whether a strict YAML reader reads ``value`` back verbatim when plain.
-
-    A value containing ``': '`` (or ending with ``:``) reads as a nested
-    mapping, one containing ``' #'`` loses everything from the hash (a
-    comment), one opening with an indicator character or with ``'- '``,
-    ``'? '``, or ``': '`` reads as structure, a node property, or a quoted
-    scalar, and leading or trailing whitespace (a tab anywhere) is dropped
-    or rejected -- so none of them may be written plain.
-    """
-    if not value:
-        return True
-    if value != value.strip():
-        return False
-    if (': ' in value) or value.endswith(':') or (' #' in value) or ('\t' in value):
-        return False
-    if _ESCAPED_CHARS.search(value):
-        return False
-    if value[0] in _INDICATOR_CHARS:
-        return False
-    if (value in ('-', '?', ':')) or (value[:2] in ('- ', '? ', ': ')):
-        return False
-    return True
-
-
 def quote(value: str) -> str:
     """YAML-quote a scalar when writing it plain would misread.
 
     A value a strict reader would not read back verbatim as plain text
-    (:func:`_plain_safe`) -- one shaped like a mapping, carrying a
+    (:func:`_is_plain_safe`) -- one shaped like a mapping, carrying a
     comment start, opening with an indicator, or wrapped in quote chars
     that :func:`unquote` would strip on read -- is written single-quoted
     with embedded single quotes doubled; one carrying a character no
@@ -1278,10 +1007,11 @@ def quote(value: str) -> str:
     if _ESCAPED_CHARS.search(value):
         escaped = value.replace('\\', '\\\\').replace('"', '\\"')
         escaped = _ESCAPED_CHARS.sub(
-            lambda match: f'\\u{ord(match.group(0)):04x}', escaped
+            repl=lambda match: f'\\u{ord(match.group(0)):04x}',
+            string=escaped,
         )
         return f'"{escaped}"'
-    if not _plain_safe(value):
+    if not _is_plain_safe(value):
         escaped = value.replace("'", "''")
         return f"'{escaped}'"
     return value
@@ -1300,20 +1030,12 @@ def unquote(value: str) -> str:
         body = value[1:-1]
         if value[0] == '"':
             return re.sub(
-                r'\\(?:u([0-9a-fA-F]{4})|x([0-9a-fA-F]{2})|(.))', _unescape, body
+                pattern=r'\\(?:u([0-9a-fA-F]{4})|x([0-9a-fA-F]{2})|(.))',
+                repl=_unescape,
+                string=body,
             )
         return body.replace("''", "'")
     return value
-
-
-def _unescape(match: re.Match[str]) -> str:
-    """Resolve one double-quoted YAML escape; an unknown one stays verbatim."""
-    code, byte, char = match.groups()
-    if code or byte:
-        return chr(int(code or byte, 16))
-    return {'n': '\n', 'r': '\r', 't': '\t', '"': '"', '\\': '\\'}.get(
-        char, f'\\{char}'
-    )
 
 
 def parse_regions(masked: str) -> tuple[dict[str, list[tuple[int, int]]], list[str]]:
@@ -1482,3 +1204,285 @@ def wrapped_marker_lines(masked: str, text: str) -> list[int]:
         if marker:
             open_items.append(indent)
     return result
+
+
+# ------ helper functions
+
+
+def _uncommented(text: str) -> str:
+    """Return ``text`` without a ``# comment`` -- one leading it or following whitespace."""
+    return re.sub(r'(?:^|\s)#.*', '', text).strip()
+
+
+def _is_valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
+    """Return whether a field's ``indicator`` line and ``body`` carry no value.
+
+    Comments are not a value: ``null # why`` resets like ``null``,
+    ``| # note`` is an empty block like ``|``, and a body of comment lines
+    is no body. The field is valueless when what remains -- on the
+    indicator line, or continued in the body -- is one of the ``nulls``
+    spellings, or a bare block header over no body at all (a block's body
+    is content, comment-shaped lines included).
+    """
+    value = _uncommented(indicator.split(':', 1)[1])
+    if re.fullmatch(r'[|>][-+0-9]*', value):
+        return not body.strip()
+    content = ' '.join(_uncommented(line) for line in body.split('\n')).strip()
+    return (value in nulls) and (content in nulls)
+
+
+def _field_comments(indicator: str, body: str) -> tuple[str, str]:
+    """Return the comments a valueless field carries: the indicator's tail, the body's lines.
+
+    The tail keeps a leading space so it re-attaches after a written value;
+    the lines keep their indentation and breaks so they re-emit under it.
+    """
+    match = re.search(r'(?:^|\s)(#.*)$', indicator.split(':', 1)[1])
+    tail = f' {match.group(1)}' if match else ''
+    lines = body.splitlines(keepends=True)
+    comments = ''.join(line for line in lines if line.lstrip().startswith('#'))
+    return tail, comments
+
+
+def _fill_stamp(frontmatter: str, key: str, now: str, *, before: Optional[str]) -> str:
+    """Stamp a missing or valueless ``key`` with ``now``.
+
+    A present key is stamped in place -- so a duplicate is never appended
+    -- when its value is blank, quoted-empty, or comments only, and the
+    comments ride along; a key over a real value (a stamp continued on an
+    indented line, a sequence) stays for lint to judge. A missing key is
+    inserted before ``before`` when that key is present, else before the
+    closing delimiter. ``now`` is quoted whenever a plain scalar would
+    misread it, and spliced rather than substituted so a backslash in a
+    user ``timestamp.format`` is emitted verbatim.
+    """
+    match = re.search(
+        pattern=rf'^{key}[ \t]*:(.*)\n({FIELD_EXTENT})',
+        string=frontmatter,
+        flags=re.MULTILINE,
+    )
+    # stamp a present-but-valueless key in place
+    if match:
+        indicator, _, body = match.group(0).partition('\n')
+        if _is_valueless(indicator, body, nulls=('', "''", '""')):
+            tail, comments = _field_comments(indicator, body)
+            stamp = f'{key}: {quote(now)}{tail}\n{comments}'
+            frontmatter = (
+                frontmatter[: match.start()] + stamp + frontmatter[match.end() :]
+            )
+        return frontmatter
+    # insert a missing key before its schema neighbor, else the closing delimiter
+    anchor = None
+    if before is not None:
+        anchor = re.search(rf'^{before}[ \t]*:', frontmatter, re.MULTILINE)
+    pos = anchor.start() if anchor else frontmatter.rfind('---')
+    return frontmatter[:pos] + f'{key}: {quote(now)}\n' + frontmatter[pos:]
+
+
+@functools.lru_cache(maxsize=_SCALAR_CACHE_SIZE)
+def _compose_fields(frontmatter: str) -> tuple[str, _Fields, tuple[_Issue, ...]]:
+    """Compose a frontmatter block into its top-level scalar fields.
+
+    Returns ``(kind, fields, issues)``. ``kind`` is ``'mapping'`` when
+    the body is a YAML mapping -- ``fields`` then maps each key, first
+    occurrence winning, to its scalar text, style (``None`` for plain,
+    else the quote or block indicator), and resolved tag, or to ``None``
+    for a sequence or mapping value -- ``'empty'`` for a body with no
+    content, ``'nonmapping'`` for valid YAML that is not a mapping, and
+    ``'invalid'`` when the parser rejects the body or a key is not a
+    scalar. ``issues`` are the findings a strict reader raises -- the
+    parse error, the non-mapping body, each non-scalar key, each
+    duplicate key -- as ``(line, reason, cause)`` with 1-based file
+    lines. Only the body between the fences reaches the parser: the
+    fences are the wiki's grammar and document markers to YAML. The node
+    graph is composed, never constructed, so a stamp stays its source
+    text and a typed-looking title stays a string.
+    """
+    import yaml
+
+    # feed the parser the body between the fences (a fenceless body reads as is)
+    lines = frontmatter.split('\n')
+    if lines and (lines[0].lstrip('\ufeff').strip() == '---'):
+        lines = lines[1:]
+    if lines and (lines[-1].rstrip() == '---'):
+        lines = lines[:-1]
+    body = '\n'.join(lines) + '\n'
+    # the C loader is a build-time option of the PyYAML wheel; values and
+    # styles match the pure loader's, which raises RecursionError on nesting
+    # the C loader composes, while the C loader raises UnicodeEncodeError,
+    # not a YAML error, encoding a lone surrogate for libyaml
+    loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+    try:
+        root = yaml.compose(body, Loader=loader)
+    except (yaml.YAMLError, RecursionError, UnicodeEncodeError) as e:
+        # body line 0 is file line 2 (the opening fence); an error without a
+        # mark (a character YAML forbids, the recursion limit) locates by the
+        # first forbidden character, else names the block's first line
+        mark = getattr(e, 'problem_mark', None)
+        forbidden = yaml.reader.Reader.NON_PRINTABLE.search(body)
+        if mark is not None:
+            line = mark.line + 2
+        elif forbidden is not None:
+            line = body.count('\n', 0, forbidden.start()) + 2
+        else:
+            line = 1
+        reason = getattr(e, 'problem', None)
+        if reason is None:
+            reason = getattr(e, 'reason', None)
+        if reason is None:
+            reason = type(e).__name__
+        return 'invalid', {}, ((line, str(reason), 'parse'),)
+    if root is None:
+        return 'empty', {}, ()
+    if not isinstance(root, yaml.MappingNode):
+        return 'nonmapping', {}, ((1, 'frontmatter is not a mapping', 'nonmapping'),)
+    # walk the pairs in order: the first occurrence of a key wins, and a
+    # repeat or a non-scalar key is a strict-reader finding
+    kind = 'mapping'
+    fields: _Fields = {}
+    issues: list[_Issue] = []
+    seen: dict[str, int] = {}
+    for key_node, value_node in root.value:
+        line = key_node.start_mark.line + 2
+        if not isinstance(key_node, yaml.ScalarNode):
+            issues.append((line, 'a key is not a scalar', 'nonscalar_key'))
+            kind = 'invalid'
+            continue
+        key = key_node.value
+        if key in seen:
+            reason = f'duplicate key {key!r} (first at line {seen[key]})'
+            issues.append((line, reason, 'duplicate_key'))
+            continue
+        seen[key] = line
+        if isinstance(value_node, yaml.ScalarNode):
+            # the C loader reports a plain style as '', the pure loader as None
+            fields[key] = (value_node.value, value_node.style or None, value_node.tag)
+        else:
+            fields[key] = None
+    return kind, fields, tuple(issues)
+
+
+def _scalar_fields(frontmatter: str) -> Optional[_Fields]:
+    """Return the block's scalar fields, or ``None`` to defer to the line grammar.
+
+    A block the parser rejects, a body that is not a mapping, and a
+    non-scalar key all read through the line grammar, so the reader
+    never fails on input the writer tolerates.
+    """
+    kind, fields, _ = _compose_fields(frontmatter)
+    if kind == 'mapping':
+        return fields
+    if kind == 'empty':
+        return {}
+    return None
+
+
+def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
+    """Read a scalar frontmatter ``key`` with the line grammar.
+
+    The fallback behind :func:`read_frontmatter_field` for a block a
+    strict parser rejects. A plain ``key: value`` returns the stripped
+    value, with one pair of matching surrounding YAML quotes stripped. A
+    block scalar (``|``/``>`` with optional chomping/indentation
+    indicators, e.g. ``|-``, ``>+``, ``|2``) resolves to its body: a
+    literal ``|`` keeps line breaks, a folded ``>`` joins consecutive
+    non-empty lines with a single space (a blank line is a paragraph
+    break). Inline text on the indicator line (``key: > one liner.``) is
+    taken as the value when no indented body follows. A bare ``key:``
+    over an indented body is a plain multi-line scalar and folds the
+    same way ``>`` does. Returns ``None`` if the field is absent; an
+    empty block body resolves to an empty string.
+    """
+    # single-line value
+    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.+)$', frontmatter, re.MULTILINE)
+    if match:
+        value = match.group(1).strip()
+        if not value.startswith(('|', '>')):
+            return unquote(value)
+    else:
+        # bare key: an indented body is a plain multi-line scalar, folded
+        # per the YAML plain-scalar rule; no body reads as an absent value
+        match = re.search(
+            pattern=rf'^{key}[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+            string=frontmatter,
+            flags=re.MULTILINE,
+        )
+        if match and match.group(1).strip():
+            return fold_lines(match.group(1))
+        return None
+    # block scalar: tolerate any header (chomping/indentation indicators
+    # |- |+ >- |2 ...) plus trailing inline text, then capture the indented
+    # body (blank lines inside the block are kept so a folded break survives)
+    match = re.search(
+        pattern=rf'^{key}[ \t]*:[^\S\n]*([|>])[-+0-9]*[^\S\n]*(.*)\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        string=frontmatter,
+        flags=re.MULTILINE,
+    )
+    if not match:
+        return None
+    indicator, inline, body = match.group(1), match.group(2), match.group(3)
+    # no indented body: the inline text on the header line is the value,
+    # unless it is a comment
+    if not body:
+        return '' if inline.strip().startswith('#') else inline.strip()
+    body = textwrap.dedent(body)
+    # folded scalar (>): join non-empty lines with a space, blank line breaks
+    if indicator == '>':
+        return fold_lines(body)
+    return body.strip()
+
+
+def _is_unset_field(frontmatter: str, key: str) -> bool:
+    """Return whether ``key`` is absent or carries the plain ``null`` reset idiom.
+
+    A plain lowercase ``null`` -- with or without a trailing comment --
+    is the one reset spelling; a quoted or block-scalar ``null`` is
+    authored text. Under the line grammar the check reads the raw
+    spelling, since unquoting first would collapse an authored
+    ``'null'`` into the idiom.
+    """
+    fields = _scalar_fields(frontmatter)
+    if fields is not None:
+        if key not in fields:
+            return True
+        entry = fields[key]
+        if entry is None:
+            return False
+        value, style, tag = entry
+        # plain and resolved as null: an explicit !!str tag makes it text
+        return (value == 'null') and (style is None) and tag.endswith(':null')
+    match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
+    return (match is None) or (match.group(1).strip() == 'null')
+
+
+def _is_plain_safe(value: str) -> bool:
+    """Return whether a strict YAML reader reads ``value`` back verbatim when plain.
+
+    A value containing ``': '`` (or ending with ``:``) reads as a nested
+    mapping, one containing ``' #'`` loses everything from the hash (a
+    comment), one opening with an indicator character or with ``'- '``,
+    ``'? '``, or ``': '`` reads as structure, a node property, or a quoted
+    scalar, and leading or trailing whitespace (a tab anywhere) is dropped
+    or rejected -- so none of them may be written plain.
+    """
+    if not value:
+        return True
+    if value != value.strip():
+        return False
+    if (': ' in value) or value.endswith(':') or (' #' in value) or ('\t' in value):
+        return False
+    if _ESCAPED_CHARS.search(value):
+        return False
+    if value[0] in _INDICATOR_CHARS:
+        return False
+    if (value in ('-', '?', ':')) or (value[:2] in ('- ', '? ', ': ')):
+        return False
+    return True
+
+
+def _unescape(match: re.Match[str]) -> str:
+    """Resolve one double-quoted YAML escape; an unknown one stays verbatim."""
+    code, byte, char = match.groups()
+    if code or byte:
+        return chr(int(code or byte, 16))
+    return _ESCAPES.get(char, f'\\{char}')

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import re
 import textwrap
 from typing import Optional
@@ -34,6 +35,20 @@ _FRONTMATTER_TAIL = (
     'created',
     'updated',
 )
+
+# per-process memo of composed frontmatter blocks: an update reads each block
+# a few times and a lint a few more, and a run over a few thousand pages fits
+# one cache at about a kilobyte per block
+_SCALAR_CACHE_SIZE = 4096
+
+# characters that open a YAML indicator (flow collection, comment, node
+# property, block scalar, quote, directive, reserved) when they lead a value
+_INDICATOR_CHARS = ',[]{}#&*!|>\'"%@`'
+
+# the scalar fields of one block: key -> (value text, style) for a scalar
+# value -- the style None for plain, else the quote or block indicator -- and
+# None for a sequence or mapping value
+_Fields = dict[str, Optional[tuple[str, Optional[str]]]]
 
 
 def extract_frontmatter(lines: list[str]) -> tuple[str, int]:
@@ -377,6 +392,22 @@ def strip_blank_lines(frontmatter: str) -> str:
     return '\n'.join(result)
 
 
+def _valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
+    """Return whether a field's ``indicator`` line and indented ``body`` carry no value.
+
+    A trailing ``# comment`` on the indicator line is not a value, so
+    ``null # why`` resets like ``null`` and ``| # note`` is an empty
+    block like ``|``; the field is valueless when what remains is one
+    of the ``nulls`` spellings or a bare block header over no body.
+    """
+    value = indicator.split(':', 1)[1].strip()
+    # a hash leading the value or following whitespace opens a comment
+    value = re.sub(r'(?:^|\s)#.*', '', value).strip()
+    no_value = value in nulls
+    bare_indicator = bool(re.fullmatch(r'[|>][-+0-9]*', value))
+    return not body.strip() and (no_value or bare_indicator)
+
+
 def repair_frontmatter(
     frontmatter: str,
     *,
@@ -423,9 +454,9 @@ def repair_frontmatter(
         # backslash-digit in the name is not read as a group reference
         fresh = f'name: {quote(name)}\n'
         value = name_field.group(1).strip()
-        if value.startswith(('|', '>')) or not value:
-            # block scalar (or bare key, folding like >): the whole indented
-            # body goes -- a `#` line or a blank inside it is content
+        if value.startswith(('|', '>')):
+            # block scalar: the whole indented body goes -- a `#` line or a
+            # blank inside it is content
             frontmatter = re.sub(
                 pattern=r'^name:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
                 repl=lambda _: fresh,
@@ -434,12 +465,12 @@ def repair_frontmatter(
                 flags=re.MULTILINE,
             )
         else:
-            # plain value: every continuation line is value text and goes -- blank
-            # lines included, since strip_blank_lines keeps a blank whose next line
-            # stays indented and a paragraph break belongs to the stale value being
-            # replaced -- while the `# comment` lines among them re-emit under the
-            # fresh name; consuming the full extent means nothing strands as a
-            # continuation of the fresh one-liner
+            # plain value or bare key: every continuation line is value text and
+            # goes -- blank lines included, since strip_blank_lines keeps a blank
+            # whose next line stays indented and a paragraph break belongs to the
+            # stale value being replaced -- while the `# comment` lines among them
+            # re-emit under the fresh name; consuming the full extent means
+            # nothing strands as a continuation of the fresh one-liner
             def keep_comments(match: re.Match[str]) -> str:
                 lines = match.group(1).splitlines(keepends=True)
                 comments = [line for line in lines if line.lstrip().startswith('#')]
@@ -466,10 +497,7 @@ def repair_frontmatter(
     )
     if desc_match:
         indicator, _, body = desc_match.group(0).partition('\n')
-        value = indicator.split(':', 1)[1].strip()
-        no_value = value in ('', "''", '""')
-        bare_indicator = bool(re.fullmatch(r'[|>][-+0-9]*', value))
-        if not body.strip() and (no_value or bare_indicator):
+        if _valueless(indicator, body, nulls=('', "''", '""')):
             frontmatter = (
                 frontmatter[: desc_match.start()]
                 + 'desc: ...\n'
@@ -483,9 +511,15 @@ def repair_frontmatter(
             count=1,
             flags=re.MULTILINE,
         )
-    # add created/updated if missing; stamp a present-but-blank key
-    # in place so a duplicate is never appended
-    if re.search(r'^created:[^\S\n]*$', frontmatter, re.MULTILINE):
+    # add created/updated if missing; stamp a present-but-blank key in
+    # place so a duplicate is never appended -- a bare key over an indented
+    # body is a value (lint judges it), never a blank to stamp over
+    created = re.search(
+        pattern=r'^created:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        string=frontmatter,
+        flags=re.MULTILINE,
+    )
+    if created and not created.group(1).strip():
         frontmatter = re.sub(
             pattern=r'^created:[^\S\n]*$',
             # a callable repl, so a backslash in a user timestamp.format is
@@ -499,7 +533,12 @@ def repair_frontmatter(
         match = re.search(r'^updated:', frontmatter, re.MULTILINE)
         pos = match.start() if match else frontmatter.rfind('---')
         frontmatter = frontmatter[:pos] + f'created: {now}\n' + frontmatter[pos:]
-    if re.search(r'^updated:[^\S\n]*$', frontmatter, re.MULTILINE):
+    updated = re.search(
+        pattern=r'^updated:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+        string=frontmatter,
+        flags=re.MULTILINE,
+    )
+    if updated and not updated.group(1).strip():
         frontmatter = re.sub(
             pattern=r'^updated:[^\S\n]*$',
             repl=lambda _: f'updated: {now}',
@@ -524,10 +563,7 @@ def repair_frontmatter(
         )
         if match:
             indicator, _, body = match.group(0).partition('\n')
-            value = indicator.split(':', 1)[1].strip()
-            no_value = value in ('', 'null')
-            bare_indicator = bool(re.fullmatch(r'[|>][-+0-9]*', value))
-            if not body.strip() and (no_value or bare_indicator):
+            if _valueless(indicator, body, nulls=('', 'null')):
                 frontmatter = frontmatter[: match.start()] + frontmatter[match.end() :]
     # drop an unset title the same way (the first occurrence wins,
     # matching every reader); an authored title's slot under name: is
@@ -540,10 +576,7 @@ def repair_frontmatter(
         )
         if match:
             indicator, _, body = match.group(0).partition('\n')
-            value = indicator.split(':', 1)[1].strip()
-            no_value = value in ('', 'null')
-            bare_indicator = bool(re.fullmatch(r'[|>][-+0-9]*', value))
-            if not body.strip() and (no_value or bare_indicator):
+            if _valueless(indicator, body, nulls=('', 'null')):
                 frontmatter = frontmatter[: match.start()] + frontmatter[match.end() :]
     # enforce the canonical field order LAST: the insertions above anchor
     # on schema neighbors and authored fields start anywhere, so the full
@@ -647,20 +680,132 @@ def replace_heading(content: str, name: str) -> str:
     return content
 
 
-def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
-    """Read a scalar frontmatter ``key``, resolving block scalars.
+@functools.lru_cache(maxsize=_SCALAR_CACHE_SIZE)
+def _compose_fields(frontmatter: str) -> tuple[str, _Fields]:
+    """Compose a frontmatter block into its top-level scalar fields.
 
-    A plain ``key: value`` returns the stripped value, with one pair of
-    matching surrounding YAML quotes stripped (a desc containing ``: ``
-    must be quoted to stay valid YAML). A block scalar (``|``/``>`` with
-    optional chomping/indentation indicators, e.g. ``|-``, ``>+``, ``|2``)
-    resolves to its body: a literal ``|`` keeps line breaks, a folded
-    ``>`` joins consecutive non-empty lines with a single space (a blank
-    line is a paragraph break). Inline text on the indicator line
-    (``key: > one liner.``) is taken as the value when no indented body
-    follows. A bare ``key:`` over an indented body is a plain multi-line
-    scalar and folds the same way ``>`` does. Returns ``None`` if the
-    field is absent; an empty block body resolves to an empty string.
+    Returns ``(kind, fields)``. ``kind`` is ``'mapping'`` when the body
+    is a YAML mapping -- ``fields`` then maps each key, first occurrence
+    winning, to its scalar text and style (``None`` for plain, else the
+    quote or block indicator), or to ``None`` for a sequence or mapping
+    value -- ``'empty'`` for a body with no content, ``'nonmapping'``
+    for valid YAML that is not a mapping, and ``'invalid'`` when the
+    parser rejects the body or a key is not a scalar. Only the body
+    between the fences reaches the parser: the fences are the wiki's
+    grammar and document markers to YAML. The node graph is composed,
+    never constructed, so a stamp stays its source text and a
+    typed-looking title stays a string.
+    """
+    import yaml
+
+    # feed the parser the body between the fences (a fenceless body reads as is)
+    lines = frontmatter.split('\n')
+    if lines and (lines[0].lstrip('﻿').strip() == '---'):
+        lines = lines[1:]
+    if lines and (lines[-1].rstrip() == '---'):
+        lines = lines[:-1]
+    body = '\n'.join(lines) + '\n'
+    # the C loader is a build-time option of the PyYAML wheel; values and
+    # styles match the pure loader's, which raises RecursionError on nesting
+    # the C loader composes
+    loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+    try:
+        root = yaml.compose(body, Loader=loader)
+    except (yaml.YAMLError, RecursionError):
+        return 'invalid', {}
+    if root is None:
+        return 'empty', {}
+    if not isinstance(root, yaml.MappingNode):
+        return 'nonmapping', {}
+    # walk the pairs in order; the first occurrence of a key wins
+    fields: _Fields = {}
+    for key_node, value_node in root.value:
+        if not isinstance(key_node, yaml.ScalarNode):
+            return 'invalid', {}
+        if key_node.value in fields:
+            continue
+        if isinstance(value_node, yaml.ScalarNode):
+            # the C loader reports a plain style as '', the pure loader as None
+            fields[key_node.value] = (value_node.value, value_node.style or None)
+        else:
+            fields[key_node.value] = None
+    return 'mapping', fields
+
+
+def _scalar_fields(frontmatter: str) -> Optional[_Fields]:
+    """Return the block's scalar fields, or ``None`` to defer to the line grammar.
+
+    A block the parser rejects, a body that is not a mapping, and a
+    non-scalar key all read through the line grammar, so the reader
+    never fails on input the writer tolerates.
+    """
+    kind, fields = _compose_fields(frontmatter)
+    if kind == 'mapping':
+        return fields
+    if kind == 'empty':
+        return {}
+    return None
+
+
+def nonmapping_frontmatter(frontmatter: str) -> bool:
+    """Return whether the block is valid YAML that is not a ``key: value`` mapping.
+
+    A bare sentence or a list between the fences has no fields to read
+    or repair; the planners keep such a page as written and report it
+    rather than append fields under the text.
+    """
+    kind, _ = _compose_fields(frontmatter)
+    return kind == 'nonmapping'
+
+
+def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
+    """Read a scalar frontmatter ``key`` as a strict YAML reader sees it.
+
+    The value is the scalar text a YAML parser resolves -- a plain scalar
+    folded across its continuation lines, a quoted scalar decoded, a
+    block scalar's body without its final line breaks (every consumer
+    wants the text, not the chomping) -- and never a coerced type: a
+    stamp stays its source text. The first occurrence of a duplicated
+    key wins. Returns ``None`` when the field is absent or a bare
+    ``key:`` has no body. A sequence or mapping value, a block the
+    parser rejects, and a body that is not a mapping fall back to the
+    line grammar (:func:`_read_field_lines`), so the wiki's leniencies --
+    an unquoted ``: `` inside a one-line value, conflict markers -- read
+    as before.
+    """
+    fields = _scalar_fields(frontmatter)
+    if fields is None:
+        return _read_field_lines(frontmatter, key)
+    if key not in fields:
+        return None
+    entry = fields[key]
+    if entry is None:
+        return _read_field_lines(frontmatter, key)
+    value, style = entry
+    # a block scalar's final breaks are chomping, not content
+    if style in ('|', '>'):
+        return value.rstrip('\n')
+    # a bare key with no body reads as an absent value
+    if (style is None) and (value == ''):
+        return None
+    return value
+
+
+def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
+    """Read a scalar frontmatter ``key`` with the line grammar.
+
+    The fallback behind :func:`read_frontmatter_field` for a block a
+    strict parser rejects. A plain ``key: value`` returns the stripped
+    value, with one pair of matching surrounding YAML quotes stripped. A
+    block scalar (``|``/``>`` with optional chomping/indentation
+    indicators, e.g. ``|-``, ``>+``, ``|2``) resolves to its body: a
+    literal ``|`` keeps line breaks, a folded ``>`` joins consecutive
+    non-empty lines with a single space (a blank line is a paragraph
+    break). Inline text on the indicator line (``key: > one liner.``) is
+    taken as the value when no indented body follows. A bare ``key:``
+    over an indented body is a plain multi-line scalar and folds the
+    same way ``>`` does. Returns ``None`` if the field is absent; an
+    empty block body resolves to an empty string.
     """
     # single-line value
     match = re.search(rf'^{key}:[^\S\n]*(.+)$', frontmatter, re.MULTILINE)
@@ -720,6 +865,22 @@ def read_frontmatter_name(frontmatter: str) -> Optional[str]:
     return join_lines(value)
 
 
+def _unset_field(frontmatter: str, key: str) -> bool:
+    """Return whether ``key`` is absent or carries the plain ``null`` reset idiom.
+
+    A plain lowercase ``null`` -- with or without a trailing comment --
+    is the one reset spelling; a quoted or block-scalar ``null`` is
+    authored text. Under the line grammar the check reads the raw
+    spelling, since unquoting first would collapse an authored
+    ``'null'`` into the idiom.
+    """
+    fields = _scalar_fields(frontmatter)
+    if fields is not None:
+        return (key not in fields) or (fields[key] == ('null', None))
+    match = re.search(rf'^{key}:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
+    return (match is None) or (match.group(1).strip() == 'null')
+
+
 def read_frontmatter_title(frontmatter: str) -> str:
     """Return the ``title`` field from frontmatter text.
 
@@ -733,12 +894,9 @@ def read_frontmatter_title(frontmatter: str) -> str:
     growth (authored frontmatter is user input; this is boundary
     validation).
     """
-    # the unset check reads the raw spelling: unquoting first would
-    # collapse an authored 'null' into the reset idiom; a bare 'title:'
-    # defers to the delegate, which resolves an indented body as a plain
-    # multi-line scalar and no body as an absent value
-    match = re.search(r'^title:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
-    if (match is None) or (match.group(1).strip() == 'null'):
+    # a bare 'title:' defers to the delegate, which resolves an indented
+    # body as a plain multi-line scalar and no body as an absent value
+    if _unset_field(frontmatter, 'title'):
         return ''
     value = read_frontmatter_field(frontmatter, 'title')
     return join_lines(value or '')
@@ -766,12 +924,9 @@ def read_frontmatter_category(frontmatter: str) -> str:
     raw newline would break the row on every parse (authored frontmatter
     is user input; this is boundary validation).
     """
-    # the unset check reads the raw spelling: unquoting first would
-    # collapse an authored 'null' into the reset idiom; a bare
-    # 'category:' defers to the delegate, which resolves an indented
+    # a bare 'category:' defers to the delegate, which resolves an indented
     # body as a plain multi-line scalar and no body as an absent value
-    match = re.search(r'^category:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
-    if (match is None) or (match.group(1).strip() == 'null'):
+    if _unset_field(frontmatter, 'category'):
         return ''
     value = read_frontmatter_field(frontmatter, 'category')
     return join_lines(value or '')
@@ -972,22 +1127,40 @@ def fold_lines(text: str) -> str:
     return '\n'.join(paragraphs)
 
 
-def quote(value: str) -> str:
-    """YAML-quote a scalar when writing it plain would break the mapping.
+def _plain_safe(value: str) -> bool:
+    """Return whether a strict YAML reader reads ``value`` back verbatim when plain.
 
     A value containing ``': '`` (or ending with ``:``) reads as a nested
-    mapping in YAML, one opening with a block-scalar indicator (``|``/``>``)
-    reads as a block scalar (:func:`read_frontmatter_field` diverts it there
-    and eats the indicator), and one wrapped in matching quote chars would
-    lose its quotes to :func:`unquote` on read, so each is written
-    single-quoted with embedded single quotes doubled; any other value
-    passes through unquoted. Inverse of :func:`unquote` for the values
-    the wiki writes.
+    mapping, one containing ``' #'`` loses everything from the hash (a
+    comment), one opening with an indicator character or ``- ``/``? ``/
+    ``: `` reads as structure, a node property, or a quoted scalar, and
+    leading or trailing whitespace (a tab anywhere) is dropped or
+    rejected -- so none of them may be written plain.
     """
-    mapping_shaped = ': ' in value or value.endswith(':')
-    block_shaped = value.startswith(('|', '>'))
-    quote_wrapped = unquote(value) != value
-    if mapping_shaped or block_shaped or quote_wrapped:
+    if not value:
+        return True
+    if value != value.strip():
+        return False
+    if (': ' in value) or value.endswith(':') or (' #' in value) or ('\t' in value):
+        return False
+    if value[0] in _INDICATOR_CHARS:
+        return False
+    if (value in ('-', '?', ':')) or (value[:2] in ('- ', '? ', ': ')):
+        return False
+    return True
+
+
+def quote(value: str) -> str:
+    """YAML-quote a scalar when writing it plain would misread.
+
+    A value a strict reader would not read back verbatim as plain text
+    (:func:`_plain_safe`) -- one shaped like a mapping, carrying a
+    comment start, opening with an indicator, or wrapped in quote chars
+    that :func:`unquote` would strip on read -- is written single-quoted
+    with embedded single quotes doubled; any other value passes through
+    unquoted. Inverse of :func:`unquote` for the values the wiki writes.
+    """
+    if not _plain_safe(value):
         escaped = value.replace("'", "''")
         return f"'{escaped}'"
     return value

--- a/wiki/core/format.py
+++ b/wiki/core/format.py
@@ -45,10 +45,23 @@ _SCALAR_CACHE_SIZE = 4096
 # property, block scalar, quote, directive, reserved) when they lead a value
 _INDICATOR_CHARS = ',[]{}#&*!|>\'"%@`'
 
-# the scalar fields of one block: key -> (value text, style) for a scalar
-# value -- the style None for plain, else the quote or block indicator -- and
-# None for a sequence or mapping value
-_Fields = dict[str, Optional[tuple[str, Optional[str]]]]
+# the scalar fields of one block: key -> (value text, style, resolved tag) for
+# a scalar value -- the style None for plain, else the quote or block
+# indicator -- and None for a sequence or mapping value
+_Fields = dict[str, Optional[tuple[str, Optional[str], str]]]
+
+# a strict-reader finding on a block: (1-based file line, reason, cause), the
+# cause one of 'parse', 'nonmapping', 'nonscalar_key', 'duplicate_key'
+_Issue = tuple[int, str, str]
+
+# characters no YAML stream may carry plain or single-quoted -- controls (a
+# tab excepted), the DEL, and the line separators NEL, LS, and PS -- plus
+# lone surrogates; a value holding one is written double-quoted with escapes
+_ESCAPED_CHARS = re.compile(r'[\x00-\x08\x0a-\x1f\x7f\x85\u2028\u2029\ud800-\udfff]')
+
+#: the lines continuing a frontmatter field below its key line: indented
+#: lines, blank lines, and column-0 sequence items (``- item``)
+FIELD_EXTENT = r'(?:[ \t]+.*\n|[ \t]*\n|-(?:[ \t].*)?\n)*'
 
 
 def extract_frontmatter(lines: list[str]) -> tuple[str, int]:
@@ -392,20 +405,72 @@ def strip_blank_lines(frontmatter: str) -> str:
     return '\n'.join(result)
 
 
-def _valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
-    """Return whether a field's ``indicator`` line and indented ``body`` carry no value.
+def _uncommented(text: str) -> str:
+    """Return ``text`` without a ``# comment`` -- one leading it or following whitespace."""
+    return re.sub(r'(?:^|\s)#.*', '', text).strip()
 
-    A trailing ``# comment`` on the indicator line is not a value, so
-    ``null # why`` resets like ``null`` and ``| # note`` is an empty
-    block like ``|``; the field is valueless when what remains is one
-    of the ``nulls`` spellings or a bare block header over no body.
+
+def _valueless(indicator: str, body: str, *, nulls: tuple[str, ...]) -> bool:
+    """Return whether a field's ``indicator`` line and ``body`` carry no value.
+
+    Comments are not a value: ``null # why`` resets like ``null``,
+    ``| # note`` is an empty block like ``|``, and a body of comment lines
+    is no body. The field is valueless when what remains -- on the
+    indicator line, or continued in the body -- is one of the ``nulls``
+    spellings, or a bare block header over no body at all (a block's body
+    is content, comment-shaped lines included).
     """
-    value = indicator.split(':', 1)[1].strip()
-    # a hash leading the value or following whitespace opens a comment
-    value = re.sub(r'(?:^|\s)#.*', '', value).strip()
-    no_value = value in nulls
-    bare_indicator = bool(re.fullmatch(r'[|>][-+0-9]*', value))
-    return not body.strip() and (no_value or bare_indicator)
+    value = _uncommented(indicator.split(':', 1)[1])
+    if re.fullmatch(r'[|>][-+0-9]*', value):
+        return not body.strip()
+    content = ' '.join(_uncommented(line) for line in body.split('\n')).strip()
+    return (value in nulls) and (content in nulls)
+
+
+def _field_comments(indicator: str, body: str) -> tuple[str, str]:
+    """Return the comments a valueless field carries: the indicator's tail, the body's lines.
+
+    The tail keeps a leading space so it re-attaches after a written value;
+    the lines keep their indentation and breaks so they re-emit under it.
+    """
+    match = re.search(r'(?:^|\s)(#.*)$', indicator.split(':', 1)[1])
+    tail = f' {match.group(1)}' if match else ''
+    lines = body.splitlines(keepends=True)
+    comments = ''.join(line for line in lines if line.lstrip().startswith('#'))
+    return tail, comments
+
+
+def _fill_stamp(frontmatter: str, key: str, now: str, *, before: Optional[str]) -> str:
+    """Stamp a missing or valueless ``key`` with ``now``.
+
+    A present key is stamped in place -- so a duplicate is never appended
+    -- when its value is blank, quoted-empty, or comments only, and the
+    comments ride along; a key over a real value (a stamp continued on an
+    indented line, a sequence) stays for lint to judge. A missing key is
+    inserted before ``before`` when that key is present, else before the
+    closing delimiter. ``now`` is quoted whenever a plain scalar would
+    misread it, and spliced rather than substituted so a backslash in a
+    user ``timestamp.format`` is emitted verbatim.
+    """
+    match = re.search(
+        pattern=rf'^{key}[ \t]*:(.*)\n({FIELD_EXTENT})',
+        string=frontmatter,
+        flags=re.MULTILINE,
+    )
+    if match:
+        indicator, _, body = match.group(0).partition('\n')
+        if _valueless(indicator, body, nulls=('', "''", '""')):
+            tail, comments = _field_comments(indicator, body)
+            stamp = f'{key}: {quote(now)}{tail}\n{comments}'
+            frontmatter = (
+                frontmatter[: match.start()] + stamp + frontmatter[match.end() :]
+            )
+        return frontmatter
+    anchor = None
+    if before is not None:
+        anchor = re.search(rf'^{before}[ \t]*:', frontmatter, re.MULTILINE)
+    pos = anchor.start() if anchor else frontmatter.rfind('---')
+    return frontmatter[:pos] + f'{key}: {quote(now)}\n' + frontmatter[pos:]
 
 
 def repair_frontmatter(
@@ -458,7 +523,7 @@ def repair_frontmatter(
             # block scalar: the whole indented body goes -- a `#` line or a
             # blank inside it is content
             frontmatter = re.sub(
-                pattern=r'^name[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+                pattern=rf'^name[ \t]*:.*\n{FIELD_EXTENT}',
                 repl=lambda _: fresh,
                 string=frontmatter,
                 count=1,
@@ -477,7 +542,7 @@ def repair_frontmatter(
                 return fresh + ''.join(comments)
 
             frontmatter = re.sub(
-                pattern=r'^name[ \t]*:.*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
+                pattern=rf'^name[ \t]*:.*\n({FIELD_EXTENT})',
                 repl=keep_comments,
                 string=frontmatter,
                 count=1,
@@ -491,16 +556,20 @@ def repair_frontmatter(
     # empty block scalar (mirrors the title branch's valueless check below),
     # all of which read as no description; a real block-scalar body is kept
     desc_match = re.search(
-        pattern=r'^desc[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+        pattern=rf'^desc[ \t]*:.*\n{FIELD_EXTENT}',
         string=frontmatter,
         flags=re.MULTILINE,
     )
     if desc_match:
         indicator, _, body = desc_match.group(0).partition('\n')
         if _valueless(indicator, body, nulls=('', "''", '""')):
+            # the comments the valueless field carried ride along with the
+            # placeholder: the indicator's tail after it, the body's lines
+            # under it
+            tail, comments = _field_comments(indicator, body)
             frontmatter = (
                 frontmatter[: desc_match.start()]
-                + 'desc: ...\n'
+                + f'desc: ...{tail}\n{comments}'
                 + frontmatter[desc_match.end() :]
             )
     elif not re.search(r'^desc[ \t]*:', frontmatter, re.MULTILINE):
@@ -511,73 +580,48 @@ def repair_frontmatter(
             count=1,
             flags=re.MULTILINE,
         )
-    # add created/updated if missing; stamp a present-but-blank key in
-    # place so a duplicate is never appended -- a bare key over an indented
-    # body is a value (lint judges it), never a blank to stamp over
-    created = re.search(
-        pattern=r'^created[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
-        string=frontmatter,
-        flags=re.MULTILINE,
-    )
-    if created and not created.group(1).strip():
-        frontmatter = re.sub(
-            pattern=r'^created[ \t]*:[^\S\n]*$',
-            # a callable repl, so a backslash in a user timestamp.format is
-            # emitted verbatim, not parsed as a group reference
-            repl=lambda _: f'created: {now}',
-            string=frontmatter,
-            count=1,
-            flags=re.MULTILINE,
-        )
-    elif not re.search(r'^created[ \t]*:', frontmatter, re.MULTILINE):
-        match = re.search(r'^updated[ \t]*:', frontmatter, re.MULTILINE)
-        pos = match.start() if match else frontmatter.rfind('---')
-        frontmatter = frontmatter[:pos] + f'created: {now}\n' + frontmatter[pos:]
-    updated = re.search(
-        pattern=r'^updated[ \t]*:[^\S\n]*\n((?:[ \t]+.*\n|[ \t]*\n)*)',
-        string=frontmatter,
-        flags=re.MULTILINE,
-    )
-    if updated and not updated.group(1).strip():
-        frontmatter = re.sub(
-            pattern=r'^updated[ \t]*:[^\S\n]*$',
-            repl=lambda _: f'updated: {now}',
-            string=frontmatter,
-            count=1,
-            flags=re.MULTILINE,
-        )
-    elif not re.search(r'^updated[ \t]*:', frontmatter, re.MULTILINE):
-        pos = frontmatter.rfind('---')
-        frontmatter = frontmatter[:pos] + f'updated: {now}\n' + frontmatter[pos:]
+    # add created/updated if missing; stamp a present-but-valueless key in
+    # place so a duplicate is never appended (created slots before updated)
+    frontmatter = _fill_stamp(frontmatter, 'created', now, before='updated')
+    frontmatter = _fill_stamp(frontmatter, 'updated', now, before=None)
     # drop an unset category: absence is the canonical unset form, so a
     # provably valueless field -- a blank value, the plain lowercase null
     # spelling, or an empty block scalar -- removes its whole extent
     # (indicator line plus indented/blank body, so a block scalar goes as
-    # one unit); a quoted or block-scalar 'null' is authored text, kept
-    # verbatim, and the field is never inserted
+    # one unit) while its comments stay behind as comment lines; a quoted
+    # or block-scalar 'null' is authored text, kept verbatim, and the field
+    # is never inserted
     if category:
         match = re.search(
-            pattern=r'^category[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+            pattern=rf'^category[ \t]*:.*\n{FIELD_EXTENT}',
             string=frontmatter,
             flags=re.MULTILINE,
         )
         if match:
             indicator, _, body = match.group(0).partition('\n')
             if _valueless(indicator, body, nulls=('', 'null')):
-                frontmatter = frontmatter[: match.start()] + frontmatter[match.end() :]
+                tail, comments = _field_comments(indicator, body)
+                kept = f'{tail.strip()}\n{comments}' if tail else comments
+                frontmatter = (
+                    frontmatter[: match.start()] + kept + frontmatter[match.end() :]
+                )
     # drop an unset title the same way (the first occurrence wins,
     # matching every reader); an authored title's slot under name: is
     # the order pass's job
     if title:
         match = re.search(
-            pattern=r'^title[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+            pattern=rf'^title[ \t]*:.*\n{FIELD_EXTENT}',
             string=frontmatter,
             flags=re.MULTILINE,
         )
         if match:
             indicator, _, body = match.group(0).partition('\n')
             if _valueless(indicator, body, nulls=('', 'null')):
-                frontmatter = frontmatter[: match.start()] + frontmatter[match.end() :]
+                tail, comments = _field_comments(indicator, body)
+                kept = f'{tail.strip()}\n{comments}' if tail else comments
+                frontmatter = (
+                    frontmatter[: match.start()] + kept + frontmatter[match.end() :]
+                )
     # enforce the canonical field order LAST: the insertions above anchor
     # on schema neighbors and authored fields start anywhere, so the full
     # reorder must have the final word
@@ -608,7 +652,7 @@ def order_frontmatter(frontmatter: str) -> str:
     preamble = []
     current = None
     for line in lines[1:-1]:
-        match = re.match(r'^([\w.-]+)[ \t]*:', line)
+        match = re.match(r'^([\w.-]+)[ \t]*:(?:[ \t]|$)', line)
         if match:
             current = (match.group(1), [line])
             extents.append(current)
@@ -681,20 +725,25 @@ def replace_heading(content: str, name: str) -> str:
 
 
 @functools.lru_cache(maxsize=_SCALAR_CACHE_SIZE)
-def _compose_fields(frontmatter: str) -> tuple[str, _Fields]:
+def _compose_fields(frontmatter: str) -> tuple[str, _Fields, tuple[_Issue, ...]]:
     """Compose a frontmatter block into its top-level scalar fields.
 
-    Returns ``(kind, fields)``. ``kind`` is ``'mapping'`` when the body
-    is a YAML mapping -- ``fields`` then maps each key, first occurrence
-    winning, to its scalar text and style (``None`` for plain, else the
-    quote or block indicator), or to ``None`` for a sequence or mapping
-    value -- ``'empty'`` for a body with no content, ``'nonmapping'``
-    for valid YAML that is not a mapping, and ``'invalid'`` when the
-    parser rejects the body or a key is not a scalar. Only the body
-    between the fences reaches the parser: the fences are the wiki's
-    grammar and document markers to YAML. The node graph is composed,
-    never constructed, so a stamp stays its source text and a
-    typed-looking title stays a string.
+    Returns ``(kind, fields, issues)``. ``kind`` is ``'mapping'`` when
+    the body is a YAML mapping -- ``fields`` then maps each key, first
+    occurrence winning, to its scalar text, style (``None`` for plain,
+    else the quote or block indicator), and resolved tag, or to ``None``
+    for a sequence or mapping value -- ``'empty'`` for a body with no
+    content, ``'nonmapping'`` for valid YAML that is not a mapping and
+    holds no ``key:`` line, and ``'invalid'`` when the parser rejects
+    the body, a key is not a scalar, or a non-mapping body still carries
+    ``key:`` lines (a colon missing its space), which the line grammar
+    reads and the repair fixes. ``issues`` are the findings a strict
+    reader raises -- the parse error, the non-mapping body, each
+    non-scalar key, each duplicate key -- as ``(line, reason, cause)``
+    with 1-based file lines. Only the body between the fences reaches
+    the parser: the fences are the wiki's grammar and document markers
+    to YAML. The node graph is composed, never constructed, so a stamp
+    stays its source text and a typed-looking title stays a string.
     """
     import yaml
 
@@ -707,29 +756,59 @@ def _compose_fields(frontmatter: str) -> tuple[str, _Fields]:
     body = '\n'.join(lines) + '\n'
     # the C loader is a build-time option of the PyYAML wheel; values and
     # styles match the pure loader's, which raises RecursionError on nesting
-    # the C loader composes
+    # the C loader composes, and either raises UnicodeError, not a YAML
+    # error, on a lone surrogate
     loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
     try:
         root = yaml.compose(body, Loader=loader)
-    except (yaml.YAMLError, RecursionError):
-        return 'invalid', {}
+    except (yaml.YAMLError, RecursionError, UnicodeError) as error:
+        # body line 0 is file line 2 (the opening fence); an error without a
+        # mark (a character YAML forbids, the recursion limit) locates by the
+        # first forbidden character, else names the block's first line
+        mark = getattr(error, 'problem_mark', None)
+        forbidden = yaml.reader.Reader.NON_PRINTABLE.search(body)
+        if mark is not None:
+            line = mark.line + 2
+        elif forbidden is not None:
+            line = body.count('\n', 0, forbidden.start()) + 2
+        else:
+            line = 1
+        reason = getattr(error, 'problem', None) or getattr(error, 'reason', None)
+        reason = str(reason or type(error).__name__)
+        return 'invalid', {}, ((line, reason, 'parse'),)
     if root is None:
-        return 'empty', {}
+        return 'empty', {}, ()
     if not isinstance(root, yaml.MappingNode):
-        return 'nonmapping', {}
-    # walk the pairs in order; the first occurrence of a key wins
+        issue = (1, 'frontmatter is not a mapping', 'nonmapping')
+        # a scalar body holding key: lines is a mapping missing the space
+        # after a colon, which the line grammar reads and the repair fixes
+        if re.search(r'^[\w.-]+[ \t]*:', body, re.MULTILINE):
+            return 'invalid', {}, (issue,)
+        return 'nonmapping', {}, (issue,)
+    # walk the pairs in order: the first occurrence of a key wins, and a
+    # repeat or a non-scalar key is a strict-reader finding
+    kind = 'mapping'
     fields: _Fields = {}
+    issues: list[_Issue] = []
+    seen: dict[str, int] = {}
     for key_node, value_node in root.value:
+        line = key_node.start_mark.line + 2
         if not isinstance(key_node, yaml.ScalarNode):
-            return 'invalid', {}
-        if key_node.value in fields:
+            issues.append((line, 'a key is not a scalar', 'nonscalar_key'))
+            kind = 'invalid'
             continue
+        key = key_node.value
+        if key in seen:
+            reason = f'duplicate key {key!r} (first at line {seen[key]})'
+            issues.append((line, reason, 'duplicate_key'))
+            continue
+        seen[key] = line
         if isinstance(value_node, yaml.ScalarNode):
             # the C loader reports a plain style as '', the pure loader as None
-            fields[key_node.value] = (value_node.value, value_node.style or None)
+            fields[key] = (value_node.value, value_node.style or None, value_node.tag)
         else:
-            fields[key_node.value] = None
-    return 'mapping', fields
+            fields[key] = None
+    return kind, fields, tuple(issues)
 
 
 def _scalar_fields(frontmatter: str) -> Optional[_Fields]:
@@ -739,7 +818,7 @@ def _scalar_fields(frontmatter: str) -> Optional[_Fields]:
     non-scalar key all read through the line grammar, so the reader
     never fails on input the writer tolerates.
     """
-    kind, fields = _compose_fields(frontmatter)
+    kind, fields, _ = _compose_fields(frontmatter)
     if kind == 'mapping':
         return fields
     if kind == 'empty':
@@ -752,10 +831,25 @@ def nonmapping_frontmatter(frontmatter: str) -> bool:
 
     A bare sentence or a list between the fences has no fields to read
     or repair; the planners keep such a page as written and report it
-    rather than append fields under the text.
+    rather than append fields under the text. A scalar body that still
+    holds ``key:`` lines is a colon missing its space, not prose, and
+    reads through the line grammar instead.
     """
-    kind, _ = _compose_fields(frontmatter)
+    kind, _, _ = _compose_fields(frontmatter)
     return kind == 'nonmapping'
+
+
+def frontmatter_issues(frontmatter: str) -> list[_Issue]:
+    """Return the findings a strict YAML reader raises on the block.
+
+    Each is ``(line, reason, cause)``: the 1-based file line, the
+    parser's problem or the wiki's description, and the cause -- a
+    ``'parse'`` error, a ``'nonmapping'`` body, a ``'nonscalar_key'``,
+    or a ``'duplicate_key'``. An empty list is a block every strict
+    reader accepts as a mapping with unique scalar keys.
+    """
+    _, _, issues = _compose_fields(frontmatter)
+    return list(issues)
 
 
 def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
@@ -781,7 +875,10 @@ def read_frontmatter_field(frontmatter: str, key: str) -> Optional[str]:
     entry = fields[key]
     if entry is None:
         return _read_field_lines(frontmatter, key)
-    value, style = entry
+    value, style, _ = entry
+    # a carriage return (a "\r" escape) would split the line model every
+    # consumer relies on, so it reads as the line break it is
+    value = value.replace('\r\n', '\n').replace('\r', '\n')
     # a block scalar's final breaks are chomping, not content
     if style in ('|', '>'):
         return value.rstrip('\n')
@@ -835,9 +932,10 @@ def _read_field_lines(frontmatter: str, key: str) -> Optional[str]:
     if not match:
         return None
     indicator, inline, body = match.group(1), match.group(2), match.group(3)
-    # no indented body: the inline text on the header line is the value
+    # no indented body: the inline text on the header line is the value,
+    # unless it is a comment
     if not body:
-        return inline.strip()
+        return '' if inline.strip().startswith('#') else inline.strip()
     body = textwrap.dedent(body)
     # folded scalar (>): join non-empty lines with a space, blank line breaks
     if indicator == '>':
@@ -876,7 +974,14 @@ def _unset_field(frontmatter: str, key: str) -> bool:
     """
     fields = _scalar_fields(frontmatter)
     if fields is not None:
-        return (key not in fields) or (fields[key] == ('null', None))
+        if key not in fields:
+            return True
+        entry = fields[key]
+        if entry is None:
+            return False
+        value, style, tag = entry
+        # plain and resolved as null: an explicit !!str tag makes it text
+        return (value == 'null') and (style is None) and tag.endswith(':null')
     match = re.search(rf'^{key}[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
     return (match is None) or (match.group(1).strip() == 'null')
 
@@ -942,7 +1047,7 @@ def field_value(line: str) -> str:
     joined value of a whole field, this reads a single line so matches
     keep their line numbers.
     """
-    match = re.match(r'^([\w.-]+)[ \t]*:[^\S\n]*', line)
+    match = re.match(r'^([\w.-]+)[ \t]*:(?:[^\S\n]+|$)', line)
     if match:
         return unquote(line[match.end() :].strip())
     return line.strip()
@@ -985,7 +1090,7 @@ def field_line_ranges(
         if lineno >= frontmatter_end:
             break
         # check for field key
-        match = re.match(r'^([\w.-]+)[ \t]*:', line)
+        match = re.match(r'^([\w.-]+)[ \t]*:(?:[ \t]|$)', line)
         if match:
             current_field = match.group(1)
             if current_field in fields:
@@ -994,10 +1099,13 @@ def field_line_ranges(
         # a dedented field line whose key sits outside the key grammar (e.g.
         # one with spaces) still ends the current field -- its line and block
         # body must not attribute to the preceding field -- while a dedented
-        # sequence item (`- https://...`) continues it, colon and all
+        # sequence item (`- https://...`) or a flow continuation (`https://b]`)
+        # continues it, colon and all: only a colon followed by a space or
+        # the line end makes a key
         dedented = line[:1] not in (' ', '\t')
         item = re.match(r'-(?:[ \t]|$)', line) is not None
-        if dedented and (':' in line) and not line.startswith('#') and not item:
+        keyed = re.search(r':(?:[ \t]|$)', line) is not None
+        if dedented and keyed and not line.startswith('#') and not item:
             current_field = None
             continue
         # continuation line of current field
@@ -1145,6 +1253,8 @@ def _plain_safe(value: str) -> bool:
         return False
     if (': ' in value) or value.endswith(':') or (' #' in value) or ('\t' in value):
         return False
+    if _ESCAPED_CHARS.search(value):
+        return False
     if value[0] in _INDICATOR_CHARS:
         return False
     if (value in ('-', '?', ':')) or (value[:2] in ('- ', '? ', ': ')):
@@ -1159,9 +1269,18 @@ def quote(value: str) -> str:
     (:func:`_plain_safe`) -- one shaped like a mapping, carrying a
     comment start, opening with an indicator, or wrapped in quote chars
     that :func:`unquote` would strip on read -- is written single-quoted
-    with embedded single quotes doubled; any other value passes through
-    unquoted. Inverse of :func:`unquote` for the values the wiki writes.
+    with embedded single quotes doubled; one carrying a character no
+    stream may hold (a control, a line separator) is written
+    double-quoted with those characters escaped; any other value passes
+    through unquoted. Inverse of :func:`unquote` for the values the wiki
+    writes.
     """
+    if _ESCAPED_CHARS.search(value):
+        escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+        escaped = _ESCAPED_CHARS.sub(
+            lambda match: f'\\u{ord(match.group(0)):04x}', escaped
+        )
+        return f'"{escaped}"'
     if not _plain_safe(value):
         escaped = value.replace("'", "''")
         return f"'{escaped}'"
@@ -1172,16 +1291,29 @@ def unquote(value: str) -> str:
     """Strip one pair of matching surrounding YAML quotes from a scalar.
 
     A quoted scalar (``"..."`` / ``'...'``) resolves to its body, with the
-    YAML escapes undone -- doubled single quotes in a single-quoted value,
-    backslash-escaped quotes/backslashes in a double-quoted one. An
-    unquoted value is returned unchanged.
+    YAML escapes undone -- doubled single quotes in a single-quoted value;
+    the backslash escapes for quotes, backslashes, line breaks, tabs, and
+    hex or unicode code points in a double-quoted one. An unquoted value
+    is returned unchanged.
     """
     if (len(value) >= 2) and (value[0] == value[-1]) and (value[0] in ('"', "'")):
         body = value[1:-1]
         if value[0] == '"':
-            return body.replace('\\"', '"').replace('\\\\', '\\')
+            return re.sub(
+                r'\\(?:u([0-9a-fA-F]{4})|x([0-9a-fA-F]{2})|(.))', _unescape, body
+            )
         return body.replace("''", "'")
     return value
+
+
+def _unescape(match: re.Match[str]) -> str:
+    """Resolve one double-quoted YAML escape; an unknown one stays verbatim."""
+    code, byte, char = match.groups()
+    if code or byte:
+        return chr(int(code or byte, 16))
+    return {'n': '\n', 'r': '\r', 't': '\t', '"': '"', '\\': '\\'}.get(
+        char, f'\\{char}'
+    )
 
 
 def parse_regions(masked: str) -> tuple[dict[str, list[tuple[int, int]]], list[str]]:

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -46,6 +46,11 @@ _DESC_NOTE_CHARS = 500
 # plants above the first conflict marker (_assets/git/merge_index.sh)
 _MERGE_HINT_TAIL = 'delete this line when resolving -->'
 
+# the malformed-frontmatter reason for a body that is valid YAML but not a
+# key: value mapping (a bare sentence, a list); the planners keep such a
+# page as written
+_NONMAPPING = 'not a key: value mapping'
+
 # str.is* predicates a policy may require (applied to the name minus allow chars)
 _NAMING_PREDICATES = {
     'ascii': str.isascii,
@@ -3771,10 +3776,12 @@ class Wiki:
             # re.sub would rewrite an authored body line the parse left as body
             if (current is None) or (content != current):
                 content = re.sub(
-                    pattern=r'^updated:.*$',
+                    # the field's whole extent, so a stamp continued on indented
+                    # lines is replaced rather than stranded under the fresh one
+                    pattern=r'^updated:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
                     # a callable repl, so a backslash in a user timestamp.format
                     # is emitted verbatim, not parsed as a group reference
-                    repl=lambda _: f'updated: {now}',
+                    repl=lambda _: f'updated: {now}\n',
                     string=content,
                     count=1,
                     flags=re.MULTILINE,
@@ -3870,7 +3877,14 @@ class Wiki:
                 text,
                 delimiter=self.index_delimiter,
             )
-            if frontmatter:
+            if frontmatter and format.nonmapping_frontmatter(frontmatter):
+                # a body that is valid YAML but not a key: value mapping has no
+                # fields to repair: keep the index as-is and report it rather
+                # than append fields under the text
+                relpath = path.relative_to(self._root)
+                event = FrontmatterMalformedEvent(path=str(relpath), reason=_NONMAPPING)
+                return text, [event]
+            elif frontmatter:
                 # refresh the name from the folder path, fill the missing
                 # or blank desc/created/updated keys, drop an unset title
                 # or category, and enforce the canonical field order
@@ -4081,6 +4095,13 @@ class Wiki:
         if not frontmatter and (first_line.strip() == '---'):
             relpath = path.relative_to(self._root)
             return text, [FrontmatterMalformedEvent(path=str(relpath))]
+        # a body that is valid YAML but not a key: value mapping (a bare
+        # sentence, a list) has no fields to repair: keep the file as-is and
+        # report it rather than append fields under the text
+        if frontmatter and format.nonmapping_frontmatter(frontmatter):
+            relpath = path.relative_to(self._root)
+            event = FrontmatterMalformedEvent(path=str(relpath), reason=_NONMAPPING)
+            return text, [event]
         # update or create frontmatter
         notices: list[Event] = []
         if frontmatter:
@@ -5043,14 +5064,15 @@ class ReadSkipEvent(Event):
 
 
 class FrontmatterMalformedEvent(Event):
-    """Emitted when a page's frontmatter never closes."""
+    """Emitted when a page's frontmatter never closes or is not a mapping."""
 
     path: str
+    reason: str = 'no closing ---'
 
     @property
     def description(self: FrontmatterMalformedEvent) -> str:
         """Return the malformed-frontmatter notice line."""
-        return f'Malformed frontmatter (no closing ---) in {self.path}'
+        return f'Malformed frontmatter ({self.reason}) in {self.path}'
 
 
 class IndexTruncatedEvent(Event):

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -51,8 +51,8 @@ _MERGE_HINT_TAIL = 'delete this line when resolving -->'
 # page as written
 _NONMAPPING = 'not a key: value mapping'
 
-# the remedy lint appends to an invalid_yaml finding, per cause (see
-# format.frontmatter_issues)
+# the remedy lint appends to an invalid_yaml finding, per
+# cause (see format.frontmatter_issues)
 _YAML_ADVICE = {
     'parse': 'a strict reader drops the whole block, so quote or rewrite the value',
     'nonmapping': 'no strict reader finds key: value pairs in it',
@@ -3897,7 +3897,7 @@ class Wiki:
                 text,
                 delimiter=self.index_delimiter,
             )
-            if frontmatter and format.nonmapping_frontmatter(frontmatter):
+            if frontmatter and format.is_nonmapping_frontmatter(frontmatter):
                 # a body that is valid YAML but not a key: value mapping has no
                 # fields to repair: keep the index as-is and report it rather
                 # than append fields under the text
@@ -4118,7 +4118,7 @@ class Wiki:
         # a body that is valid YAML but not a key: value mapping (a bare
         # sentence, a list) has no fields to repair: keep the file as-is and
         # report it rather than append fields under the text
-        if frontmatter and format.nonmapping_frontmatter(frontmatter):
+        if frontmatter and format.is_nonmapping_frontmatter(frontmatter):
             relpath = path.relative_to(self._root)
             event = FrontmatterMalformedEvent(path=str(relpath), reason=_NONMAPPING)
             return text, [event]
@@ -4540,15 +4540,14 @@ class Wiki:
             # comment, the likely cause of the missing period
             raw = re.search(r'^desc[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
             hint = ''
-            if (
-                raw
-                and (' #' in raw.group(1))
-                and not raw.group(1).startswith(("'", '"', '|', '>'))
-            ):
-                hint = (
-                    " (the text after ' #' is a YAML comment; quote the value if"
-                    ' it was meant as text)'
-                )
+            if raw:
+                value = raw.group(1)
+                plain = not value.startswith(("'", '"', '|', '>'))
+                if (' #' in value) and plain:
+                    hint = (
+                        " (the text after ' #' is a YAML comment; quote the value"
+                        ' if it was meant as text)'
+                    )
             result.append(
                 Issue(
                     f'{relpath}: Missing period in desc{hint}',

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -1444,6 +1444,7 @@ class Wiki:
                     result.extend(self._lint_desc(index_path, frontmatter))
                     result.extend(self._lint_title(index_path, frontmatter))
                     result.extend(self._lint_timestamps(index_path, frontmatter))
+                    result.extend(self._lint_frontmatter_yaml(index_path, frontmatter))
                     # the root display name has no enclosing dir to validate it
                     if folder == self._root:
                         root_name = format.read_frontmatter_name(frontmatter)
@@ -1664,6 +1665,7 @@ class Wiki:
                     result.extend(self._lint_desc(page, frontmatter))
                     result.extend(self._lint_title(page, frontmatter))
                     result.extend(self._lint_timestamps(page, frontmatter))
+                    result.extend(self._lint_frontmatter_yaml(page, frontmatter))
                 # hand-wrap artifacts in the content and raw desc lines
                 # are hard issues
                 result.extend(
@@ -4516,9 +4518,22 @@ class Wiki:
         if desc == '...':
             self.on_desc_missing(path=str(relpath))
         elif desc and not desc.strip().endswith('.'):
+            # a plain one-line value with ' #' after it lost its tail to a YAML
+            # comment, the likely cause of the missing period
+            raw = re.search(r'^desc:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
+            hint = ''
+            if (
+                raw
+                and (' #' in raw.group(1))
+                and not raw.group(1).startswith(("'", '"'))
+            ):
+                hint = (
+                    " (the text after ' #' is a YAML comment; quote the value if"
+                    ' it was meant as text)'
+                )
             result.append(
                 Issue(
-                    f'{relpath}: Missing period in desc',
+                    f'{relpath}: Missing period in desc{hint}',
                     kind='missing_period',
                     path=str(relpath),
                 )
@@ -4603,6 +4618,119 @@ class Wiki:
                         value=value,
                     )
                 )
+        return result
+
+    def _lint_frontmatter_yaml(
+        self: Wiki,
+        path: pathlib.Path,
+        frontmatter: str,
+    ) -> list[Issue]:
+        """Check the frontmatter body is a mapping a strict YAML reader accepts.
+
+        The wiki's own reader is lenient -- an unquoted ``': '`` inside a
+        one-line value still reads as the authored text through the line
+        grammar -- but a strict reader (Obsidian's, any YAML library)
+        refuses the whole block and loses every field with it, so a body
+        the parser rejects is a hard issue naming the line. A duplicate
+        top-level key (a strict reader refuses it or keeps the last copy
+        where the wiki reads the first), a key that is not a scalar, and
+        a body that is not a mapping are reported the same way. The
+        fences stay outside the parse -- they are the wiki's grammar, and
+        document markers to YAML -- and update never rewrites an authored
+        value, so the fix is the author's: quote the value, drop the
+        duplicate, or write ``key: value`` pairs.
+        """
+        import yaml
+
+        # initialize issues
+        result = []
+        # alias relative path
+        relpath = path.relative_to(self._root)
+        # an empty or unclosed block has nothing to parse (reported elsewhere)
+        if not frontmatter:
+            return result
+        body = '\n'.join(frontmatter.split('\n')[1:-1]) + '\n'
+        # the C loader is a build-time option of the PyYAML wheel; the pure
+        # loader raises RecursionError on nesting the C loader composes
+        loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+        try:
+            node = yaml.compose(body, Loader=loader)
+        except (yaml.YAMLError, RecursionError) as error:
+            # body line 0 is file line 2 (the opening fence); a mark-less error
+            # (a control character, the recursion limit) locates by its stream
+            # position or falls back to the block's first line
+            mark = getattr(error, 'problem_mark', None)
+            position = getattr(error, 'position', None)
+            if mark is not None:
+                line = mark.line + 2
+            elif position is not None:
+                line = body.count('\n', 0, position) + 2
+            else:
+                line = 1
+            reason = getattr(error, 'problem', None) or getattr(error, 'reason', None)
+            reason = str(reason or type(error).__name__)
+            result.append(
+                Issue(
+                    f'{relpath}: Invalid YAML frontmatter (line {line}):'
+                    f' {reason}; a strict reader drops the whole block, so'
+                    ' quote or rewrite the value',
+                    kind='invalid_yaml',
+                    path=str(relpath),
+                    line=line,
+                    reason=reason,
+                )
+            )
+            return result
+        # an empty or comment-only body has no fields to judge
+        if node is None:
+            return result
+        # a body that is not a mapping has no fields at all
+        if not isinstance(node, yaml.MappingNode):
+            result.append(
+                Issue(
+                    f'{relpath}: Invalid YAML frontmatter (line 1): frontmatter'
+                    ' is not a key: value mapping; the wiki reads no fields'
+                    ' from it and leaves it untouched',
+                    kind='invalid_yaml',
+                    path=str(relpath),
+                    line=1,
+                    reason='frontmatter is not a mapping',
+                )
+            )
+            return result
+        # duplicate and non-scalar keys: compose keeps every pair in order
+        seen: dict[str, int] = {}
+        for key_node, _value_node in node.value:
+            line = key_node.start_mark.line + 2
+            if not isinstance(key_node, yaml.ScalarNode):
+                result.append(
+                    Issue(
+                        f'{relpath}: Invalid YAML frontmatter (line {line}): a'
+                        ' key is not a scalar; the wiki reads the block by its'
+                        ' line grammar alone',
+                        kind='invalid_yaml',
+                        path=str(relpath),
+                        line=line,
+                        reason='a key is not a scalar',
+                    )
+                )
+                continue
+            key = key_node.value
+            if key in seen:
+                result.append(
+                    Issue(
+                        f'{relpath}: Invalid YAML frontmatter (line {line}):'
+                        f' duplicate key {key!r} (first at line {seen[key]}); a'
+                        ' strict reader rejects the block or keeps the last'
+                        ' copy, the wiki reads the first',
+                        kind='invalid_yaml',
+                        path=str(relpath),
+                        line=line,
+                        reason=f'duplicate key {key!r}',
+                    )
+                )
+            else:
+                seen[key] = line
         return result
 
     def _lint_link_desc(

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -51,6 +51,18 @@ _MERGE_HINT_TAIL = 'delete this line when resolving -->'
 # page as written
 _NONMAPPING = 'not a key: value mapping'
 
+# the remedy lint appends to an invalid_yaml finding, per cause (see
+# format.frontmatter_issues)
+_YAML_ADVICE = {
+    'parse': 'a strict reader drops the whole block, so quote or rewrite the value',
+    'nonmapping': 'no strict reader finds key: value pairs in it',
+    'nonscalar_key': 'the wiki reads the block by its line grammar alone',
+    'duplicate_key': (
+        'a strict reader rejects the block or keeps the last copy, the wiki'
+        ' reads the first'
+    ),
+}
+
 # str.is* predicates a policy may require (applied to the name minus allow chars)
 _NAMING_PREDICATES = {
     'ascii': str.isascii,
@@ -3777,13 +3789,19 @@ class Wiki:
             # -- on a verbatim passthrough of an unclosed-frontmatter page the
             # re.sub would rewrite an authored body line the parse left as body
             if (current is None) or (content != current):
+                # the field's whole extent is replaced, so a stamp continued on
+                # indented lines never strands under the fresh one, while the
+                # comment lines among them ride along; a callable repl, so a
+                # backslash in a user timestamp.format is emitted verbatim,
+                # not parsed as a group reference
+                def restamp(match: re.Match[str]) -> str:
+                    lines = match.group(1).splitlines(keepends=True)
+                    comments = [line for line in lines if line.lstrip().startswith('#')]
+                    return f'updated: {format.quote(now)}\n' + ''.join(comments)
+
                 content = re.sub(
-                    # the field's whole extent, so a stamp continued on indented
-                    # lines is replaced rather than stranded under the fresh one
-                    pattern=r'^updated[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
-                    # a callable repl, so a backslash in a user timestamp.format
-                    # is emitted verbatim, not parsed as a group reference
-                    repl=lambda _: f'updated: {now}\n',
+                    pattern=rf'^updated[ \t]*:.*\n({format.FIELD_EXTENT})',
+                    repl=restamp,
                     string=content,
                     count=1,
                     flags=re.MULTILINE,
@@ -4525,7 +4543,7 @@ class Wiki:
             if (
                 raw
                 and (' #' in raw.group(1))
-                and not raw.group(1).startswith(("'", '"'))
+                and not raw.group(1).startswith(("'", '"', '|', '>'))
             ):
                 hint = (
                     " (the text after ' #' is a YAML comment; quote the value if"
@@ -4640,8 +4658,6 @@ class Wiki:
         value, so the fix is the author's: quote the value, drop the
         duplicate, or write ``key: value`` pairs.
         """
-        import yaml
-
         # initialize issues
         result = []
         # alias relative path
@@ -4649,88 +4665,20 @@ class Wiki:
         # an empty or unclosed block has nothing to parse (reported elsewhere)
         if not frontmatter:
             return result
-        body = '\n'.join(frontmatter.split('\n')[1:-1]) + '\n'
-        # the C loader is a build-time option of the PyYAML wheel; the pure
-        # loader raises RecursionError on nesting the C loader composes
-        loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
-        try:
-            node = yaml.compose(body, Loader=loader)
-        except (yaml.YAMLError, RecursionError) as error:
-            # body line 0 is file line 2 (the opening fence); a mark-less error
-            # (a control character, the recursion limit) locates by its stream
-            # position or falls back to the block's first line
-            mark = getattr(error, 'problem_mark', None)
-            position = getattr(error, 'position', None)
-            if mark is not None:
-                line = mark.line + 2
-            elif position is not None:
-                line = body.count('\n', 0, position) + 2
-            else:
-                line = 1
-            reason = getattr(error, 'problem', None) or getattr(error, 'reason', None)
-            reason = str(reason or type(error).__name__)
+        # the reader's own parse supplies the findings, so lint and update
+        # judge one composition of the block
+        for line, reason, cause in format.frontmatter_issues(frontmatter):
+            advice = _YAML_ADVICE[cause]
             result.append(
                 Issue(
-                    f'{relpath}: Invalid YAML frontmatter (line {line}):'
-                    f' {reason}; a strict reader drops the whole block, so'
-                    ' quote or rewrite the value',
+                    f'{relpath}: Invalid YAML frontmatter (line {line}): {reason};'
+                    f' {advice}',
                     kind='invalid_yaml',
                     path=str(relpath),
                     line=line,
                     reason=reason,
                 )
             )
-            return result
-        # an empty or comment-only body has no fields to judge
-        if node is None:
-            return result
-        # a body that is not a mapping has no fields at all
-        if not isinstance(node, yaml.MappingNode):
-            result.append(
-                Issue(
-                    f'{relpath}: Invalid YAML frontmatter (line 1): frontmatter'
-                    ' is not a key: value mapping; the wiki reads no fields'
-                    ' from it and leaves it untouched',
-                    kind='invalid_yaml',
-                    path=str(relpath),
-                    line=1,
-                    reason='frontmatter is not a mapping',
-                )
-            )
-            return result
-        # duplicate and non-scalar keys: compose keeps every pair in order
-        seen: dict[str, int] = {}
-        for key_node, _value_node in node.value:
-            line = key_node.start_mark.line + 2
-            if not isinstance(key_node, yaml.ScalarNode):
-                result.append(
-                    Issue(
-                        f'{relpath}: Invalid YAML frontmatter (line {line}): a'
-                        ' key is not a scalar; the wiki reads the block by its'
-                        ' line grammar alone',
-                        kind='invalid_yaml',
-                        path=str(relpath),
-                        line=line,
-                        reason='a key is not a scalar',
-                    )
-                )
-                continue
-            key = key_node.value
-            if key in seen:
-                result.append(
-                    Issue(
-                        f'{relpath}: Invalid YAML frontmatter (line {line}):'
-                        f' duplicate key {key!r} (first at line {seen[key]}); a'
-                        ' strict reader rejects the block or keeps the last'
-                        ' copy, the wiki reads the first',
-                        kind='invalid_yaml',
-                        path=str(relpath),
-                        line=line,
-                        reason=f'duplicate key {key!r}',
-                    )
-                )
-            else:
-                seen[key] = line
         return result
 
     def _lint_link_desc(

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -30,7 +30,9 @@ from wiki.constants import (
 from wiki.typing import Link, PathLike
 
 from . import _obsidian, _search, format
+from ._obsidian import _OBSIDIAN_PLUGIN_DIGESTS, _OBSIDIAN_PLUGINS
 from .event import Event
+from .format import FIELD_EXTENT
 
 __all__ = ['Wiki']
 
@@ -783,7 +785,7 @@ class Wiki:
                 target = obsidian_dir / 'plugins' / source.name
                 shutil.copytree(source, target, dirs_exist_ok=True)
                 # download pinned plugin code from its release, unless offline
-                release_url = _obsidian._OBSIDIAN_PLUGINS.get(source.name)
+                release_url = _OBSIDIAN_PLUGINS.get(source.name)
                 if release_url and offline:
                     warnings.append(
                         f'Skipped {source.name} download (OFFLINE_MODE).'
@@ -793,7 +795,7 @@ class Wiki:
                     # fetch all assets to temp paths first, then move them into
                     # place only after every fetch succeeds, so a mid-fetch
                     # failure never leaves a skewed main.js/manifest.json pair
-                    digests = _obsidian._OBSIDIAN_PLUGIN_DIGESTS[source.name]
+                    digests = _OBSIDIAN_PLUGIN_DIGESTS[source.name]
                     staged = []
                     try:
                         for asset in digests:
@@ -1020,9 +1022,8 @@ class Wiki:
             self._dispatch_notice(event)
         # dry run: report which files would change without writing (a CRLF
         # file reads equal but would be rewritten, so probe its bytes too);
-        # _current_text answers a file vanishing under the probe (a
-        # concurrent delete) as absent, reporting it as pending rather
-        # than raising
+        # _current_text answers a file vanishing under the probe (a concurrent
+        # delete) as absent, reporting it as pending rather than raising
         if check:
             return [
                 str(path.relative_to(self._root))
@@ -1115,10 +1116,9 @@ class Wiki:
             violation = self._name_violation(part)
             if violation is not None:
                 raise ValueError(f'Invalid folder name {part!r}: {violation}')
-        # a symlinked segment is excluded from every walk and may point
-        # outside the root, so writing through one would land an invisible
-        # index -- or an out-of-root file the lexical containment above
-        # cannot see
+        # a symlinked segment is excluded from every walk and may point outside
+        # the root, so writing through one would land an invisible index -- or
+        # an out-of-root file the lexical containment above cannot see
         current = self._root
         for part in folder.relative_to(self._root).parts:
             current = current / part
@@ -1186,10 +1186,9 @@ class Wiki:
             raise ValueError(
                 'Merge conflict markers in the authored input; resolve them and rerun.'
             )
-        # pre-flight the wiring sweep's refusals against the parent scope
-        # (a discarded dry plan): a refusal after the write would strand a
-        # half-adoption whose retry dead-ends on the never-overwrites
-        # guard above
+        # pre-flight the wiring sweep's refusals against the parent scope (a
+        # discarded dry plan): a refusal after the write would strand a
+        # half-adoption whose retry dead-ends on the never-overwrites guard
         parent = folder.parent
         scope = None
         if parent != self._root:
@@ -3800,16 +3799,15 @@ class Wiki:
                     return f'updated: {format.quote(now)}\n' + ''.join(comments)
 
                 content = re.sub(
-                    pattern=rf'^updated[ \t]*:.*\n({format.FIELD_EXTENT})',
+                    pattern=rf'^updated[ \t]*:.*\n({FIELD_EXTENT})',
                     repl=restamp,
                     string=content,
                     count=1,
                     flags=re.MULTILINE,
                 )
             # a folder vanishing between the plan and the write (a concurrent
-            # delete) leaves the write nowhere to land: drop the file -- the
-            # next run converges -- while a failure with the folder still
-            # present propagates
+            # delete) leaves the write nowhere to land, so drop the file and let
+            # the next run converge; a failure with the folder present propagates
             try:
                 wiki.util.fs.write_atomic(path, content)
             except FileNotFoundError:
@@ -4344,9 +4342,8 @@ class Wiki:
             else:
                 child_path = self._root / target
                 is_markdown = False
-            # a link resolving outside this folder (or to a missing file) is a
-            # dangling row (pending prune): annotate it, never recurse into
-            # another subtree
+            # a link resolving outside this folder (or to a missing file) is a dangling
+            # row (pending prune): annotate it, never recurse into another subtree
             broken = unicodedata.normalize('NFC', target) not in expected_targets
             # apply markdown filter (pages only)
             if not is_folder and (markdown is not None) and (markdown != is_markdown):

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -2985,7 +2985,7 @@ class Wiki:
         and files the enclosing repo's gitignore fences
         (:meth:`_is_gitignored`).
         """
-        if path.name == WIKI_INDEX or path.name.startswith('.') or path.is_symlink():
+        if (path.name == WIKI_INDEX) or path.name.startswith('.') or path.is_symlink():
             return True
         if self._excluded_by(path) is not None:
             return True

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -3780,7 +3780,7 @@ class Wiki:
                 content = re.sub(
                     # the field's whole extent, so a stamp continued on indented
                     # lines is replaced rather than stranded under the fresh one
-                    pattern=r'^updated:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
+                    pattern=r'^updated[ \t]*:.*\n(?:[ \t]+.*\n|[ \t]*\n)*',
                     # a callable repl, so a backslash in a user timestamp.format
                     # is emitted verbatim, not parsed as a group reference
                     repl=lambda _: f'updated: {now}\n',
@@ -4520,7 +4520,7 @@ class Wiki:
         elif desc and not desc.strip().endswith('.'):
             # a plain one-line value with ' #' after it lost its tail to a YAML
             # comment, the likely cause of the missing period
-            raw = re.search(r'^desc:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
+            raw = re.search(r'^desc[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
             hint = ''
             if (
                 raw

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -32,7 +32,6 @@ from wiki.typing import Link, PathLike
 from . import _obsidian, _search, format
 from ._obsidian import _OBSIDIAN_PLUGIN_DIGESTS, _OBSIDIAN_PLUGINS
 from .event import Event
-from .format import FIELD_EXTENT
 
 __all__ = ['Wiki']
 
@@ -48,10 +47,13 @@ _DESC_NOTE_CHARS = 500
 # plants above the first conflict marker (_assets/git/merge_index.sh)
 _MERGE_HINT_TAIL = 'delete this line when resolving -->'
 
-# the malformed-frontmatter reason for a body that is valid YAML but not a
-# key: value mapping (a bare sentence, a list); the planners keep such a
-# page as written
+# the malformed-frontmatter reasons the planners keep a page as written for:
+# a body that is valid YAML but not a key: value mapping (a bare sentence, a
+# list), a mapping whose keys open off column 0 (a flow or indented mapping),
+# and a block whose byte-level repair would leave it invalid
 _NONMAPPING = 'not a key: value mapping'
+_UNADDRESSABLE = 'keys are not column-0 key: value lines'
+_UNREPAIRABLE = 'its repair would break the YAML'
 
 # the remedy lint appends to an invalid_yaml finding, per
 # cause (see format.frontmatter_issues)
@@ -1452,6 +1454,11 @@ class Wiki:
                                 path=str(index_relpath),
                             )
                         )
+                    else:
+                        name = self._path_to_name(folder)
+                        result.extend(
+                            self._lint_unrepairable(index_path, frontmatter, name)
+                        )
                     result.extend(self._lint_desc(index_path, frontmatter))
                     result.extend(self._lint_title(index_path, frontmatter))
                     result.extend(self._lint_timestamps(index_path, frontmatter))
@@ -1663,6 +1670,9 @@ class Wiki:
                             path=str(page_relpath),
                         )
                     )
+                elif frontmatter:
+                    name = self._path_to_name(page)
+                    result.extend(self._lint_unrepairable(page, frontmatter, name))
                 elif not frontmatter:
                     result.append(
                         Issue(
@@ -1859,6 +1869,7 @@ class Wiki:
                 if not frontmatter:
                     continue
                 field_lines = format.field_line_ranges(frontmatter, lines, fields)
+                keys = format.line_keys(frontmatter)
                 for lineno, line in enumerate(lines, 1):
                     if lineno not in field_lines:
                         continue
@@ -1866,8 +1877,11 @@ class Wiki:
                     # continuation indentation) would defeat value anchors and
                     # match key names; surrounding YAML quotes are stripped so
                     # anchors see the value the wiki writes via format.quote,
-                    # and the reported line text stays raw
-                    value = format.field_value(line)
+                    # and the reported line text stays raw; a composed block
+                    # names its key lines, so its other lines are value text
+                    # whatever their shape
+                    key = keys.get(lineno, '' if keys else None)
+                    value = format.field_value(line, key=key)
                     if regex.search(value):
                         result.append((relpath, lineno, line))
             else:
@@ -3603,6 +3617,7 @@ class Wiki:
         self: Wiki,
         folder: pathlib.Path,
         overlay: Optional[dict[pathlib.Path, str]] = None,
+        now: Optional[str] = None,
     ) -> dict[str, str]:
         """Read categorized labels from child frontmatter.
 
@@ -3610,11 +3625,13 @@ class Wiki:
         ``_index.md`` and each child ``.md`` page, producing a
         ``[category]`` prefix for the parent's link label. Cross-file
         reads route through :meth:`_current_text`, so staged plan
-        content (``overlay``) is honored during a plan.
+        content (``overlay``) is honored during a plan, and read the
+        block as the write leaves it (``now``, see :func:`_as_written`).
 
         Args:
             folder: Parent folder to scan.
             overlay: Staged ``{path: content}`` from earlier passes.
+            now: The run's timestamp, to read each block re-stamped.
 
         Returns:
             Dict mapping wikilink targets to categorized labels.
@@ -3637,6 +3654,8 @@ class Wiki:
             text = self._current_text(child_index, overlay)
             if text is not None:
                 frontmatter, _ = format.parse_page(text)
+                if now is not None:
+                    frontmatter = _as_written(frontmatter, now)
                 category = format.read_frontmatter_category(frontmatter)
             else:
                 category = ''
@@ -3652,6 +3671,8 @@ class Wiki:
             text = self._current_text(page, overlay)
             if text is not None:
                 frontmatter, _ = format.parse_page(text)
+                if now is not None:
+                    frontmatter = _as_written(frontmatter, now)
                 category = format.read_frontmatter_category(frontmatter)
             else:
                 category = ''
@@ -3679,7 +3700,7 @@ class Wiki:
     ]:
         """Compute corrected content for every file under ``folder``.
 
-        Runs the two update passes (indexes bottom-up, then pages) into
+        Runs the two update passes (pages, then indexes bottom-up) into
         an in-memory overlay without writing to disk. The overlay maps
         each file path to its corrected content
         carrying the file's *original* ``updated:`` value, so a caller
@@ -3707,6 +3728,23 @@ class Wiki:
         overlay: dict[pathlib.Path, str] = {}
         baseline: dict[pathlib.Path, Optional[str]] = {}
         notices = []
+        # plan pages first: a page reads no other file, and an index reads
+        # its pages' repaired frontmatter from the overlay, so a row never
+        # lags a repair by one run
+        for folder in folders:
+            for page in self._find_pages(folder):
+                if page.suffix == '.md':
+                    # a page vanishing between the walk and the read (a
+                    # concurrent delete) plans as absent from the walk; the
+                    # next run prunes its stale index row
+                    try:
+                        text = self._read_text(page)
+                    except FileNotFoundError:
+                        continue
+                    baseline[page] = text
+                    content, page_notices = self._plan_page(page, now, text=text)
+                    overlay[page] = content
+                    notices.extend(page_notices)
         # plan indexes (bottom-up so child categories
         # exist before parents read them)
         for folder in reversed(folders):
@@ -3724,21 +3762,6 @@ class Wiki:
             )
             overlay[index_path] = content
             notices.extend(index_notices)
-        # plan pages
-        for folder in folders:
-            for page in self._find_pages(folder):
-                if page.suffix == '.md':
-                    # a page vanishing between the walk and the read (a
-                    # concurrent delete) plans as absent from the walk; the
-                    # next run prunes its stale index row
-                    try:
-                        text = self._read_text(page)
-                    except FileNotFoundError:
-                        continue
-                    baseline[page] = text
-                    content, page_notices = self._plan_page(page, now, text=text)
-                    overlay[page] = content
-                    notices.extend(page_notices)
         # return overlay, baseline, and notices
         return overlay, baseline, notices
 
@@ -3788,23 +3811,21 @@ class Wiki:
             # -- on a verbatim passthrough of an unclosed-frontmatter page the
             # re.sub would rewrite an authored body line the parse left as body
             if (current is None) or (content != current):
-                # the field's whole extent is replaced, so a stamp continued on
-                # indented lines never strands under the fresh one, while the
-                # comment lines among them ride along; a callable repl, so a
-                # backslash in a user timestamp.format is emitted verbatim,
-                # not parsed as a group reference
-                def restamp(match: re.Match[str]) -> str:
-                    lines = match.group(1).splitlines(keepends=True)
-                    comments = [line for line in lines if line.lstrip().startswith('#')]
-                    return f'updated: {format.quote(now)}\n' + ''.join(comments)
-
-                content = re.sub(
-                    pattern=rf'^updated[ \t]*:.*\n({FIELD_EXTENT})',
-                    repl=restamp,
-                    string=content,
-                    count=1,
-                    flags=re.MULTILINE,
-                )
+                # the stamp lives in the frontmatter block alone, so a body
+                # line spelled like one is never touched, and a passthrough
+                # page (no closed block) is not stamped at all
+                block, _ = format.extract_frontmatter(content.split('\n'))
+                if block:
+                    # the re-stamp may drop the alias that pinned the field
+                    # order, or close the quote or bracket that kept a blank
+                    # line as content: order the block and strip the stray
+                    # now, as the next run's repair would, so the write
+                    # converges in one run
+                    stamped = format.restamp_updated(block, now)
+                    stamped = format.strip_blank_lines(
+                        format.order_frontmatter(stamped)
+                    )
+                    content = stamped + content[len(block) :]
             # a folder vanishing between the plan and the write (a concurrent
             # delete) leaves the write nowhere to land, so drop the file and let
             # the next run converge; a failure with the folder present propagates
@@ -3902,11 +3923,20 @@ class Wiki:
                 relpath = path.relative_to(self._root)
                 event = FrontmatterMalformedEvent(path=str(relpath), reason=_NONMAPPING)
                 return text, [event]
+            elif frontmatter and format.is_unaddressable_frontmatter(frontmatter):
+                # a mapping with no column-0 key lines (a flow mapping, an
+                # indented one) has nothing the byte-level repair can edit
+                relpath = path.relative_to(self._root)
+                event = FrontmatterMalformedEvent(
+                    path=str(relpath), reason=_UNADDRESSABLE
+                )
+                return text, [event]
             elif frontmatter:
                 # refresh the name from the folder path, fill the missing
                 # or blank desc/created/updated keys, drop an unset title
-                # or category, and enforce the canonical field order
-                frontmatter = format.repair_frontmatter(
+                # or category, and enforce the canonical field order; a
+                # repair that would leave a valid block invalid is refused
+                repaired = format.repair_frontmatter(
                     frontmatter,
                     name=name,
                     now=now,
@@ -3914,6 +3944,14 @@ class Wiki:
                     category=True,
                     order=True,
                 )
+                restamped = format.restamp_updated(repaired, now)
+                if format.repair_breaks_frontmatter(frontmatter, restamped):
+                    relpath = path.relative_to(self._root)
+                    event = FrontmatterMalformedEvent(
+                        path=str(relpath), reason=_UNREPAIRABLE
+                    )
+                    return text, [event]
+                frontmatter = repaired
             else:
                 # an existing index with no (closed) frontmatter is an emptied or
                 # truncated file: rebuilding it fresh would permanently discard its
@@ -3931,9 +3969,14 @@ class Wiki:
         # enrich frontmatter (hook for subclass tag enrichment)
         frontmatter = self._enrich_frontmatter(path, frontmatter)
         # required-titles mode: seed the null placeholder lint holds open
-        # until a title is authored
+        # until a title is authored; the seed lands under the first name:
+        # line, and the write orders the block, so the plan orders it too --
+        # or a duplicated name: would part the two on every run
         if self._titles_required:
             frontmatter = format.seed_frontmatter_title(frontmatter)
+            frontmatter = format.strip_blank_lines(
+                format.order_frontmatter(frontmatter)
+            )
         # build expected links from filesystem
         expected = self._build_expected_links(folder)
         # drop links for filesystem entries whose stem/name fails the naming
@@ -3951,7 +3994,7 @@ class Wiki:
         invalid_targets = {target for target, _, _ in invalid}
         expected = [(t, label) for t, label in expected if t not in invalid_targets]
         # enrich new entries from child frontmatter
-        labels = self._read_child_labels(folder, overlay)
+        labels = self._read_child_labels(folder, overlay, now)
         # merge and sort
         links, broken, new = self._merge_links(
             existing=existing,
@@ -4015,7 +4058,9 @@ class Wiki:
                 propagated.append((target, label, link_desc))
                 continue
             child_frontmatter, _ = format.parse_page(child_text)
-            child_desc = format.read_frontmatter_desc(child_frontmatter)
+            child_desc = format.read_frontmatter_desc(
+                _as_written(child_frontmatter, now)
+            )
             if child_desc and (child_desc != '...'):
                 # child desc is source of truth; rstrip each line first
                 # (format.parse_index never preserves trailing spaces, so an
@@ -4055,8 +4100,9 @@ class Wiki:
             else:
                 propagated.append((target, label, link_desc))
         links = propagated
-        # resolve the H1: an authored title wins over the path-derived name
-        title = format.read_frontmatter_title(frontmatter)
+        # resolve the H1: an authored title wins over the path-derived name,
+        # read from the block as the write leaves it
+        title = format.read_frontmatter_title(_as_written(frontmatter, now))
         # render the corrected index
         content = format.render_index(
             heading=title or name,
@@ -4120,14 +4166,21 @@ class Wiki:
             relpath = path.relative_to(self._root)
             event = FrontmatterMalformedEvent(path=str(relpath), reason=_NONMAPPING)
             return text, [event]
+        # a mapping with no column-0 key lines (a flow mapping, an indented
+        # one) has nothing the byte-level repair can edit: keep it as-is too
+        if frontmatter and format.is_unaddressable_frontmatter(frontmatter):
+            relpath = path.relative_to(self._root)
+            event = FrontmatterMalformedEvent(path=str(relpath), reason=_UNADDRESSABLE)
+            return text, [event]
         # update or create frontmatter
         notices: list[Event] = []
         if frontmatter:
             # refresh the name from the file path, fill the missing or
             # blank desc/created/updated keys, drop an unset title or
-            # category, and enforce the canonical field order
+            # category, and enforce the canonical field order; a repair
+            # that would leave a valid block invalid is refused
             page_name = self._path_to_name(path)
-            frontmatter = format.repair_frontmatter(
+            repaired = format.repair_frontmatter(
                 frontmatter,
                 name=page_name,
                 now=now,
@@ -4135,6 +4188,14 @@ class Wiki:
                 category=True,
                 order=True,
             )
+            restamped = format.restamp_updated(repaired, now)
+            if format.repair_breaks_frontmatter(frontmatter, restamped):
+                relpath = path.relative_to(self._root)
+                event = FrontmatterMalformedEvent(
+                    path=str(relpath), reason=_UNREPAIRABLE
+                )
+                return text, [event]
+            frontmatter = repaired
         else:
             # use the path-joined name (not the bare stem), so a fresh page
             # converges in one pass instead of two
@@ -4163,11 +4224,17 @@ class Wiki:
             relpath = path.relative_to(self._root)
             notices.append(PageAdoptEvent(path=str(relpath), title=adopted_title))
         # required-titles mode: seed the null placeholder lint holds open
-        # until a title is authored
+        # until a title is authored; the seed lands under the first name:
+        # line, and the write orders the block, so the plan orders it too --
+        # or a duplicated name: would part the two on every run
         if self._titles_required:
             frontmatter = format.seed_frontmatter_title(frontmatter)
-        # rewrite the H1: an authored title wins over the path-joined name
-        title = format.read_frontmatter_title(frontmatter)
+            frontmatter = format.strip_blank_lines(
+                format.order_frontmatter(frontmatter)
+            )
+        # rewrite the H1: an authored title wins over the path-joined name,
+        # read from the block as the write leaves it
+        title = format.read_frontmatter_title(_as_written(frontmatter, now))
         content = format.replace_heading(content, title or page_name)
         # render the corrected page
         result = format.render_page(frontmatter, content)
@@ -4533,18 +4600,14 @@ class Wiki:
         if desc == '...':
             self.on_desc_missing(path=str(relpath))
         elif desc and not desc.strip().endswith('.'):
-            # a plain one-line value with ' #' after it lost its tail to a YAML
+            # a plain value with ' #' in its lines lost its tail to a YAML
             # comment, the likely cause of the missing period
-            raw = re.search(r'^desc[ \t]*:[^\S\n]*(.*)$', frontmatter, re.MULTILINE)
             hint = ''
-            if raw:
-                value = raw.group(1)
-                plain = not value.startswith(("'", '"', '|', '>'))
-                if (' #' in value) and plain:
-                    hint = (
-                        " (the text after ' #' is a YAML comment; quote the value"
-                        ' if it was meant as text)'
-                    )
+            if format.comment_cuts_desc(frontmatter):
+                hint = (
+                    " (the text after ' #' is a YAML comment; quote the value"
+                    ' if it was meant as text)'
+                )
             result.append(
                 Issue(
                     f'{relpath}: Missing period in desc{hint}',
@@ -4614,6 +4677,16 @@ class Wiki:
         policy = self._timestamp_policy
         for field in ('created', 'updated'):
             value = format.read_frontmatter_field(frontmatter, field)
+            # a sequence or mapping under the key is a value no format parses,
+            # spelled by its lines below the key or by the key line's own text
+            if format.is_collection_field(frontmatter, field):
+                text = format.field_text(frontmatter, field)
+                # a key line the line grammar cannot place (an indented
+                # mapping) is the unaddressable check's finding, not this one
+                if text is None:
+                    continue
+                key_line, _, body = text.partition('\n')
+                value = body.strip() or key_line.split(':', 1)[1].strip()
             if not value:
                 continue
             try:
@@ -4632,6 +4705,50 @@ class Wiki:
                         value=value,
                     )
                 )
+        return result
+
+    def _lint_unrepairable(
+        self: Wiki,
+        path: pathlib.Path,
+        frontmatter: str,
+        name: str,
+    ) -> list[Issue]:
+        """Check the block is one the planners repair rather than keep as written.
+
+        A mapping with no column-0 key lines, and a block whose repair
+        (the re-stamp included) would leave a strict reader rejecting
+        it, are left untouched by update with a notice on every run (see
+        ``_plan_page``); lint surfaces the same refusal as a hard issue,
+        with the same reason, so the page does not stay stale in silence.
+        """
+        # initialize issues
+        result = []
+        # alias relative path
+        relpath = path.relative_to(self._root)
+        # the same refusals the planners apply, judged on the same block
+        if format.is_unaddressable_frontmatter(frontmatter):
+            reason = _UNADDRESSABLE
+        else:
+            now = self._utc_now()
+            repaired = format.repair_frontmatter(
+                frontmatter,
+                name=name,
+                now=now,
+                title=True,
+                category=True,
+                order=True,
+            )
+            restamped = format.restamp_updated(repaired, now)
+            if not format.repair_breaks_frontmatter(frontmatter, restamped):
+                return result
+            reason = _UNREPAIRABLE
+        result.append(
+            Issue(
+                f'{relpath}: Malformed frontmatter ({reason})',
+                kind='malformed_frontmatter',
+                path=str(relpath),
+            )
+        )
         return result
 
     def _lint_frontmatter_yaml(
@@ -5291,20 +5408,33 @@ _NOTICE_HOOKS = {
 # ------ helper functions
 
 
+def _as_written(frontmatter: str, now: str) -> str:
+    """Return the block as a write leaves it -- re-stamped -- when a strict reader accepts that, else as written.
+
+    The ``updated:`` re-stamp can turn a block the parser rejects into one
+    it accepts (a quote it closes, a bracket it drops), so a value read
+    before the re-stamp lags the write by a run; a block the re-stamp would
+    leave rejected reads as written, since the write leaves it so too.
+    """
+    stamped = format.restamp_updated(frontmatter, now)
+    return frontmatter if format.frontmatter_issues(stamped) else stamped
+
+
 def _conflict_marker_lines(text: str) -> list[int]:
     """Return 1-based line numbers of git merge conflict markers.
 
     Scans the RAW text, deliberately bypassing the code masking every
     other rule uses: a real merge conflict can land entirely inside a
     fenced block, where a masked scan goes blind, and git's marker shape
-    -- a line starting with exactly seven ``<``/``>`` then a space or end
+    -- a line starting with seven or more ``<``/``>`` (the
+    ``conflict-marker-size`` attribute lengthens them) then a space or end
     of line -- is never legitimate rendered content. The rare page that
     must show marker lines (e.g. a git tutorial) wraps them in a
     ``no-lint`` region instead.
     """
     result = []
     for lineno, line in enumerate(text.split('\n'), 1):
-        if re.match(r'^(<{7}|>{7})( |$)', line):
+        if re.match(r'^(<{7,}|>{7,})( |$)', line):
             result.append(lineno)
     return result
 

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -1870,6 +1870,8 @@ class Wiki:
                     continue
                 field_lines = format.field_line_ranges(frontmatter, lines, fields)
                 keys = format.line_keys(frontmatter)
+                # the line grammar strips only where the composed block names no keys
+                default = '' if keys else None
                 for lineno, line in enumerate(lines, 1):
                     if lineno not in field_lines:
                         continue
@@ -1880,7 +1882,7 @@ class Wiki:
                     # and the reported line text stays raw; a composed block
                     # names its key lines, so its other lines are value text
                     # whatever their shape
-                    key = keys.get(lineno, '' if keys else None)
+                    key = keys.get(lineno, default)
                     value = format.field_value(line, key=key)
                     if regex.search(value):
                         result.append((relpath, lineno, line))
@@ -3928,7 +3930,8 @@ class Wiki:
                 # indented one) has nothing the byte-level repair can edit
                 relpath = path.relative_to(self._root)
                 event = FrontmatterMalformedEvent(
-                    path=str(relpath), reason=_UNADDRESSABLE
+                    path=str(relpath),
+                    reason=_UNADDRESSABLE,
                 )
                 return text, [event]
             elif frontmatter:
@@ -3948,7 +3951,8 @@ class Wiki:
                 if format.repair_breaks_frontmatter(frontmatter, restamped):
                     relpath = path.relative_to(self._root)
                     event = FrontmatterMalformedEvent(
-                        path=str(relpath), reason=_UNREPAIRABLE
+                        path=str(relpath),
+                        reason=_UNREPAIRABLE,
                     )
                     return text, [event]
                 frontmatter = repaired
@@ -4192,7 +4196,8 @@ class Wiki:
             if format.repair_breaks_frontmatter(frontmatter, restamped):
                 relpath = path.relative_to(self._root)
                 event = FrontmatterMalformedEvent(
-                    path=str(relpath), reason=_UNREPAIRABLE
+                    path=str(relpath),
+                    reason=_UNREPAIRABLE,
                 )
                 return text, [event]
             frontmatter = repaired

--- a/wiki/skills/wiki/SKILL.md
+++ b/wiki/skills/wiki/SKILL.md
@@ -122,8 +122,10 @@ rather than authoring or auditing page by page yourself:
 - **Frontmatter order is tool-enforced.** `wiki update` keeps every block in
   canonical order — `name`, `title`, `desc`, `category`, `tags`, `sources`,
   `created`, `updated` — moving each field (with its block-scalar body) verbatim
-  into its slot. Custom keys are allowed: they keep their relative order below
-  the known fields, above the timestamps.
+  into its slot. Custom keys are allowed: one named like `com.example` (word
+  characters, dots, dashes) keeps its relative order below the known fields,
+  above the timestamps; a key spelled any other way (one with spaces) stays with
+  the field above it.
 - **Frontmatter reads as YAML.** Field values are read the way a strict YAML
   reader reads them — a value continued on indented lines folds into one, a
   quoted value decodes, a space followed by `#` starts a comment, and
@@ -131,7 +133,10 @@ rather than authoring or auditing page by page yourself:
   reader rejects (an unquoted `: ` inside a value, a duplicate key, a body that
   is not `key: value` pairs) as an `invalid_yaml` issue; `wiki update` still
   repairs such a block through its line grammar, except a body that is not
-  `key: value` pairs, which it leaves untouched.
+  `key: value` pairs, a mapping whose keys are not column-0 `key:` lines, or a
+  block whose repair would leave a strict reader worse off (an accepted block
+  rejected, or authored lines folded into a quoted value), which it leaves
+  untouched.
 - **Wikilinks stay inside the wiki.** A wikilink (`[[...]]`) must target another
   page in the same wiki. Files outside the wiki (source files, configs, another
   wiki's pages) can be referenced by name or in backticks, but never linked.
@@ -154,11 +159,14 @@ rather than authoring or auditing page by page yourself:
   only draws a soft note. Author the desc in the child page's frontmatter —
   `wiki update` copies it onto the parent index's link line. A desc containing
   `: ` or ` #` must be YAML-quoted — a strict reader rejects the unquoted colon
-  (`wiki lint` reports it as `invalid_yaml`) and reads ` #` as a comment (lint
-  names it as the likely cause only when the cut-short desc loses its period);
-  surrounding quotes are stripped when the value is read. Never hand-wrap a desc
-  mid-word or onto a list-marker start — let the block scalar carry the breaks;
-  lint fails the wrap artifacts (a hyphen dangle, a phantom list item).
+  on a one-line desc or on a continuation line of one (`wiki lint` reports it as
+  `invalid_yaml`; under a bare `desc:` key an indented `Key: value` line nests a
+  mapping instead, which no strict reader shows as text and lint does not
+  report) and reads ` #` as a comment (lint names it as the likely cause only
+  when the cut-short desc loses its period); surrounding quotes are stripped
+  when the value is read. Never hand-wrap a desc mid-word or onto a list-marker
+  start — let the block scalar carry the breaks; lint fails the wrap artifacts
+  (a hyphen dangle, a phantom list item).
 - **Fill in auto-created index descs.** `wiki update` creates a missing
   `_index.md` for every new directory with a `desc: ...` placeholder and
   announces the batch in its condensed summary
@@ -199,10 +207,13 @@ rather than authoring or auditing page by page yourself:
   prettier) exclude the wiki root instead (`wiki/` in `.prettierignore`).
 - **The git merge driver resolves only the generated region.** For `_index.md`
   files it normalizes the regenerated `name`/`updated` keys to *ours* (plus
-  `created` on an add/add merge, where both sides seeded it), resolves the link
-  block to the union of both sides' rows — ours' layout wins and rows present
-  only in theirs ride over with their desc continuations, appended above the
-  closing `***`, so a merge never drops one side's additions — and three-way
+  `created` whenever the base index carries no real stamp — an add/add merge, a
+  hand-written or imported index), resolves the link block to the union of both
+  sides' rows — ours' layout wins, rows present only in theirs ride over with
+  their desc continuations, appended above the closing `***`, and a row both
+  sides carry keeps ours' text unless only theirs changed it against the base,
+  so a merge never drops one side's additions, and an edit only one side made is
+  never lost (when both sides edit the same row, ours wins) — and three-way
   merges everything authored — the remaining frontmatter fields
   (`title`/`desc`/`created`/`category`/`tags`/`sources`) and the user content
   below `***` — which can still conflict for hand-resolution. A side missing its

--- a/wiki/skills/wiki/SKILL.md
+++ b/wiki/skills/wiki/SKILL.md
@@ -124,6 +124,14 @@ rather than authoring or auditing page by page yourself:
   `created`, `updated` — moving each field (with its block-scalar body) verbatim
   into its slot. Custom keys are allowed: they keep their relative order below
   the known fields, above the timestamps.
+- **Frontmatter reads as YAML.** Field values are read the way a strict YAML
+  reader reads them — a value continued on indented lines folds into one, a
+  quoted value decodes, a space followed by `#` starts a comment, and
+  `null # comment` unsets like `null`. `wiki lint` reports a block a strict
+  reader rejects (an unquoted `: ` inside a value, a duplicate key, a body that
+  is not `key: value` pairs) as an `invalid_yaml` issue; `wiki update` still
+  repairs such a block through its line grammar, except a body that is not
+  `key: value` pairs, which it leaves untouched.
 - **Wikilinks stay inside the wiki.** A wikilink (`[[...]]`) must target another
   page in the same wiki. Files outside the wiki (source files, configs, another
   wiki's pages) can be referenced by name or in backticks, but never linked.
@@ -145,10 +153,11 @@ rather than authoring or auditing page by page yourself:
   link description) that lacks a trailing period; the seeded `...` placeholder
   only draws a soft note. Author the desc in the child page's frontmatter —
   `wiki update` copies it onto the parent index's link line. A desc containing
-  `: ` must be YAML-quoted; surrounding quotes are stripped when the value is
-  read. Never hand-wrap a desc mid-word or onto a list-marker start — let the
-  block scalar carry the breaks; lint fails the wrap artifacts (a hyphen dangle,
-  a phantom list item).
+  `: ` or ` #` must be YAML-quoted — a strict reader rejects the unquoted colon
+  and reads ` #` as a comment, and `wiki lint` reports both; surrounding quotes
+  are stripped when the value is read. Never hand-wrap a desc mid-word or onto a
+  list-marker start — let the block scalar carry the breaks; lint fails the wrap
+  artifacts (a hyphen dangle, a phantom list item).
 - **Fill in auto-created index descs.** `wiki update` creates a missing
   `_index.md` for every new directory with a `desc: ...` placeholder and
   announces the batch in its condensed summary

--- a/wiki/skills/wiki/SKILL.md
+++ b/wiki/skills/wiki/SKILL.md
@@ -154,10 +154,11 @@ rather than authoring or auditing page by page yourself:
   only draws a soft note. Author the desc in the child page's frontmatter —
   `wiki update` copies it onto the parent index's link line. A desc containing
   `: ` or ` #` must be YAML-quoted — a strict reader rejects the unquoted colon
-  and reads ` #` as a comment, and `wiki lint` reports both; surrounding quotes
-  are stripped when the value is read. Never hand-wrap a desc mid-word or onto a
-  list-marker start — let the block scalar carry the breaks; lint fails the wrap
-  artifacts (a hyphen dangle, a phantom list item).
+  (`wiki lint` reports it as `invalid_yaml`) and reads ` #` as a comment (lint
+  names it as the likely cause only when the cut-short desc loses its period);
+  surrounding quotes are stripped when the value is read. Never hand-wrap a desc
+  mid-word or onto a list-marker start — let the block scalar carry the breaks;
+  lint fails the wrap artifacts (a hyphen dangle, a phantom list item).
 - **Fill in auto-created index descs.** `wiki update` creates a missing
   `_index.md` for every new directory with a `desc: ...` placeholder and
   announces the batch in its condensed summary


### PR DESCRIPTION
Resolves #3 — with a different shape than the issue proposed. The evaluation declined ruamel.yaml round-trip mode (numbers below); instead the frontmatter reader takes its values from PyYAML's composed node graph, every write stays byte-level, and a differential oracle suite pins the reader, the repair, and the writer against a strict YAML reader.

## What changes

- **Reader.** `read_frontmatter_field` and the title/category readers take scalar values from PyYAML `compose()` — no dumper ever runs. A plain scalar folds across its continuation lines, a quoted scalar decodes, a bare key with trailing spaces or an indented `# comment` reads as YAML reads it, and `null # comment` unsets like `null`. A block a strict parser rejects (the 17 `collatz/math` pages, merge-conflict states) falls back to the line grammar, so nothing that read before stops reading. Composed blocks are memoized per process.
- **Writer twin.** `quote()` single-quotes any value a plain scalar would misread — a leading indicator character, a ` #` comment start, leading or trailing whitespace — so an adopted `# TODO #123` heading survives the next update.
- **Repair fixes.** A bare `created:`/`updated:` over an indented stamp is a value, not a blank to stamp over (in the repair and in `_apply_plan`'s re-stamp); a bare-key `name:` refresh keeps its comment; `title: null # why` and `desc: | # note` count as unset; a body that is valid YAML but not `key: value` pairs is left untouched with a notice; a dotted key sorts as a custom field; `desc : x` is the desc field; a column-0 `- https://…` item stays in its field.
- **Merge driver.** A regenerated key moves with its indented body, so a block-scalar `name:` on one side no longer strands its body under the other side's one-liner.
- **Lint.** New hard issue `invalid_yaml` (payload `line`, `reason`): an unquoted `: `, a trailing `:`, a duplicate key, a control character, a non-scalar key, a non-mapping body — reported under both PyYAML loaders rather than aborting the sweep. "Missing period in desc" names a ` #` comment as the likely cause.
- **Dependency.** `pyyaml>=6,<7` moves from the test group to the runtime dependencies; the search `_SCHEMA_VERSION` bumps to 3.
- **Tests.** `tests/test_core/_oracle.py` and a rewritten `test_format.py`: 396 grammar shapes across 10 keys plus hostile extras, judged against PyYAML for the reader, the repair (idempotence, validity, authored values, comment survival), `quote()`, and field extents; engine tests for every multi-line desc, category, and title shape, a full-grammar convergence test, the stamp pair, the driver, and the lint kinds under both loaders. The suite grows from 732 to 2052 tests (about 13 s).

## Evidence

- Against `dev`'s package, 286 of the new tests fail (624 pass); on this branch all 2052 pass, and pre-commit and `sphinx-build -W` are clean.
- Gate 1 (no authored-value corruption): the reader matches PyYAML on every grammar shape; the evaluation measured 0 value changes over 46,963 reads of 4,326 real frontmatter blocks.
- Gate 2 (bounded first-update churn): `wiki update --check` prints `Nothing to update.` on converged copies of `collatz/math` (3,915 pages) and `patterns` (310 pages) with this branch.
- `wiki lint` on `collatz/math` reports exactly the 17 known `invalid_yaml` pages and no other new finding.

## Why not ruamel, in short

Round-trip mode is pure Python at about 44× the custom reader per block (1.4–2× on `update` and `lint` end to end), needs an emitter subclass, a null sentinel, and per-document indent sniffing to stay byte-identical, still restyles a bare-key multi-line desc, and rejects the 17 invalid pages outright. The full record is the plan `scratch/plans/2026-08-27T17:44:40Z-ruamel_frontmatter_roundtrip.md` and the evaluation reports it lists.

## Not in this PR

- The release: bumping the five version literals to 1.4.0 and tagging. The CHANGELOG entry sits under `[Unreleased]` with Breaking, Fixed, and Changed headings.
- `collatz/math`: 17 pages need their `desc:`/`title:` line quoted before that repo's `wiki lint` gates go green under the new release.
- The matching wording change to `conventions/docs/wiki/descs.md` in the patterns wiki, left uncommitted there.
