### PR TITLE
links.external: let wikilinks reach allowlisted folders outside the wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,14 @@ may include breaking changes, each listed under a Breaking heading.
   names it (`(use [[overview]])`) and, when the same text read from the wiki
   root reaches a real file under a `links.external` folder, that file's
   page-relative spelling too
-  (`(use [[../../src/main.py]] for the file outside the wiki)`). The
+  (`(use [[../../src/main.py]] for the path outside the wiki)`). The
   folder-relative slip `[[../overview]]` from a nested page, which was a soft
   `Stale link` note carrying the same `(use [[overview]])` suggestion, is now
-  this issue. A wiki with no such link lints exactly as before.
+  this issue; so is a `./` target, or a `.` or `..` segment after a plain one,
+  that resolved to a real page from the wiki root (`[[./overview]]`,
+  `[[core/../overview]]`, `[[../wiki/overview]]` through the wiki's own folder
+  name), which linted clean before. A wiki with no such link draws no new issue
+  and exits as before.
 
 ### Added
 
@@ -65,13 +69,16 @@ may include breaking changes, each listed under a Breaking heading.
   folder holding `.wiki/settings.json`) is judged by that wiki's own settings —
   a page by stem is live, a folder it indexes is the `directory_link` issue
   naming its `_index` page, a folder its `exclude.patterns` keeps out is live —
-  read as a JSON parse that runs none of that wiki's code (a malformed or
-  unreadable settings file there fails lint naming that wiki once a link needs
-  its rules; the home directory and the config home never count as a wiki). A
-  real file outside every listed folder is noted with the entry to add
-  (`LinkOutsideEvent`, hook `on_link_outside`, JSON kind `link_outside` with
-  `path`, `target`, and `folder`), and an entry naming no folder on this machine
-  draws one note per run while the links into it go unchecked
+  read as a JSON parse that runs none of that wiki's code (a settings file there
+  that is not valid JSON or not a JSON object, whose `exclude` block is invalid,
+  or that cannot be read — its `.wiki` folder included — fails lint naming that
+  wiki once a link needs its rules, any target but a page by stem; the home
+  directory and the config home never count as a wiki). A real file outside
+  every listed folder is noted with the entry to add, and a folder holding an
+  `_index.md` with the index page a wiki would link it by (`LinkOutsideEvent`,
+  hook `on_link_outside`, JSON kind `link_outside` with `path`, `target`,
+  `folder`, and an optional `canonical`), and an entry naming no folder on this
+  machine draws one note per run while the links into it go unchecked
   (`LinkFolderMissingEvent`, hook `on_link_folder_missing`, JSON kind
   `link_folder_missing` with `folder` and no `path`). The allowlist is a lint
   rule alone: `wiki read`, `map`, `match`, `search`, `update`, and `new` stay
@@ -103,7 +110,17 @@ may include breaking changes, each listed under a Breaking heading.
   outside every `links.external` folder is noted as
   `Link [[../docs/guide]] points outside the wiki (add '../docs' to links.external in .wiki/settings.json to allow it)`
   instead of `Stale link [[../docs/guide]]` — still a note, never an issue; a
-  target with nothing at its path keeps the stale note.
+  target with nothing at its path keeps the stale note, as does one whose entry
+  the policy would refuse (reached through a symlink alias of the wiki, at the
+  filesystem root, or through a folder name carrying a backslash).
+- A prose wikilink's target is read without surrounding spaces and tabs, and a
+  `[` never opens or sits inside a target: `[[ page ]]` links `page` (so
+  `[[ notes ]]` is judged as the folder `notes` — the directory-link issue where
+  the padded text was a stale note), and a stray third bracket (`[[[page]]`)
+  reads as `[` before `[[page]]`, so neither typo draws a stale note for the
+  junk-carrying text; likewise `[[page[x]]` links `page`, the text after the `[`
+  being junk, and a target of only spaces and tabs (`[[ ]]`) is no link at all,
+  as `[[]]` never was.
 - The `(use [[...]])` suggestion also names a raw file's spelling inside the
   wiki — `(use [[Makefile]])` on the relative-link issue for a `[[../Makefile]]`
   slip to a root-level `Makefile`, `(use [[notes/Makefile]])` on the stale note
@@ -113,6 +130,9 @@ may include breaking changes, each listed under a Breaking heading.
 
 ### Fixed
 
+- A `.wiki/settings.json` nested past the JSON parser's recursion limit fails as
+  `Malformed JSON in .wiki/settings.json: ...`, naming the file (and, for an
+  allowlisted wiki, that wiki), instead of a bare recursion error.
 - A stamp written as a bare `created:`/`updated:` key over an indented line is a
   value: `wiki update` no longer stamps the run's clock onto the key line and
   strands the authored stamp below it, and the `updated:` re-stamp replaces the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,14 +113,13 @@ may include breaking changes, each listed under a Breaking heading.
   target with nothing at its path keeps the stale note, as does one whose entry
   the policy would refuse (reached through a symlink alias of the wiki, at the
   filesystem root, or through a folder name carrying a backslash).
-- A prose wikilink's target is read without surrounding spaces and tabs, and a
-  `[` never opens or sits inside a target: `[[ page ]]` links `page` (so
-  `[[ notes ]]` is judged as the folder `notes` — the directory-link issue where
-  the padded text was a stale note), and a stray third bracket (`[[[page]]`)
-  reads as `[` before `[[page]]`, so neither typo draws a stale note for the
-  junk-carrying text; likewise `[[page[x]]` links `page`, the text after the `[`
-  being junk, and a target of only spaces and tabs (`[[ ]]`) is no link at all,
-  as `[[]]` never was.
+- A prose wikilink's target is read without surrounding spaces and tabs:
+  `[[ page ]]` links `page` (so `[[ notes ]]` is judged as the folder `notes` —
+  the directory-link issue where the padded text was a stale note), and a target
+  of only spaces and tabs (`[[ ]]`) is no link at all, as `[[]]` never was. A
+  target carrying `[` (`[[[page]]`, `[[page[x]]`) is junk no name can carry: it
+  stays the stale note it always was, quoted as written, and is never read from
+  the page's folder.
 - The `(use [[...]])` suggestion also names a raw file's spelling inside the
   wiki — `(use [[Makefile]])` on the relative-link issue for a `[[../Makefile]]`
   slip to a root-level `Makefile`, `(use [[notes/Makefile]])` on the stale note

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,23 +65,24 @@ may include breaking changes, each listed under a Breaking heading.
   folder holding `.wiki/settings.json`) is judged by that wiki's own settings —
   a page by stem is live, a folder it indexes is the `directory_link` issue
   naming its `_index` page, a folder its `exclude.patterns` keeps out is live —
-  read as a JSON parse that runs none of that wiki's code (a malformed settings
-  file there fails lint naming that wiki). A real file outside every listed
-  folder is noted with the entry to add (`LinkOutsideEvent`, hook
-  `on_link_outside`, JSON kind `link_outside` with `path`, `target`, and
-  `folder`), and an entry naming no folder on this machine draws one note per
-  run while the links into it go unchecked (`LinkFolderMissingEvent`, hook
-  `on_link_folder_missing`, JSON kind `link_folder_missing` with `folder` and no
-  `path`). The allowlist is a lint rule alone: `wiki read`, `map`, `match`,
-  `search`, `update`, and `new` stay confined to the root, and generated index
-  rows never carry an external target, so `wiki map` never shows an external
-  folder. Obsidian reads `./` and `../` from the note's folder too, so nothing
-  lint accepts renders as a different file there, but it cannot see outside the
-  vault, so an external link shows unresolved — do not click it: Obsidian
-  creates the missing target at that path. `wiki init` does not seed the block
-  but validates one passed through `--settings`; `wiki lint` reads it on every
-  run and `wiki update` never does; earlier versions ignore it and note external
-  links as stale.
+  read as a JSON parse that runs none of that wiki's code (a malformed or
+  unreadable settings file there fails lint naming that wiki once a link needs
+  its rules; the home directory and the config home never count as a wiki). A
+  real file outside every listed folder is noted with the entry to add
+  (`LinkOutsideEvent`, hook `on_link_outside`, JSON kind `link_outside` with
+  `path`, `target`, and `folder`), and an entry naming no folder on this machine
+  draws one note per run while the links into it go unchecked
+  (`LinkFolderMissingEvent`, hook `on_link_folder_missing`, JSON kind
+  `link_folder_missing` with `folder` and no `path`). The allowlist is a lint
+  rule alone: `wiki read`, `map`, `match`, `search`, `update`, and `new` stay
+  confined to the root, and generated index rows never carry an external target,
+  so `wiki map` never shows an external folder. Obsidian reads `./` and `../`
+  from the note's folder too, so nothing lint accepts renders as a different
+  file there, but it cannot see outside the vault, so an external link shows
+  unresolved — do not click it: Obsidian creates the missing target at that
+  path. `wiki init` does not seed the block but validates one passed through
+  `--settings`; `wiki lint` reads it on every run and `wiki update` never does;
+  earlier versions ignore it and note external links as stale.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,50 @@ may include breaking changes, each listed under a Breaking heading.
   on that first update, as one opening the block's body is.
 - PyYAML (`pyyaml>=6,<7`) is a runtime dependency; environments synced before
   this release need a `uv sync` (or a reinstall).
+- `wiki lint` reports a `./` or `../` prose wikilink that lands inside the wiki
+  as a new hard issue, `relative_link` (with `path`, `target`, `canonical`, and
+  `external` payload fields — the last two only when a fix resolves). A prefixed
+  target is read from the page's folder, as Obsidian and markdown read it, and
+  must point outside the wiki: the in-wiki form is prefix-free, so the issue
+  names it (`(use [[overview]])`) and, when the same text read from the wiki
+  root reaches a real file under a `links.external` folder, that file's
+  page-relative spelling too
+  (`(use [[../../src/main.py]] for the file outside the wiki)`). The
+  folder-relative slip `[[../overview]]` from a nested page, which was a soft
+  `Stale link` note carrying the same `(use [[overview]])` suggestion, is now
+  this issue. A wiki with no such link lints exactly as before.
+
+### Added
+
+- `links.external` external link folders: a list in `.wiki/settings.json` of
+  folder paths relative to the wiki root, each climbing out of it with leading
+  `..` (`{"links": {"external": ["../src", "../math"]}}`), under which prose
+  wikilinks may leave the wiki. Two link bases, one rule each: a prefix-free
+  target is read from the wiki root and must name something inside it; a `./` or
+  `../` target is read from the page's folder, as Obsidian and markdown read it,
+  and must leave the wiki. Under a listed folder present on this machine
+  `wiki lint` holds a link live when the file, its `.md` page, or the folder
+  exists and notes a missing target stale; a target inside another wiki (a
+  folder holding `.wiki/settings.json`) is judged by that wiki's own settings —
+  a page by stem is live, a folder it indexes is the `directory_link` issue
+  naming its `_index` page, a folder its `exclude.patterns` keeps out is live —
+  read as a JSON parse that runs none of that wiki's code (a malformed settings
+  file there fails lint naming that wiki). A real file outside every listed
+  folder is noted with the entry to add (`LinkOutsideEvent`, hook
+  `on_link_outside`, JSON kind `link_outside` with `path`, `target`, and
+  `folder`), and an entry naming no folder on this machine draws one note per
+  run while the links into it go unchecked (`LinkFolderMissingEvent`, hook
+  `on_link_folder_missing`, JSON kind `link_folder_missing` with `folder` and no
+  `path`). The allowlist is a lint rule alone: `wiki read`, `map`, `match`,
+  `search`, `update`, and `new` stay confined to the root, and generated index
+  rows never carry an external target, so `wiki map` never shows an external
+  folder. Obsidian reads `./` and `../` from the note's folder too, so nothing
+  lint accepts renders as a different file there, but it cannot see outside the
+  vault, so an external link shows unresolved — do not click it: Obsidian
+  creates the missing target at that path. `wiki init` does not seed the block
+  but validates one passed through `--settings`; `wiki lint` reads it on every
+  run and `wiki update` never does; earlier versions ignore it and note external
+  links as stale.
 
 ### Changed
 
@@ -54,6 +98,17 @@ may include breaking changes, each listed under a Breaking heading.
   one space).
 - The `wiki update` narration counts files with malformed frontmatter without
   the `(no closing ---)` suffix; each per-file notice names its reason.
+- A prose wikilink that leaves the wiki and resolves to a real file or folder
+  outside every `links.external` folder is noted as
+  `Link [[../docs/guide]] points outside the wiki (add '../docs' to links.external in .wiki/settings.json to allow it)`
+  instead of `Stale link [[../docs/guide]]` — still a note, never an issue; a
+  target with nothing at its path keeps the stale note.
+- The `(use [[...]])` suggestion also names a raw file's spelling inside the
+  wiki — `(use [[Makefile]])` on the relative-link issue for a `[[../Makefile]]`
+  slip to a root-level `Makefile`, `(use [[notes/Makefile]])` on the stale note
+  for a `[[Makefile]]` in `notes/` that resolves only from the page's folder —
+  and the page-relative spelling of an allowlisted file a prefixed or absolute
+  link missed (`Stale link [[/repo/src/main.py]] (use [[../../src/main.py]])`).
 
 ### Fixed
 
@@ -267,6 +322,11 @@ may include breaking changes, each listed under a Breaking heading.
   its block scalar with an explicit indentation indicator (`desc: |2`), so a
   strict reader takes the leading whitespace as content instead of mis-detecting
   the block's indentation and rejecting it.
+- `wiki lint` no longer exits 2 on Python 3.11 to 3.13 when a prose wikilink or
+  an index row names a path the filesystem cannot stat (a name over 255 bytes,
+  an unreadable directory): every link probe goes through `os.path`, so the
+  target reads as missing — a stale note for prose, a broken-link issue for a
+  generated row — as it does on 3.14.
 
 ## [1.3.1] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ or identifier-style names, through the `naming` block in `.wiki/settings.json`;
 `wiki lint` flags any name that violates the policy. Whole subtrees can be
 excluded from indexing with gitignore-style globs in `exclude.patterns` —
 excluded paths are never walked or linted, though `wiki read` still serves them.
+Prose wikilinks stay inside the wiki unless `links.external` lists folders
+outside it, as paths relative to the wiki root (`../src`, `../math`): a `./` or
+`../` link, read from the page's folder as Obsidian reads it, may then target a
+file or another wiki's page under a listed folder. The allowlist is a lint rule
+alone — `wiki lint` checks such links in place, while `wiki read` and every
+other command stay confined to the wiki root.
 
 Frontmatter timestamps default to UTC in ISO-8601. To change them, set a
 timezone (any IANA name) and format (a strftime string) under `timestamp` in
@@ -162,15 +168,17 @@ Maintain indexes as files are added and removed:
 - `wiki new` — create an indexed folder with an authored desc and content
 
 `wiki lint` exits 1 on issues and 0 on a clean wiki (soft notes go to stderr and
-never affect the exit code — a stale wikilink in prose is a note, while a broken
-link in a generated index block, a prose link naming a folder rather than its
-`_index` page, or frontmatter a strict YAML reader rejects, is an issue).
-Scripts should read `wiki lint --json` — one JSON document on stdout listing
-every issue and note with a `severity` and `kind` — rather than parse the prose;
-the exit code is unchanged. A page that must display otherwise-flagged content —
-sample conflict markers, stale link examples — wraps those lines in a
-`<!-- start: no-lint -->` ... `<!-- end: no-lint -->` region, which suppresses
-the positional rules, notes included, for just that span.
+never affect the exit code — a stale wikilink in prose, or a prose link to a
+real file outside every allowlisted folder, is a note, while a broken link in a
+generated index block, a prose link naming a folder rather than its `_index`
+page, a `./` or `../` prose link that lands inside the wiki, or frontmatter a
+strict YAML reader rejects, is an issue). Scripts should read `wiki lint --json`
+— one JSON document on stdout listing every issue and note with a `severity` and
+`kind` — rather than parse the prose; the exit code is unchanged. A page that
+must display otherwise-flagged content — sample conflict markers, stale link
+examples — wraps those lines in a `<!-- start: no-lint -->` ...
+`<!-- end: no-lint -->` region, which suppresses the positional rules, notes
+included, for just that span.
 
 Browse structure, search across content, and read entries:
 

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -261,8 +261,10 @@ The name resolves relative to the wiki root: a directory reads its
 (appended, not substituted — ``app.config`` resolves to ``app.config.md``). A
 miss fails with ``Wiki entry not found: '<name>'``, suggesting the full key
 when exactly one page's stem matches; a path escaping the root fails with
-``Path is outside wiki root: '<name>'``. Resolution is directory-first: a
-folder shadows a same-named page.
+``Path is outside wiki root: '<name>'`` — even under a ``links.external``
+folder; the allowlist is a lint rule, not a read grant (see
+:doc:`/configuration`). Resolution is directory-first: a folder shadows a
+same-named page.
 
 The slice options are pairwise mutually exclusive and share the format
 ``n:m``, ``n:``, or ``:m`` (0-indexed, half-open). A slice applies to the
@@ -617,8 +619,8 @@ stderr note is not a blocking issue). ``--json`` replaces the prose report
 with one JSON document on stdout carrying every finding under an explicit
 ``severity`` (``issue``/``note``) and a machine ``kind`` with its per-kind
 payload fields (``path`` on every issue and on most notes — the
-``resolver_notice``, ``merge_driver_unconfigured``, and
-``git_fence_unavailable`` notes carry none — plus e.g. ``target``/``label``
+``resolver_notice``, ``merge_driver_unconfigured``, ``git_fence_unavailable``,
+and ``link_folder_missing`` notes carry none — plus e.g. ``target``/``label``
 on a broken link, ``line`` on a wrap mangle, or ``line``/``reason`` on
 invalid YAML frontmatter), the rendered prose under ``text``, and a
 ``summary`` with both counts; the exit-code contract is unchanged.
@@ -636,29 +638,39 @@ nested wiki roots, formatter-damage signatures (escaped wikilinks, a missing
 delimiter), hand-wrap mangles, authored descriptions missing their trailing
 period, unparseable ``created:``/``updated:`` stamps, broken links in the
 generated index block, prose wikilinks naming a folder rather than its
-``_index`` page, dangling or nested region markers, and — when the
+``_index`` page (in this wiki, or in another wiki a ``links.external``
+folder admits, judged by that wiki's own settings), prose wikilinks written
+with ``./`` or ``../`` that land inside the wiki (a prefixed target is read
+from the page's folder and must leave the wiki; the issue names the
+prefix-free form), dangling or nested region markers, and — when the
 ``titles.required`` setting is on — missing titles.
 
 **Notes** (soft, stderr) flag placeholder (``...``) descriptions, descriptions
 over 500 characters, empty index content sections, CRLF line endings, stale
-``[[wikilinks]]`` in authored prose (suggesting the canonical target when one
-resolves), an indexed path this machine's git ignores (a personal
-``core.excludesFile`` rule — the row ships where the file cannot, so every other
-clone reds on a broken link), a gitignore fence the probe cannot read inside an
-enclosing repository (``git check-ignore`` failed — git off ``PATH`` or a
-broken install — so indexing proceeds unfenced and adopts what the repository
-ignores), and a ``.gitattributes`` mapping ``merge=wiki`` with no
-``merge.wiki.driver`` configured — the fresh-clone state where index merges
-silently fall back to a plain text merge until ``wiki config`` registers the
-driver. Resolver diagnostics (an upward resolution, a missing settings marker
-or root index, an outer index above the declared root) join the notes too —
-counted in the closing summary and typed as ``resolver_notice`` rows in
-``--json`` — beside their stderr prose.
+``[[wikilinks]]`` in authored prose (inside the wiki, or under a
+``links.external`` folder present on this machine; the note suggests the
+prefix-free target, or the page-relative spelling of an allowlisted file,
+when one resolves), a ``./`` or ``../`` link reaching a real file outside
+every ``links.external`` folder (naming the entry to add), a
+``links.external`` entry naming no folder on this machine (noted once per
+run; links into it go unchecked), an indexed path this machine's git ignores
+(a personal ``core.excludesFile`` rule — the row ships where the file cannot,
+so every other clone reds on a broken link), a gitignore fence the probe
+cannot read inside an enclosing repository (``git check-ignore`` failed — git
+off ``PATH`` or a broken install — so indexing proceeds unfenced and adopts
+what the repository ignores), and a ``.gitattributes`` mapping ``merge=wiki``
+with no ``merge.wiki.driver`` configured — the fresh-clone state where index
+merges silently fall back to a plain text merge until ``wiki config``
+registers the driver. Resolver diagnostics (an upward resolution, a missing
+settings marker or root index, an outer index above the declared root) join
+the notes too — counted in the closing summary and typed as
+``resolver_notice`` rows in ``--json`` — beside their stderr prose.
 
 A ``<!-- start: no-lint -->`` ... ``<!-- end: no-lint -->`` region suppresses
 the position-based rules (conflict markers, escaped wikilinks, wrap mangles,
-stale-link notes, directory-link issues) for the lines it wraps; a malformed
-pair is itself an issue and suppresses nothing.
+stale-link and outside-link notes, directory-link and relative-link issues)
+for the lines it wraps; a malformed pair is itself an issue and suppresses
+nothing.
 
 .. list-table::
    :header-rows: 1

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -392,7 +392,8 @@ external links (in-wiki links, being root-relative, survive the move).
      (no wikilink target can carry one); an empty segment (``//``); a ``.``
      segment; a ``..`` segment anywhere but the start; a path naming the
      whole filesystem; a path inside the wiki root (an in-wiki link needs no
-     allowlist); and a path that aliases the wiki root through a symlink.
+     allowlist); and a path that resolves inside the wiki root through a
+     symlink alias.
    - An entry may name a folder absent from this machine — a sibling
      checkout missing from a partial clone. ``wiki lint`` notes it once per
      run (``links.external entry '../src' names no folder on this machine;
@@ -401,11 +402,14 @@ external links (in-wiki links, being root-relative, survive the move).
      file rather than a folder draws the same note: list the folder that
      holds the file.
 
-A target under a listed folder may lie inside another wiki — a folder
-holding ``.wiki/settings.json`` on the path from the entry down to the
-target, the entry itself included (an entry that lies inside another wiki
-admits that wiki's files as plain files). Such a target is judged by that
-wiki's own page rules, read from its settings: a page links by stem
+A target under a listed folder may lie inside another wiki — the nearest
+folder holding ``.wiki/settings.json`` on the path from the filesystem root
+down to the target, above the entry or below it, so an entry inside another
+wiki still hands its files to that wiki's rules. Your home directory and
+the config home (``~/.wiki``, or ``WIKI_CONFIG_DIR``) are never taken for a
+wiki: the trust store lives there, and a home that counted would enclose
+every wiki beneath it. Such a target is judged by that wiki's own page
+rules, read from its settings: a page links by stem
 (``[[../math/lemmas]]``); a folder that wiki indexes — one its
 ``exclude.patterns`` and its repository's gitignore leave in its walk,
 holding an ``_index.md`` — is the same hard directory-link issue as at home
@@ -414,13 +418,15 @@ holding an ``_index.md`` — is the same hard directory-link issue as at home
 The read is a JSON parse of that wiki's settings plus, on the first folder
 link into it per run, its indexed-folder walk and one ``git check-ignore``;
 none of that wiki's code runs — a ``.wiki/wiki.py`` hook loads only through
-the CLI's trust check on the wiki being linted. A malformed settings file
-there fails this lint with exit 2, naming it (``links.external wiki
-'../math': ...``). And because that wiki's own ``wiki update`` mints an
-``_index.md`` in every folder it indexes, a bare folder link here turns into
-the issue the moment it does — exactly as inside one wiki. A target under a
-plain folder, with no wiki marker on the path down to it, is judged by
-existence alone; a stray ``_index.md`` there has no effect.
+the CLI's trust check on the wiki being linted. A malformed or unreadable
+settings file there fails this lint with exit 2, naming it
+(``links.external wiki '../math': ...``), as soon as a link needs that
+wiki's rules — any target but a page by stem. And because that wiki's own
+``wiki update`` mints an ``_index.md`` in every folder it indexes, a bare
+folder link here turns into the issue the moment it does — exactly as inside
+one wiki. A target under a plain folder, with no wiki marker on the path
+down to it, is judged by existence alone; a stray ``_index.md`` there has no
+effect.
 
 Obsidian reads a prefix-free link from the vault root and a ``./`` or ``../``
 link from the note's folder — the same two bases ``wiki lint`` uses — so

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -333,16 +333,21 @@ indexing depend on the machine.
 
 Lets prose wikilinks reach files outside the wiki. A wikilink is read from
 one of two places: a prefix-free target (``[[core/design]]``) is read from
-the wiki root and must name something inside it, while a target that starts
-with ``./`` or ``../`` is read from the folder of the page that carries it —
-as Obsidian and markdown read it — and must leave the wiki. From a root-level
+the wiki root and must name something inside it, while a target carrying a
+``.`` or ``..`` segment anywhere (most often at its start, as ``./`` or
+``../``) is read from the folder of the page that carries it — as Obsidian
+and markdown read it — and must leave the wiki. From a root-level
 page a sibling wiki's page is ``[[../math/lemmas]]``; from ``nodes/verify.md``
 the same file is ``[[../../math/lemmas]]``. ``wiki lint`` accepts such a link
 when its target lands under a folder this block lists and the file, its
 ``.md`` form, or the folder exists there; judges a target inside another wiki
 by that wiki's own page rules (below); notes a missing target as a ``Stale
 link``; and, when a link reaches a real file outside every listed folder,
-notes the entry to add. The block is a lint rule and nothing more:
+notes the entry to add (and, for a folder holding an ``_index.md``, the index
+page a wiki would link it by; a target whose entry the policy would refuse —
+through a symlink alias of the wiki, at the filesystem root, or through a
+folder name carrying a backslash — is noted stale instead). The block is a
+lint rule and nothing more:
 ``wiki read``, ``wiki map``, ``wiki match``, ``wiki search``, ``wiki update``,
 and ``wiki new`` stay confined to the wiki root (a name under a listed folder
 still fails with ``Path is outside wiki root``), generated index rows never
@@ -416,12 +421,19 @@ holding an ``_index.md`` — is the same hard directory-link issue as at home
 (``Link [[../math/g2]] targets a folder, not a page (use
 [[../math/g2/_index]])``); a folder it excludes is live in the bare form.
 The read is a JSON parse of that wiki's settings plus, on the first folder
-link into it per run, its indexed-folder walk and one ``git check-ignore``;
-none of that wiki's code runs — a ``.wiki/wiki.py`` hook loads only through
-the CLI's trust check on the wiki being linted. A malformed or unreadable
-settings file there fails this lint with exit 2, naming it
-(``links.external wiki '../math': ...``), as soon as a link needs that
-wiki's rules — any target but a page by stem. And because that wiki's own
+link into it per run, its indexed-folder walk and one ``git check-ignore``
+(a note that walk raises, such as its gitignore fence being unavailable, is
+that wiki's, worded as during its own update); none of that wiki's code runs
+— a ``.wiki/wiki.py`` hook loads only through the CLI's trust check on the
+wiki being linted. A settings file there that is not valid JSON, not a JSON
+object, whose ``exclude`` block is invalid, or that cannot be read — the
+marker folder itself included — fails this lint with exit 2, naming it
+(``links.external wiki '../math': ...``), as soon as a link's verdict needs
+that wiki's rules — any target but a page by stem; a link judged without
+them (one landing inside this wiki, or an absolute target) keeps its verdict,
+and its suggestion names only a spelling that needs none of that wiki's rules
+— a page there by stem, never a folder or raw file there. And because that
+wiki's own
 ``wiki update`` mints an ``_index.md`` in every folder it indexes, a bare
 folder link here turns into the issue the moment it does — exactly as inside
 one wiki. A target under a plain folder, with no wiki marker on the path

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,8 +4,8 @@ Configuration
 ``wiki`` reads configuration from the following places:
 
 - the per-wiki settings file, ``.wiki/settings.json``, at the wiki root —
-  naming policy, timestamp rendering, map presentation, and title
-  requirements for that wiki;
+  naming policy, timestamp rendering, map presentation, title requirements,
+  indexing exclusions, and external link folders for that wiki;
 - the user-global file ``~/.wiki/settings.json`` — the machine-local trust
   store, not wiki policy;
 - the environment variables ``OFFLINE_MODE`` and ``WIKI_CONFIG_DIR``.
@@ -80,9 +80,9 @@ The settings file: ``.wiki/settings.json``
 A JSON object at the wiki root. An absent file means all defaults; malformed
 JSON or a non-object top level fails every command that reads policy, with a
 message naming the file. The recognized blocks — ``naming``, ``timestamp``,
-``map``, ``titles``, and ``exclude`` — are all optional, all objects.
-Unknown top-level keys are ignored, but a wrong-typed known block or key is
-an error naming the file and key.
+``map``, ``titles``, ``exclude``, and ``links`` — are all optional, all
+objects. Unknown top-level keys are ignored, but a wrong-typed known block or
+key is an error naming the file and key.
 
 Seeding and restoration are asymmetric:
 
@@ -327,6 +327,121 @@ reds on a broken link your own ``wiki lint`` never shows. Both the sweep that
 mints such a row and the lint that audits it emit a note naming the path and
 the excluding source; the row is still minted, since refusing it would make
 indexing depend on the machine.
+
+``links`` — external link folders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lets prose wikilinks reach files outside the wiki. A wikilink is read from
+one of two places: a prefix-free target (``[[core/design]]``) is read from
+the wiki root and must name something inside it, while a target that starts
+with ``./`` or ``../`` is read from the folder of the page that carries it —
+as Obsidian and markdown read it — and must leave the wiki. From a root-level
+page a sibling wiki's page is ``[[../math/lemmas]]``; from ``nodes/verify.md``
+the same file is ``[[../../math/lemmas]]``. ``wiki lint`` accepts such a link
+when its target lands under a folder this block lists and the file, its
+``.md`` form, or the folder exists there; judges a target inside another wiki
+by that wiki's own page rules (below); notes a missing target as a ``Stale
+link``; and, when a link reaches a real file outside every listed folder,
+notes the entry to add. The block is a lint rule and nothing more:
+``wiki read``, ``wiki map``, ``wiki match``, ``wiki search``, ``wiki update``,
+and ``wiki new`` stay confined to the wiki root (a name under a listed folder
+still fails with ``Path is outside wiki root``), generated index rows never
+carry an external target, and ``wiki map`` never shows an external folder.
+``wiki lint`` reads the block on every run, links or none; ``wiki update``
+never reads it; ``wiki init`` validates a block passed through ``--settings``
+but seeds none.
+
+.. code-block:: json
+
+   {
+     "links": {
+       "external": ["../src", "../math", ".."]
+     }
+   }
+
+Entries are folder paths relative to the *wiki root*; the links themselves
+are relative to the *page*. With the block above, ``notes/meeting.md`` links
+the ``src/main.py`` beside the wiki as ``[[../../src/main.py]]`` — one ``..``
+per folder of depth — so the same external file is spelled differently from
+pages at different depths, and moving a page to another depth breaks its
+external links (in-wiki links, being root-relative, survive the move).
+
+``links.external``
+   List of strings, default ``[]``. Each entry names a folder outside the
+   wiki:
+
+   - Written with ``/`` as the separator, as one or more leading ``..``
+     segments followed by plain segments — ``../src``, ``../../patterns``,
+     or ``..`` alone. One trailing ``/`` is stripped, and repeated spellings
+     of one folder collapse to one entry.
+   - An ancestor of the wiki root (``..`` for the enclosing repository)
+     admits everything beneath it, sibling wikis included. Prefer the
+     narrowest folder that holds what you link.
+   - Containment is byte-lexical: a link's text is joined onto the page's
+     folder and compared with the entry before any stat follows. An entry
+     and a link must therefore agree in case and Unicode form — ``../Src``
+     does not admit a link into ``src/``, even on a case-insensitive
+     filesystem — and a case variant of the wiki's own folder name
+     (``../WIKI`` beside a wiki at ``wiki/``) is not refused: on a
+     case-insensitive filesystem a link written through it is judged as a
+     link into another wiki, never failed as an in-wiki link written with
+     ``../``.
+   - Rejected when the policy loads, with a message naming the entry, the
+     reason, and the file: an empty or whitespace-only path; an absolute or
+     ``~`` path; a ``\`` separator; a ``#``, ``|``, ``]``, or NUL character
+     (no wikilink target can carry one); an empty segment (``//``); a ``.``
+     segment; a ``..`` segment anywhere but the start; a path naming the
+     whole filesystem; a path inside the wiki root (an in-wiki link needs no
+     allowlist); and a path that aliases the wiki root through a symlink.
+   - An entry may name a folder absent from this machine — a sibling
+     checkout missing from a partial clone. ``wiki lint`` notes it once per
+     run (``links.external entry '../src' names no folder on this machine;
+     links into it are not checked``) and checks nothing under it, so a
+     stale link into it stays invisible on that clone. An entry naming a
+     file rather than a folder draws the same note: list the folder that
+     holds the file.
+
+A target under a listed folder may lie inside another wiki — a folder
+holding ``.wiki/settings.json`` on the path from the entry down to the
+target, the entry itself included (an entry that lies inside another wiki
+admits that wiki's files as plain files). Such a target is judged by that
+wiki's own page rules, read from its settings: a page links by stem
+(``[[../math/lemmas]]``); a folder that wiki indexes — one its
+``exclude.patterns`` and its repository's gitignore leave in its walk,
+holding an ``_index.md`` — is the same hard directory-link issue as at home
+(``Link [[../math/g2]] targets a folder, not a page (use
+[[../math/g2/_index]])``); a folder it excludes is live in the bare form.
+The read is a JSON parse of that wiki's settings plus, on the first folder
+link into it per run, its indexed-folder walk and one ``git check-ignore``;
+none of that wiki's code runs — a ``.wiki/wiki.py`` hook loads only through
+the CLI's trust check on the wiki being linted. A malformed settings file
+there fails this lint with exit 2, naming it (``links.external wiki
+'../math': ...``). And because that wiki's own ``wiki update`` mints an
+``_index.md`` in every folder it indexes, a bare folder link here turns into
+the issue the moment it does — exactly as inside one wiki. A target under a
+plain folder, with no wiki marker on the path down to it, is judged by
+existence alone; a stray ``_index.md`` there has no effect.
+
+Obsidian reads a prefix-free link from the vault root and a ``./`` or ``../``
+link from the note's folder — the same two bases ``wiki lint`` uses — so
+nothing lint accepts renders as a different note in Obsidian. An external
+target lies outside the vault, though, so Obsidian shows the link
+unresolved; do not click it: Obsidian creates the missing target at that
+path, and for a path that escapes the vault it creates folders outside the
+vault through a known bug. See :doc:`/guide/obsidian`.
+
+The settings file is committed with the wiki and takes effect on every clone
+without a consent step, and ``wiki lint`` stats the target of a ``./`` or
+``../`` link that leaves the wiki even when no listed folder holds it — the
+outside note fires only when something real is there — so a page can reveal
+whether a file exists at any path reachable from it by ``..``, within the
+lint user's permissions. The probes never read content and never raise (a
+path the filesystem cannot stat reads as missing), and lint output travels
+(stderr, ``--json``, CI logs): list the narrowest folder that holds what you
+link. Restoring a deleted settings file as ``{}`` drops the list, as it drops
+every other block. Every earlier plasma-wiki version ignores the block and
+notes external links as stale — soft notes only — so a wiki may carry it
+before every clone upgrades.
 
 The trust store: ``~/.wiki/settings.json``
 ------------------------------------------

--- a/docs/guide/generation.rst
+++ b/docs/guide/generation.rst
@@ -249,8 +249,10 @@ reports two kinds of problem — without writing anything:
   *cannot* fix. Any issue makes lint **exit 1** — and nothing else does: a
   command error exits 2, so 1 always means exactly "issues found".
 - **Notes** (stderr): soft advisories — unauthored descriptions, stale prose
-  links, pending CRLF normalization, an unconfigured merge driver in a fresh
-  clone. Notes **never affect the exit code**.
+  links, a prose link to a real file outside every ``links.external``
+  folder, a ``links.external`` entry naming no folder on this machine,
+  pending CRLF normalization, an unconfigured merge driver in a fresh clone.
+  Notes **never affect the exit code**.
 
 .. code-block:: console
 
@@ -426,7 +428,27 @@ its meaning:
    (an anchor suffix rides along, and a target reports once per file).
    Only a folder the walk reaches is flagged — a dot-prefixed, symlinked,
    or ``exclude.patterns`` segment keeps its whole subtree out of the
-   index, leaving nothing to name.
+   index, leaving nothing to name. The same issue covers a folder that
+   another wiki indexes, reached through a ``links.external`` folder and
+   judged by that wiki's own settings — ``Link [[../math/g2]] targets a
+   folder, not a page (use [[../math/g2/_index]])`` (see
+   :doc:`/configuration`).
+
+``Link [[target]] points inside the wiki through './' or '../' (use [[canonical]])``
+   A prose wikilink written with a ``./`` or ``../`` segment that lands
+   inside the wiki. Such a target is read from the page's folder — as
+   Obsidian and markdown read it — and must leave the wiki; the in-wiki form
+   is prefix-free and read from the wiki root, so the message names it: a
+   page by stem, an indexed folder's ``_index`` page, or the bare path of a
+   raw file or unindexed folder. When the same text read from the wiki root
+   would reach a real file under a ``links.external`` folder, the message
+   also offers that file's page-relative spelling — ``(use
+   [[folder_b/file_b]], or [[../../folder_b/file_b]] for the file outside
+   the wiki)`` — or offers it alone when nothing inside the wiki matches;
+   with nothing to name, the ``(use ...)`` tail is omitted. An anchor and
+   alias ride along, and a target reports once per file. The
+   folder-relative slip ``[[../overview]]`` from a nested page is this
+   issue, with ``(use [[overview]])`` as its fix.
 
 ``Nested '<!-- start: no-lint -->' (line N)`` / ``Dangling '<!-- start: no-lint -->' (line N)`` / ``Dangling '<!-- end: no-lint -->' (line N)``
    A malformed region directive (below): a second start inside an open
@@ -459,12 +481,28 @@ notes is clean — lint exits 0.
    * - ``<path>: CRLF line endings; update will normalize``
      - The next writing update rewrites the file to LF.
    * - ``<path>: Stale link [[target]]``
-     - A ``[[wikilink]]`` in authored prose points at nothing. When a
-       folder-relative target (e.g. ``../overview``) resolves to a real
-       page, the note suggests the root-relative form: ``(use
-       [[canonical]])``. Prose links are soft because pages come and go —
-       the generated link block's broken-link check is the hard surface.
-       A target notes once per file, however often the prose repeats it.
+     - A ``[[wikilink]]`` in authored prose points at nothing — inside the
+       wiki for a prefix-free target, or under a ``links.external`` folder
+       present on this machine for a ``./`` or ``../`` target (see
+       :doc:`/configuration`); an absolute target is never live. The note
+       names the fix when one reading resolves: for a prefix-free target
+       whose folder-relative reading lands on something real inside the
+       wiki, its root-relative form — ``(use [[canonical]])``: a page by
+       stem, an indexed folder's ``_index`` page, or the bare path of a raw
+       file or unindexed folder; for a prefixed or absolute target whose
+       text read from the wiki root reaches a real file under a
+       ``links.external`` folder, that file's page-relative spelling —
+       ``(use [[../../src/main.py]])``.
+       Prose links are soft because pages come and go — the generated link
+       block's broken-link check is the hard surface. A target notes once
+       per file, however often the prose repeats it.
+   * - ``<path>: Link [[target]] points outside the wiki (add '<folder>' to links.external in .wiki/settings.json to allow it)``
+     - A ``./`` or ``../`` prose link that leaves the wiki and reaches a real
+       file or folder under no ``links.external`` folder. The named entry is
+       the target's folder — or the target itself, when it is a folder —
+       relative to the wiki root; add it to allow the link, or put the
+       reference in backticks. Typed ``link_outside`` in ``--json``, with
+       ``path``, ``target``, and ``folder`` fields.
    * - ``<path>: indexed, but this machine's git ignores it (<source>:<line> '<pattern>'); its generated row ships where the file cannot, so every other clone reds on a broken link``
      - The gitignore fence reads only the repository's own rules (pinned, so
        indexing is identical on every clone), but the named ignore rule —
@@ -478,6 +516,14 @@ notes is clean — lint exits 0.
        per-clone ``merge.wiki.driver`` config, so git text-merges
        ``_index.md`` files until ``wiki config`` registers the driver (see
        :doc:`/guide/merge-driver`).
+   * - ``links.external entry '<folder>' names no folder on this machine; links into it are not checked``
+     - A ``links.external`` entry names a folder absent from this clone (a
+       sibling checkout missing from a partial clone) or names a file
+       rather than a folder. Lint notes it once per run, links or none, and
+       skips every link into it — neither live nor stale — so a stale link
+       under it stays invisible on this machine. An environment condition:
+       nothing in the wiki needs to change. Typed ``link_folder_missing`` in
+       ``--json``, with a ``folder`` field and no ``path``.
    * - ``Gitignore fence unavailable: `git check-ignore` failed inside the enclosing repository (is git installed?); indexing proceeds unfenced, so paths the repository ignores are adopted``
      - A ``.git`` directory encloses the wiki root but ``git check-ignore``
        could not run (git missing or broken), so the walk proceeds without
@@ -507,11 +553,12 @@ wrapped lines:
    <!-- end: no-lint -->
 
 Each marker stands alone on its line. The region suppresses the positional
-rules — conflict markers, escaped wikilinks, wrap mangles, stale-link notes,
-directory-link issues — for the wrapped lines only; file-level checks are
-unaffected. Content inside fenced or inline code is already masked, so those
-code samples need no region. The link rules — stale-link notes and
-directory-link issues — also skip a wikilink inside an HTML comment or an
+rules — conflict markers, escaped wikilinks, wrap mangles, stale-link and
+outside-link notes, directory-link and relative-link issues — for the
+wrapped lines only; file-level checks are unaffected. Content inside fenced
+or inline code is already masked, so those code samples need no region. The
+link rules — the stale-link and outside-link notes, the directory-link and
+relative-link issues — also skip a wikilink inside an HTML comment or an
 indented code block, so a link sample in either needs no wrapping; the
 escaped-wikilink and wrap-mangle checks do not mask those, so an
 escaped-bracket sample or a deliberately wrapped line in a comment or

--- a/docs/guide/generation.rst
+++ b/docs/guide/generation.rst
@@ -440,12 +440,16 @@ its meaning:
    Obsidian and markdown read it — and must leave the wiki; the in-wiki form
    is prefix-free and read from the wiki root, so the message names it: a
    page by stem, an indexed folder's ``_index`` page, or the bare path of a
-   raw file or unindexed folder. When the same text read from the wiki root
-   would reach a real file under a ``links.external`` folder, the message
-   also offers that file's page-relative spelling — ``(use
-   [[folder_b/file_b]], or [[../../folder_b/file_b]] for the file outside
+   raw file or unindexed folder. When nothing exists at the page-relative
+   reading, the same text read from the wiki root is tried —
+   ``[[./overview]]`` from ``notes/`` names ``(use [[overview]])`` — and the
+   wiki root itself always names ``_index``. When the same text read from
+   the wiki root would reach a real file under a ``links.external`` folder,
+   the message also offers that file's page-relative spelling — ``(use
+   [[folder_b/file_b]], or [[../../folder_b/file_b]] for the path outside
    the wiki)`` — or offers it alone when nothing inside the wiki matches;
-   with nothing to name, the ``(use ...)`` tail is omitted. An anchor and
+   with nothing to name either way, the ``(use ...)`` tail is omitted. An
+   anchor and
    alias ride along, and a target reports once per file. The
    folder-relative slip ``[[../overview]]`` from a nested page is this
    issue, with ``(use [[overview]])`` as its fix.
@@ -484,12 +488,15 @@ notes is clean — lint exits 0.
      - A ``[[wikilink]]`` in authored prose points at nothing — inside the
        wiki for a prefix-free target, or under a ``links.external`` folder
        present on this machine for a ``./`` or ``../`` target (see
-       :doc:`/configuration`); an absolute target is never live. The note
+       :doc:`/configuration`); an absolute target that leaves the wiki is
+       never live. The note
        names the fix when one reading resolves: for a prefix-free target
        whose folder-relative reading lands on something real inside the
        wiki, its root-relative form — ``(use [[canonical]])``: a page by
        stem, an indexed folder's ``_index`` page, or the bare path of a raw
-       file or unindexed folder; for a prefixed or absolute target whose
+       file or unindexed folder; for a prefixed target that misses only by
+       a trailing slash, the same path without it — ``(use
+       [[../../docs/guide]])``; for a prefixed or absolute target whose
        text read from the wiki root reaches a real file under a
        ``links.external`` folder, that file's page-relative spelling —
        ``(use [[../../src/main.py]])``.
@@ -498,11 +505,18 @@ notes is clean — lint exits 0.
        per file, however often the prose repeats it.
    * - ``<path>: Link [[target]] points outside the wiki (add '<folder>' to links.external in .wiki/settings.json to allow it)``
      - A ``./`` or ``../`` prose link that leaves the wiki and reaches a real
-       file or folder under no ``links.external`` folder. The named entry is
+       file or folder under no ``links.external`` folder. A target whose
+       entry the policy would refuse — reached through a symlink alias of
+       the wiki itself, at the filesystem root (the root itself, or a file
+       directly under it), or through a folder name carrying a backslash —
+       is a ``Stale link`` instead. The named entry is
        the target's folder — or the target itself, when it is a folder —
        relative to the wiki root; add it to allow the link, or put the
-       reference in backticks. Typed ``link_outside`` in ``--json``, with
-       ``path``, ``target``, and ``folder`` fields.
+       reference in backticks. A folder holding an ``_index.md`` may be
+       another wiki's, so the note adds ``, and link [[<folder>/_index]] if
+       a wiki indexes the folder``. Typed ``link_outside`` in ``--json``,
+       with ``path``, ``target``, ``folder``, and (for such a folder)
+       ``canonical`` fields.
    * - ``<path>: indexed, but this machine's git ignores it (<source>:<line> '<pattern>'); its generated row ships where the file cannot, so every other clone reds on a broken link``
      - The gitignore fence reads only the repository's own rules (pinned, so
        indexing is identical on every clone), but the named ignore rule —

--- a/docs/guide/obsidian.rst
+++ b/docs/guide/obsidian.rst
@@ -147,6 +147,15 @@ Day-to-day use
 - ``wiki update`` never linkifies prose: author ``[[wikilink]]``
   cross-references in page bodies by hand (Obsidian's link suggestions help
   here).
+- Obsidian and ``wiki lint`` read wikilinks from the same places: a
+  prefix-free target (``[[topics/example]]``) from the vault root — the wiki
+  root — and a ``./`` or ``../`` target from the note's own folder, so
+  nothing lint accepts renders as a different note in Obsidian. A prefixed
+  target must leave the wiki, reaching a file under a ``links.external``
+  folder (see :doc:`/configuration`); that target lies outside the vault, so
+  Obsidian shows the link unresolved — do not click it: Obsidian creates the
+  missing target at that path, as folders outside the vault, through a known
+  bug.
 - Keep markdown-formatting plugins away from the wiki: a formatter that
   rewrites ``***`` into ``---`` or backslash-escapes ``[[`` brackets corrupts
   the generated region. ``wiki lint`` names these damage signatures when they

--- a/docs/guide/obsidian.rst
+++ b/docs/guide/obsidian.rst
@@ -151,8 +151,9 @@ Day-to-day use
   prefix-free target (``[[topics/example]]``) from the vault root — the wiki
   root — and a ``./`` or ``../`` target from the note's own folder, so
   nothing lint accepts renders as a different note in Obsidian. A prefixed
-  target must leave the wiki, reaching a file under a ``links.external``
-  folder (see :doc:`/configuration`); that target lies outside the vault, so
+  target must leave the wiki, reaching a file, folder, or another wiki's
+  page under a ``links.external`` folder (see :doc:`/configuration`); that
+  target lies outside the vault, so
   Obsidian shows the link unresolved — do not click it: Obsidian creates the
   missing target at that path, as folders outside the vault, through a known
   bug.

--- a/docs/guide/pages.rst
+++ b/docs/guide/pages.rst
@@ -232,10 +232,10 @@ Each row has the shape ``[[target|label]]: description``:
 - **Targets** in generated rows are always relative to the wiki root, joined
   with ``/``, with the ``.md`` suffix stripped — ``topics/example``, never a
   platform path. A prose wikilink reads the same way when its target is
-  prefix-free; a prose target starting with ``./`` or ``../`` is read from
-  the page's folder, as Obsidian and markdown read it, and must leave the
-  wiki — it reaches only a file under a ``links.external`` folder (see
-  :doc:`/configuration`).
+  prefix-free; a prose target carrying a ``./`` or ``../`` segment is read
+  from the page's folder, as Obsidian and markdown read it, and must leave
+  the wiki — it reaches only a file, folder, or another wiki's page under a
+  ``links.external`` folder (see :doc:`/configuration`).
 - The **parent row**, labeled ``..``, comes first, targets the parent
   folder's ``_index``, and carries no description. The root index has no
   parent row.

--- a/docs/guide/pages.rst
+++ b/docs/guide/pages.rst
@@ -229,8 +229,13 @@ Link rows
 
 Each row has the shape ``[[target|label]]: description``:
 
-- **Targets** are always relative to the wiki root, joined with ``/``, with
-  the ``.md`` suffix stripped — ``topics/example``, never a platform path.
+- **Targets** in generated rows are always relative to the wiki root, joined
+  with ``/``, with the ``.md`` suffix stripped — ``topics/example``, never a
+  platform path. A prose wikilink reads the same way when its target is
+  prefix-free; a prose target starting with ``./`` or ``../`` is read from
+  the page's folder, as Obsidian and markdown read it, and must leave the
+  wiki — it reaches only a file under a ``links.external`` folder (see
+  :doc:`/configuration`).
 - The **parent row**, labeled ``..``, comes first, targets the parent
   folder's ``_index``, and carries no description. The root index has no
   parent row.
@@ -298,13 +303,14 @@ Any page or index may wrap lines in an HTML-comment region:
 
 Each marker sits alone on its line. The ``no-lint`` directive suppresses
 ``wiki lint``'s positional rules — conflict markers and leftover merge repair
-hints, escaped wikilinks, wrap mangles, stale-link notes, directory-link
-issues — for the wrapped lines, so a page can display sample conflict markers
-or stale-link examples without failing lint. A nested or dangling marker is
-itself a hard lint issue, and a malformed pair suppresses nothing. Markers
-inside fenced or inline code are masked — a marker shown in a code block is a
-sample, not a directive. Well-formed regions with other directive names are
-inert; ``no-lint`` is the only directive with shipped semantics.
+hints, escaped wikilinks, wrap mangles, stale-link and outside-link notes,
+directory-link and relative-link issues — for the wrapped lines, so a page
+can display sample conflict markers or stale-link examples without failing
+lint. A nested or dangling marker is itself a hard lint issue, and a
+malformed pair suppresses nothing. Markers inside fenced or inline code are
+masked — a marker shown in a code block is a sample, not a directive.
+Well-formed regions with other directive names are inert; ``no-lint`` is the
+only directive with shipped semantics.
 
 Ownership summary
 -----------------

--- a/docs/guide/structure.rst
+++ b/docs/guide/structure.rst
@@ -120,6 +120,10 @@ Any ``[[topics/example]]`` wikilinks in prose now
 name a folder rather than a page, which ``wiki lint`` reports as an issue
 naming the ``[[topics/example/_index]]`` form to use instead (a plain rename,
 where the old name vanishes, draws a stale-link note — once per target).
+A prose link written with ``./`` or ``../`` to a page inside the wiki —
+``[[./example/basics]]`` from ``topics/other.md`` — is an issue too, naming
+the prefix-free ``[[topics/example/basics]]`` form: a prefixed target is read
+from the page's folder and must leave the wiki (see :doc:`/configuration`).
 Wikilinks in prose are authored by hand, so find them (``wiki match``) and
 update them yourself.
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -226,6 +226,64 @@ them by hand:
 Any you miss show up as ``Stale link [[topics/example]]`` notes the next time
 ``wiki lint`` runs.
 
+Link to files outside the wiki
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prose wikilinks may reach a source file, a config, or a sibling wiki's page
+once the folder holding it is allowlisted in ``.wiki/settings.json``. Entries
+are folder paths relative to the wiki root, climbing out of it with ``..``:
+
+.. code-block:: json
+
+   {
+     "links": {
+       "external": ["../src", "../math"]
+     }
+   }
+
+The links themselves are relative to the page, as Obsidian and markdown read
+a ``./`` or ``../`` link, so the same file takes one more ``..`` per folder of
+page depth. In ``overview.md`` at the wiki root:
+
+.. code-block:: markdown
+
+   See [[../src/main.py]] and [[../math/lemmas|the lemmas]].
+
+In ``notes/meeting.md``, one folder down:
+
+.. code-block:: markdown
+
+   See [[../../src/main.py]] and [[../../math/lemmas|the lemmas]].
+
+A prefix-free target is still read from the wiki root and names something
+inside it. List every prefixed link with ``wiki match``; it over-reports,
+matching code samples where lint sees no link, so the notes and issues from
+``wiki lint`` are the authoritative list:
+
+.. code-block:: console
+
+   $ wiki match '\[\[\.\.?/' --lines
+   overview.md:12: See [[../src/main.py]] and [[../math/lemmas|the lemmas]].
+
+``wiki lint`` accepts a link whose target — the file, its ``.md`` form, or a
+folder — exists under a listed folder on this machine, and judges a target
+inside another wiki by that wiki's own rules: a folder it indexes is the
+``targets a folder, not a page (use [[../math/g2/_index]])`` issue, as at
+home. A prefixed link that lands inside the wiki is a hard issue, ``points
+inside the wiki through './' or '../'``, naming the prefix-free form (or the
+page-relative spelling of the outside file the text would have reached); a
+missing target is a ``Stale link`` note, suggesting the page-relative
+spelling when the text read from the wiki root reaches a listed file; a real
+file under no listed folder is the note ``points outside the wiki (add
+'../docs' to links.external in .wiki/settings.json to allow it)``; and an
+entry naming no folder on this machine is noted once per run, its links
+unchecked. The allowlist is a lint rule alone: ``wiki read ../src/main.py``
+still fails with ``Path is outside wiki root`` (read another wiki with
+``wiki read --path <its root>``), and ``wiki map`` never shows an external
+folder. In Obsidian an external target lies outside the vault and shows
+unresolved — do not click it: Obsidian creates the missing target at that
+path. See :doc:`/configuration` for the entry grammar.
+
 Preview before writing
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -305,25 +363,34 @@ and leftover merge-repair hint comments, malformed frontmatter, frontmatter a
 strict YAML reader rejects, truncated indexes, escaped wikilinks in page prose
 and hyphen dangles or wrapped list
 markers (formatter and line-wrap damage), descriptions missing their trailing
-period, prose wikilinks naming a folder rather than its ``_index`` page,
-unparseable ``created:``/``updated:`` stamps, a nested ``.wiki/settings.json``
-declaring a foreign wiki root, dangling or nested region markers, and — under
-``titles.required`` — a missing or unfilled ``title:``.
+period, prose wikilinks naming a folder rather than its ``_index`` page (in
+this wiki, or in another wiki a ``links.external`` folder admits), prose
+wikilinks written with ``./`` or ``../`` that land inside the wiki (the
+prefix-free form is the fix), unparseable ``created:``/``updated:`` stamps, a
+nested ``.wiki/settings.json`` declaring a foreign wiki root, dangling or
+nested region markers, and — under ``titles.required`` — a missing or
+unfilled ``title:``.
 
 Notes flag soft hygiene: placeholder (``...``) and oversized descriptions,
-empty index content sections, CRLF line endings, and stale ``[[wikilinks]]`` in
-prose — where a folder-relative target that resolves to a real page gets a
-``(use [[canonical]])`` suggestion, since wiki targets are root-relative.
-Four environment notes ride along and count in the closing summary: a
+empty index content sections, CRLF line endings, stale ``[[wikilinks]]`` in
+prose, and a prose link to a real file outside every ``links.external``
+folder (naming the entry to add). A prefix-free target is read from the wiki
+root and a ``./`` or ``../`` target from the page's folder, so a stale note
+suggests the form the author likely meant when one resolves: the
+root-relative ``(use [[canonical]])`` for a prefix-free slip, or the
+page-relative spelling of an allowlisted file for a prefixed or absolute one.
+Five environment notes ride along and count in the closing summary: a
 ``.gitattributes`` ``merge=wiki`` mapping with no ``merge.wiki.driver``
 configured in the clone (the fresh-clone state — run ``wiki config``); an
 indexed path this machine's personal ``core.excludesFile`` ignores (its
 generated row ships where the file cannot, so every other clone reds on a
 broken link); a ``git check-ignore`` probe that fails inside the enclosing
-repository (git missing or broken), so indexing proceeds unfenced; and any
-root-resolution diagnostic the command printed while starting — a ``--path``
-inside the wiki resolved upward to its root, a missing ``.wiki/settings.json``
-or root ``_index.md``, or an index chain extending above the declared root.
+repository (git missing or broken), so indexing proceeds unfenced; a
+``links.external`` entry naming no folder on this machine (links into it go
+unchecked); and any root-resolution diagnostic the command printed while
+starting — a ``--path`` inside the wiki resolved upward to its root, a
+missing ``.wiki/settings.json`` or root ``_index.md``, or an index chain
+extending above the declared root.
 
 Exempt intentional content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -256,9 +256,11 @@ In ``notes/meeting.md``, one folder down:
    See [[../../src/main.py]] and [[../../math/lemmas|the lemmas]].
 
 A prefix-free target is still read from the wiki root and names something
-inside it. List every prefixed link with ``wiki match``; it over-reports,
-matching code samples where lint sees no link, so the notes and issues from
-``wiki lint`` are the authoritative list:
+inside it. List every link opening with ``./`` or ``../`` with ``wiki match``;
+it over-reports (code samples where lint sees no link) and under-reports
+(``[[..]]``, ``[[.]]``, an interior ``..`` segment, and a target padded with
+spaces), so the notes and issues from ``wiki lint`` are the authoritative
+list:
 
 .. code-block:: console
 

--- a/docs/skill.rst
+++ b/docs/skill.rst
@@ -185,10 +185,20 @@ document each area in full:
 - **Descriptions live in the child page's frontmatter** and end in a period;
   ``wiki update`` propagates them onto parent index rows, and placeholder
   ``desc: ...`` values get filled in promptly.
-- **Wikilinks stay inside the wiki.** Files outside it are referenced by name,
-  never linked, and a folder is linked as ``folder/_index``, never ``folder``.
-  Stale prose links are soft lint notes; broken generated-index links and
-  prose links naming a folder are hard issues.
+- **Wikilinks stay inside the wiki unless a folder is allowlisted.** A
+  prefix-free target is relative to the wiki root and names something inside
+  it; a ``./`` or ``../`` target is relative to the page's folder, as Obsidian
+  reads it, and must leave the wiki for a file — or another wiki's page — under
+  a folder the wiki lists in ``links.external`` (see :doc:`/configuration`).
+  Files elsewhere are referenced in backticks, never linked, and a folder is
+  linked as ``folder/_index``, never ``folder``. Stale prose links are soft
+  lint notes, as is a link to a real file outside every allowlisted folder;
+  broken generated-index links, prose links naming a folder — this wiki's or
+  an allowlisted wiki's — and a ``./`` or ``../`` link that lands inside the
+  wiki are hard issues. The allowlist is a lint rule alone: ``wiki read`` never
+  serves an external target, and Obsidian, which cannot see outside the vault,
+  shows an external link unresolved — do not click it: Obsidian creates the
+  missing target at that path.
 - **Markdown formatters need the wiki plugin.** Generic formatters corrupt the
   ``***`` delimiter and ``[[wikilinks]]``; the sanctioned fixes are the
   ``mdformat-wiki`` plugin or excluding the wiki root (see the formatter

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -1191,6 +1191,7 @@ def test_links_external_end_to_end(tmp_path: pathlib.Path) -> None:
     assert init.returncode == 0, init.stdout + init.stderr
     _write(tmp_path / 'src' / 'main.py', 'print()\n')
     _write(tmp_path / 'docs' / 'y.md', 'Doc.\n')
+    _write(tmp_path / 'idx' / '_index.md', 'Idx.\n')
     # a sibling wiki with a page and an indexed folder
     math = tmp_path / 'math'
     assert _wiki(tmp_path, 'init', '--path', str(math)).returncode == 0
@@ -1199,15 +1200,13 @@ def test_links_external_end_to_end(tmp_path: pathlib.Path) -> None:
     assert _wiki(math, 'update', '--path', str(math)).returncode == 0
     # a root-level page and a nested page linking outside
     _write(root / 'core' / '_index.md', _index('Core', 'Core concepts.', 'Text.'))
-    _write(
-        root / 'links.md',
-        _page(
-            'Links',
-            'Links.',
-            'See [[../src/main.py]], [[../src/gone.py]], [[../math/lemmas]],'
-            ' [[../docs/x]], [[../docs/y]], and [[../missing/z]].',
-        ),
+    links = _page(
+        name='Links',
+        desc='Links.',
+        body='See [[../src/main.py]], [[../src/gone.py]], [[../math/lemmas]],'
+        ' [[../docs/x]], [[../docs/y]], [[../idx]], and [[../missing/z]].',
     )
+    _write(root / 'links.md', links)
     _write(
         root / 'core' / 'page.md',
         _page('Page', 'A page.', 'See [[../../src/main.py]] and [[../src/main.py]].'),
@@ -1218,13 +1217,18 @@ def test_links_external_end_to_end(tmp_path: pathlib.Path) -> None:
     assert lint.returncode == 1
     assert (
         'core/page.md: Link [[../src/main.py]] points inside the wiki through'
-        " './' or '../' (use [[../../src/main.py]] for the file outside the wiki)"
+        " './' or '../' (use [[../../src/main.py]] for the path outside the wiki)"
     ) in lint.stdout
     assert 'links.md: Stale link [[../src/gone.py]]' in lint.stderr
     assert 'links.md: Stale link [[../docs/x]]' in lint.stderr
     assert (
         "links.md: Link [[../docs/y]] points outside the wiki (add '../docs' to"
         ' links.external in .wiki/settings.json to allow it)'
+    ) in lint.stderr
+    assert (
+        "links.md: Link [[../idx]] points outside the wiki (add '../idx' to"
+        ' links.external in .wiki/settings.json to allow it, and link'
+        ' [[../idx/_index]] if a wiki indexes the folder)'
     ) in lint.stderr
     assert (
         "links.external entry '../missing' names no folder on this machine;"
@@ -1243,21 +1247,26 @@ def test_links_external_end_to_end(tmp_path: pathlib.Path) -> None:
     ) in lint.stdout
     # --json carries every finding typed
     document = json.loads(_wiki(root, 'lint', '--path', str(root), '--json').stdout)
-    assert {issue['kind'] for issue in document['issues']} == {
-        'directory_link',
-        'relative_link',
-    }
+    kinds = {issue['kind'] for issue in document['issues']}
+    assert kinds == {'directory_link', 'relative_link'}
     outside = [note for note in document['notes'] if note['kind'] == 'link_outside']
-    assert [(note['path'], note['folder']) for note in outside] == [
-        ('links.md', '../docs')
+    outside_rows = [
+        (note['path'], note['folder'], note.get('canonical', 'absent'))
+        for note in outside
+    ]
+    assert outside_rows == [
+        ('links.md', '../docs', 'absent'),
+        ('links.md', '../idx', '../idx/_index'),
     ]
     missing = [
         note for note in document['notes'] if note['kind'] == 'link_folder_missing'
     ]
-    assert [note['folder'] for note in missing] == ['../missing']
+    missing_folders = [note['folder'] for note in missing]
+    assert missing_folders == ['../missing']
     assert 'path' not in missing[0]
     stale = [note for note in document['notes'] if note['kind'] == 'link_stale']
-    assert {note['target'] for note in stale} == {'../src/gone.py', '../docs/x'}
+    stale_targets = {note['target'] for note in stale}
+    assert stale_targets == {'../src/gone.py', '../docs/x'}
     # with both links fixed, lint is clean
     _write(
         root / 'core' / 'page.md',
@@ -1276,7 +1285,8 @@ def test_links_external_end_to_end(tmp_path: pathlib.Path) -> None:
     data = json.loads(config.read_text(encoding='utf-8'))
     data['links'] = {'external': ['src']}
     config.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
-    assert _wiki(root, 'update', '--path', str(root)).returncode == 0
+    update = _wiki(root, 'update', '--path', str(root))
+    assert update.returncode == 0, update.stdout + update.stderr
     lint = _wiki(root, 'lint', '--path', str(root))
     assert lint.returncode == 2
     assert "Invalid links.external folder 'src': inside the wiki root" in lint.stderr

--- a/tests/test_cli/test_wiki_commands.py
+++ b/tests/test_cli/test_wiki_commands.py
@@ -59,6 +59,7 @@ __all__ = [
     'test_update_refuses_a_scope_inside_a_nested_wiki',
     'test_update_refuses_an_excluded_dot_directory_scope',
     'test_exclude_patterns_end_to_end',
+    'test_links_external_end_to_end',
     'test_update_cli_refuses_conflict_markers',
     'test_lint_reports_issue_taxonomy_and_exits_nonzero',
     'test_lint_summary_counts_notes',
@@ -1171,6 +1172,123 @@ def test_exclude_patterns_end_to_end(tmp_path: pathlib.Path) -> None:
     # nothing is left to flag: the fence and the tree agree
     lint = _wiki(root, 'lint', '--path', str(root))
     assert lint.returncode == 0, lint.stdout + lint.stderr
+
+
+def test_links_external_end_to_end(tmp_path: pathlib.Path) -> None:
+    """``links.external`` flows through init, lint, ``--json``, and read.
+
+    A seeded allowlist admits a source file and a sibling wiki's page;
+    lint notes a missing file as stale, a real file under no entry with
+    the entry to add, an entry naming no folder once per run, and fails a
+    prefixed link that lands inside the wiki or names a folder the
+    sibling wiki indexes -- each typed in ``--json``. ``wiki read`` stays
+    confined to the root, a malformed block fails lint but never update,
+    and a malformed sibling settings file is named.
+    """
+    root = tmp_path / 'wiki'
+    settings = '{"links": {"external": ["../src", "../math", "../missing"]}}'
+    init = _wiki(tmp_path, 'init', '--path', str(root), '--settings', settings)
+    assert init.returncode == 0, init.stdout + init.stderr
+    _write(tmp_path / 'src' / 'main.py', 'print()\n')
+    _write(tmp_path / 'docs' / 'y.md', 'Doc.\n')
+    # a sibling wiki with a page and an indexed folder
+    math = tmp_path / 'math'
+    assert _wiki(tmp_path, 'init', '--path', str(math)).returncode == 0
+    _write(math / 'lemmas.md', _page('Lemmas', 'Lemmas.', 'Body.'))
+    _write(math / 'g2' / 'topic.md', _page('Topic', 'A topic.', 'Body.'))
+    assert _wiki(math, 'update', '--path', str(math)).returncode == 0
+    # a root-level page and a nested page linking outside
+    _write(root / 'core' / '_index.md', _index('Core', 'Core concepts.', 'Text.'))
+    _write(
+        root / 'links.md',
+        _page(
+            'Links',
+            'Links.',
+            'See [[../src/main.py]], [[../src/gone.py]], [[../math/lemmas]],'
+            ' [[../docs/x]], [[../docs/y]], and [[../missing/z]].',
+        ),
+    )
+    _write(
+        root / 'core' / 'page.md',
+        _page('Page', 'A page.', 'See [[../../src/main.py]] and [[../src/main.py]].'),
+    )
+    assert _wiki(root, 'update', '--path', str(root)).returncode == 0
+    # the short nested link is the one issue; the notes sort the rest
+    lint = _wiki(root, 'lint', '--path', str(root))
+    assert lint.returncode == 1
+    assert (
+        'core/page.md: Link [[../src/main.py]] points inside the wiki through'
+        " './' or '../' (use [[../../src/main.py]] for the file outside the wiki)"
+    ) in lint.stdout
+    assert 'links.md: Stale link [[../src/gone.py]]' in lint.stderr
+    assert 'links.md: Stale link [[../docs/x]]' in lint.stderr
+    assert (
+        "links.md: Link [[../docs/y]] points outside the wiki (add '../docs' to"
+        ' links.external in .wiki/settings.json to allow it)'
+    ) in lint.stderr
+    assert (
+        "links.external entry '../missing' names no folder on this machine;"
+        ' links into it are not checked'
+    ) in lint.stderr
+    assert 'Stale link [[../src/main.py]]' not in lint.stderr
+    assert '[[../math/lemmas]]' not in lint.stderr
+    assert '[[../missing/z]]' not in lint.stderr
+    # a bare folder of the sibling wiki is that wiki's directory link
+    _write(root / 'g2.md', _page('G2', 'G2.', 'See [[../math/g2]].'))
+    assert _wiki(root, 'update', '--path', str(root)).returncode == 0
+    lint = _wiki(root, 'lint', '--path', str(root))
+    assert (
+        'g2.md: Link [[../math/g2]] targets a folder, not a page'
+        ' (use [[../math/g2/_index]])'
+    ) in lint.stdout
+    # --json carries every finding typed
+    document = json.loads(_wiki(root, 'lint', '--path', str(root), '--json').stdout)
+    assert {issue['kind'] for issue in document['issues']} == {
+        'directory_link',
+        'relative_link',
+    }
+    outside = [note for note in document['notes'] if note['kind'] == 'link_outside']
+    assert [(note['path'], note['folder']) for note in outside] == [
+        ('links.md', '../docs')
+    ]
+    missing = [
+        note for note in document['notes'] if note['kind'] == 'link_folder_missing'
+    ]
+    assert [note['folder'] for note in missing] == ['../missing']
+    assert 'path' not in missing[0]
+    stale = [note for note in document['notes'] if note['kind'] == 'link_stale']
+    assert {note['target'] for note in stale} == {'../src/gone.py', '../docs/x'}
+    # with both links fixed, lint is clean
+    _write(
+        root / 'core' / 'page.md',
+        _page('Page', 'A page.', 'See [[../../src/main.py]].'),
+    )
+    _write(root / 'g2.md', _page('G2', 'G2.', 'See [[../math/g2/_index]].'))
+    assert _wiki(root, 'update', '--path', str(root)).returncode == 0
+    lint = _wiki(root, 'lint', '--path', str(root))
+    assert lint.returncode == 0, lint.stdout + lint.stderr
+    # the allowlist is a lint rule alone: read stays confined to the root
+    read = _wiki(root, 'read', '../src/main.py', '--path', str(root))
+    assert read.returncode == 2
+    assert 'outside wiki root' in (read.stdout + read.stderr).lower()
+    # a malformed block fails lint, naming the file and key, never update
+    config = root / '.wiki' / 'settings.json'
+    data = json.loads(config.read_text(encoding='utf-8'))
+    data['links'] = {'external': ['src']}
+    config.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+    assert _wiki(root, 'update', '--path', str(root)).returncode == 0
+    lint = _wiki(root, 'lint', '--path', str(root))
+    assert lint.returncode == 2
+    assert "Invalid links.external folder 'src': inside the wiki root" in lint.stderr
+    # a malformed sibling settings file is named as that wiki's -- read the
+    # moment a link needs its rules, which a bare folder link does
+    data['links'] = {'external': ['../math']}
+    config.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+    _write(root / 'g2.md', _page('G2', 'G2.', 'See [[../math/g2]].'))
+    (math / '.wiki' / 'settings.json').write_text('{', encoding='utf-8')
+    lint = _wiki(root, 'lint', '--path', str(root))
+    assert lint.returncode == 2
+    assert "links.external wiki '../math'" in lint.stderr
 
 
 def test_update_cli_refuses_conflict_markers(tmp_path: pathlib.Path) -> None:

--- a/tests/test_core/__init__.py
+++ b/tests/test_core/__init__.py
@@ -7,6 +7,7 @@ from .test_config import *
 from .test_event import *
 from .test_exclude import *
 from .test_format import *
+from .test_links import *
 from .test_lint import *
 from .test_map import *
 from .test_match import *

--- a/tests/test_core/_helpers.py
+++ b/tests/test_core/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import shutil
 import subprocess
@@ -16,6 +17,7 @@ from wiki.core.wiki import Wiki
 __all__ = [
     'page_index',
     '_needs_git',
+    '_needs_unprivileged',
     '_git',
     '_git_repo',
     '_capture_notices',
@@ -30,6 +32,11 @@ page_index = pytest.mark.parametrize('kind', ['page', 'index'])
 
 # gates the tests that drive a real git repository
 _needs_git = pytest.mark.skipif(shutil.which('git') is None, reason='requires git')
+
+# gates the tests that rely on a permission denial
+_needs_unprivileged = pytest.mark.skipif(
+    os.geteuid() == 0, reason='needs a non-root user'
+)
 
 
 def _git(cwd: pathlib.Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/tests/test_core/_helpers.py
+++ b/tests/test_core/_helpers.py
@@ -16,6 +16,7 @@ from wiki.core.wiki import Wiki
 
 __all__ = [
     'page_index',
+    'bare_anchored',
     '_needs_git',
     '_needs_unprivileged',
     '_git',
@@ -25,17 +26,22 @@ __all__ = [
     '_make_wiki',
     '_make_category_folder',
     '_set_exclude_patterns',
-    '_set_links_external',
 ]
 
 page_index = pytest.mark.parametrize('kind', ['page', 'index'])
+bare_anchored = pytest.mark.parametrize(
+    argnames='anchor',
+    argvalues=['', '#context'],
+    ids=['bare', 'anchored'],
+)
 
 # gates the tests that drive a real git repository
 _needs_git = pytest.mark.skipif(shutil.which('git') is None, reason='requires git')
 
 # gates the tests that rely on a permission denial
 _needs_unprivileged = pytest.mark.skipif(
-    os.geteuid() == 0, reason='needs a non-root user'
+    os.geteuid() == 0,
+    reason='needs a non-root user',
 )
 
 
@@ -144,16 +150,4 @@ def _set_exclude_patterns(path: pathlib.Path, patterns: list[str]) -> None:
     settings = path / '.wiki' / 'settings.json'
     data = json.loads(settings.read_text(encoding='utf-8'))
     data['exclude'] = {'patterns': patterns}
-    settings.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
-
-
-def _set_links_external(path: pathlib.Path, folders: list[str]) -> None:
-    """Write ``links.external`` into an existing wiki's ``settings.json``.
-
-    Policies are cached per instance, so construct a fresh ``Wiki``
-    after calling this.
-    """
-    settings = path / '.wiki' / 'settings.json'
-    data = json.loads(settings.read_text(encoding='utf-8'))
-    data['links'] = {'external': folders}
     settings.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')

--- a/tests/test_core/_helpers.py
+++ b/tests/test_core/_helpers.py
@@ -23,6 +23,7 @@ __all__ = [
     '_make_wiki',
     '_make_category_folder',
     '_set_exclude_patterns',
+    '_set_links_external',
 ]
 
 page_index = pytest.mark.parametrize('kind', ['page', 'index'])
@@ -136,4 +137,16 @@ def _set_exclude_patterns(path: pathlib.Path, patterns: list[str]) -> None:
     settings = path / '.wiki' / 'settings.json'
     data = json.loads(settings.read_text(encoding='utf-8'))
     data['exclude'] = {'patterns': patterns}
+    settings.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+
+
+def _set_links_external(path: pathlib.Path, folders: list[str]) -> None:
+    """Write ``links.external`` into an existing wiki's ``settings.json``.
+
+    Policies are cached per instance, so construct a fresh ``Wiki``
+    after calling this.
+    """
+    settings = path / '.wiki' / 'settings.json'
+    data = json.loads(settings.read_text(encoding='utf-8'))
+    data['links'] = {'external': folders}
     settings.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')

--- a/tests/test_core/test_links.py
+++ b/tests/test_core/test_links.py
@@ -258,8 +258,10 @@ def test_links_policy_accepts_missing_and_ancestor_folders(
             '../../docs/guide/',
             'stale-fix:../../docs/guide',
         ),
-        # a stray bracket or surrounding spaces and tabs are not part of the target
-        (['../src'], {'src/main.py'}, 'nested', '[../../src/main.py', 'live'),
+        # a stray bracket is junk no name carries: stale as written, never read
+        # from the page's folder
+        (['../src'], {'src/main.py'}, 'nested', '[../../src/main.py', 'stale'),
+        # surrounding spaces and tabs are not part of the target
         (['../src'], {'src/main.py'}, 'nested', ' ../../src/main.py', 'live'),
         (['../src'], {'src/main.py'}, 'nested', '../../src/main.py ', 'live'),
         (['../src'], {'src/main.py'}, 'nested', '\t../../src/main.py\t', 'live'),
@@ -363,9 +365,10 @@ def test_lint_judges_external_targets_by_the_allowlist(
     index page a wiki would link it by; an absolute target leaving the wiki
     is never live, but is steered to its page-relative spelling when it
     lands under an entry; a ``..`` chain clamped at the filesystem root is
-    stale, since no entry could admit it; a stray bracket or surrounding
-    whitespace is not part of the target, and a path of thousands of
-    segments is judged like any other. Nothing here is a hard issue.
+    stale, since no entry could admit it; surrounding whitespace is not part
+    of the target, a stray bracket makes the text junk (stale as written),
+    and a path of thousands of segments is judged like any other. Nothing
+    here is a hard issue.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root, folders={'notes': ['meeting']})

--- a/tests/test_core/test_links.py
+++ b/tests/test_core/test_links.py
@@ -1,4 +1,4 @@
-"""Behavioral tests for the external link allowlist.
+"""Behavioral tests for the ``links.external`` allowlist.
 
 ``links.external`` (``.wiki/settings.json``): policy validation and the
 init-seed refusal, the verdicts for targets under an allowlisted folder
@@ -10,7 +10,10 @@ masking, the symlink probe posture, another wiki's folders judged by its
 own settings (its notices riding the host's funnel; a marker at the home
 or config home never a wiki), and the unchanged root boundary of the
 name-taking operations and the generated index rows. The in-wiki relative-prefix
-issue is covered beside the link tests in ``test_lint``.
+issue is covered beside the link tests in ``test_lint``. The other-wiki tests
+assume no ``.wiki/settings.json`` sits above pytest's base temporary
+directory, where a marker would read as an enclosing wiki (the CLI suite
+assumes the same of its root resolver).
 """
 
 from __future__ import annotations
@@ -30,7 +33,7 @@ from ._helpers import (
     _needs_git,
     _needs_unprivileged,
     _set_exclude_patterns,
-    _set_links_external,
+    bare_anchored,
     page_index,
 )
 
@@ -38,8 +41,8 @@ __all__ = [
     'test_links_policy_rejects_invalid_settings',
     'test_init_rejects_invalid_links_seed',
     'test_links_policy_accepts_missing_and_ancestor_folders',
-    'test_lint_external_target_verdicts',
-    'test_lint_external_link_parity_across_pages_and_indexes',
+    'test_lint_judges_external_targets_by_the_allowlist',
+    'test_lint_reads_external_links_alike_in_pages_and_indexes',
     'test_lint_relative_prefix_names_both_readings',
     'test_lint_stale_external_link_suggests_page_relative_spelling',
     'test_lint_external_links_spare_samples_and_regions',
@@ -48,9 +51,11 @@ __all__ = [
     'test_lint_external_probe_never_raises',
     'test_lint_other_wiki_targets_follow_its_rules',
     'test_lint_other_wiki_unreadable_settings_fail_loudly',
+    'test_lint_other_wiki_broken_settings_spare_unrelated_links',
     'test_links_other_wiki_runs_no_hook',
     'test_links_other_wiki_notices_ride_the_host_funnel',
     'test_links_home_marker_is_not_a_wiki',
+    'test_links_home_symlink_loop_never_raises',
     'test_lint_missing_external_folder_notes_once',
     'test_links_external_never_widens_root_boundary',
     'test_links_external_never_admits_index_rows',
@@ -63,25 +68,31 @@ __all__ = [
 @pytest.mark.parametrize(
     argnames=('links', 'match'),
     argvalues=[
+        # a wrong-typed block or entry
         ('vendor', r'links block must be a JSON object'),
         ({'external': '../src'}, r'links\.external must be a list'),
         ({'external': [5]}, r'entry must be a string'),
+        # an entry naming nothing
         ({'external': ['']}, r'empty or whitespace-only'),
         ({'external': ['   ']}, r'empty or whitespace-only'),
         ({'external': ['/']}, r'empty or whitespace-only'),
+        # absolute and home paths, and a foreign separator
         ({'external': ['/etc']}, r'absolute'),
         ({'external': ['~/x']}, r'absolute'),
         ({'external': ['..\\x']}, r'separator'),
+        # characters no wikilink target can carry
         ({'external': ['../c#']}, r'no wikilink target can carry'),
         ({'external': ['../a|b']}, r'no wikilink target can carry'),
         ({'external': ['../a]b']}, r'no wikilink target can carry'),
         ({'external': ['../a\x00b']}, r'no wikilink target can carry'),
+        # empty, '.', and interior '..' segments
         ({'external': ['..//x']}, r'empty segment'),
         ({'external': ['../x/./y']}, r"'\.' segments"),
         ({'external': ['.']}, r"'\.' segments"),
         ({'external': ['../a/../b']}, r'only at the start'),
         ({'external': ['core/..']}, r'only at the start'),
-        ({'external': ['{fsroot}']}, r'whole filesystem'),
+        # the filesystem root, and any spelling of a folder inside the wiki
+        ({'external': ['{filesystem_root}']}, r'whole filesystem'),
         ({'external': ['src']}, r'inside the wiki root'),
         ({'external': ['../{root}/core']}, r'inside the wiki root'),
         ({'external': ['../alias']}, r'through an alias'),
@@ -135,7 +146,7 @@ def test_links_policy_rejects_invalid_settings(
         external = []
         for entry in links['external']:
             if isinstance(entry, str):
-                entry = entry.format(root=root.name, fsroot=climbs)
+                entry = entry.format(root=root.name, filesystem_root=climbs)
             external.append(entry)
         links = {'external': external}
     settings = root / '.wiki' / 'settings.json'
@@ -144,8 +155,9 @@ def test_links_policy_rejects_invalid_settings(
     # a fresh instance fails loudly, naming the settings file
     with pytest.raises(ValueError, match=match) as excinfo:
         Wiki(root).lint()
-    assert 'links' in str(excinfo.value)
-    assert 'settings.json' in str(excinfo.value)
+    message = str(excinfo.value)
+    assert 'links' in message
+    assert 'settings.json' in message
 
 
 def test_init_rejects_invalid_links_seed(tmp_path: pathlib.Path) -> None:
@@ -214,33 +226,84 @@ def test_links_policy_accepts_missing_and_ancestor_folders(
         (['../src/'], {'src/main.py'}, 'root', '../src/main.py', 'live'),
         (['..'], {'README.md'}, 'root', '../README.md', 'live'),
         # an absent entry beside an ancestor: skipped in either order
-        (['..', '../missing'], set(), 'root', '../missing/x', 'skip'),
-        (['../missing', '..'], set(), 'root', '../missing/x', 'skip'),
+        (['..', '../missing'], set(), 'root', '../missing/x', 'skip:../missing'),
+        (['../missing', '..'], set(), 'root', '../missing/x', 'skip:../missing'),
         # an entry naming a file names no folder, and shadows an ancestor
-        (['../README.md'], {'README.md'}, 'root', '../README.md', 'skip'),
-        (['..', '../README.md'], {'README.md'}, 'root', '../README.md', 'skip'),
-        # a missing file under a present folder
+        (
+            ['../README.md'],
+            {'README.md'},
+            'root',
+            '../README.md/x',
+            'skip:../README.md',
+        ),
+        (
+            ['..', '../README.md'],
+            {'README.md'},
+            'root',
+            '../README.md/x',
+            'skip:../README.md',
+        ),
+        # a trailing slash never names a page: the fix drops it, at any depth
+        (
+            ['../docs'],
+            {'docs/guide.md'},
+            'root',
+            '../docs/guide/',
+            'stale-fix:../docs/guide',
+        ),
+        (
+            ['../docs'],
+            {'docs/guide.md'},
+            'nested',
+            '../../docs/guide/',
+            'stale-fix:../../docs/guide',
+        ),
+        # a stray bracket or surrounding spaces and tabs are not part of the target
+        (['../src'], {'src/main.py'}, 'nested', '[../../src/main.py', 'live'),
+        (['../src'], {'src/main.py'}, 'nested', ' ../../src/main.py', 'live'),
+        (['../src'], {'src/main.py'}, 'nested', '../../src/main.py ', 'live'),
+        (['../src'], {'src/main.py'}, 'nested', '\t../../src/main.py\t', 'live'),
+        # a missing file under a present folder, however deep the path
         (['../src'], {'src/'}, 'root', '../src/gone.py', 'stale'),
+        (['../src'], {'src/'}, 'root', '../src/{deep}gone.py', 'stale'),
         # a real file, folder, or normalized path under no entry
         (['../src'], {'docs/guide.md'}, 'root', '../docs/guide', 'outside:../docs'),
         (['../src'], {'docs/'}, 'root', '../docs', 'outside:../docs'),
+        (
+            ['../src'],
+            {'docs/_index.md'},
+            'root',
+            '../docs',
+            'outside:../docs:../docs/_index',
+        ),
+        # a folder name spelling an entry the policy refuses: stale, not the note
+        (['../src'], {'we\\ird/x.md'}, 'root', '../we\\ird/x', 'stale'),
         (['../src'], {'docs/x.md'}, 'root', '../src/../docs/x', 'outside:../docs'),
         # nothing at all under no entry
         (['../src'], set(), 'root', '../docs/guide', 'stale'),
         # no block: a real file is the outside note, a missing one stale
         ([], {'src/main.py'}, 'root', '../src/main.py', 'outside:../src'),
+        ([], {'README.md'}, 'root', '../README.md', 'outside:..'),
         ([], set(), 'root', '../src/main.py', 'stale'),
         # an absolute target is never live; under an entry its fix is spelled
         (
             ['../src'],
             {'src/main.py'},
             'nested',
-            '{abs}/src/main.py',
+            '{absolute}/src/main.py',
             'stale-fix:../../src/main.py',
         ),
-        ([], {'src/main.py'}, 'root', '{abs}/src/main.py', 'stale'),
+        ([], {'src/main.py'}, 'root', '{absolute}/src/main.py', 'stale'),
+        # an absolute target inside the wiki that misses keeps its in-wiki hint
+        (
+            [],
+            set(),
+            'root',
+            '{absolute}/wiki/notes/meeting/',
+            'stale-fix:notes/meeting',
+        ),
         # a '..' chain clamped at the filesystem root: no entry could admit it
-        (['../src'], set(), 'root', '{fsroot}', 'stale'),
+        (['../src'], set(), 'root', '{filesystem_root}', 'stale'),
     ],
     ids=[
         'literal-file',
@@ -258,19 +321,30 @@ def test_links_policy_accepts_missing_and_ancestor_folders(
         'overlap-order-b',
         'file-entry',
         'file-entry-shadows-ancestor',
+        'page-trailing-slash',
+        'page-trailing-slash-nested',
+        'stray-bracket',
+        'leading-space',
+        'trailing-space',
+        'tabs-both',
         'missing-file',
+        'deep-missing-file',
         'not-allowlisted-exists',
         'not-allowlisted-folder-target',
+        'not-allowlisted-indexed-folder',
+        'backslash-folder',
         'normalizes-out',
         'not-allowlisted-missing',
         'no-block-exists',
+        'no-block-parent-file',
         'no-block-missing',
         'absolute-under-entry',
         'absolute-not-allowlisted',
+        'absolute-inside-trailing-slash',
         'clamped-at-filesystem-root',
     ],
 )
-def test_lint_external_target_verdicts(
+def test_lint_judges_external_targets_by_the_allowlist(
     tmp_path: pathlib.Path,
     external: list[str],
     tree: set[str],
@@ -282,49 +356,70 @@ def test_lint_external_target_verdicts(
 
     Under an allowlisted folder present on this machine a target is live
     when the file, its ``.md`` form, or the folder exists, and stale
-    otherwise; under an entry naming no folder here it is skipped; under
-    no entry a real file draws the note naming the entry to add, and a
-    missing one the stale note; an absolute target is never live, but is
-    steered to its page-relative spelling when it lands under an entry; a
-    ``..`` chain clamped at the filesystem root is stale, since no entry
-    could admit it. Nothing here is a hard issue.
+    otherwise; under an entry naming no folder here -- absent, or a file
+    -- it is skipped, and only that entry's note fires; under no entry a
+    real file draws the note naming the entry to add, and a missing one
+    the stale note, and a folder holding an index file is noted with the
+    index page a wiki would link it by; an absolute target leaving the wiki
+    is never live, but is steered to its page-relative spelling when it
+    lands under an entry; a ``..`` chain clamped at the filesystem root is
+    stale, since no entry could admit it; a stray bracket or surrounding
+    whitespace is not part of the target, and a path of thousands of
+    segments is judged like any other. Nothing here is a hard issue.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root, folders={'notes': ['meeting']})
     _plant(tmp_path, tree)
     # the placeholders spell paths only the layout knows: the wiki's real
-    # location, and enough climbs to reach the filesystem root
+    # location, enough climbs to reach the filesystem root, and a path deep
+    # enough to expose a walk that pays per segment
     climbs = '/'.join(['..'] * len(root.resolve().parts))
-    link = link.format(abs=tmp_path.resolve(), fsroot=climbs)
+    deep = 'a/' * 3000
+    link = link.format(absolute=tmp_path.resolve(), filesystem_root=climbs, deep=deep)
     relpath = _link_from(root, page, link)
     _set_links_external(root, external)
     wiki = Wiki(root)
 
+    # nothing is a hard issue; the link notes carry the verdict, and a skipped
+    # link leaves only its entry's folder note behind
     notices = _capture_notices(wiki)
     assert wiki.lint() == []
+    folder_notes = [
+        event.description for event in notices if 'names no folder' in event.description
+    ]
     notes = [
         event.description
         for event in notices
         if 'names no folder' not in event.description
     ]
-    if verdict in ('live', 'skip'):
+    if verdict == 'live':
         assert notes == []
+    elif verdict.startswith('skip:'):
+        entry = verdict.partition(':')[2]
+        assert notes == []
+        assert folder_notes == [
+            f'links.external entry {entry!r} names no folder on this machine;'
+            ' links into it are not checked'
+        ]
     elif verdict == 'stale':
         assert notes == [f'{relpath}: Stale link [[{link}]]']
     elif verdict.startswith('stale-fix:'):
         fix = verdict.partition(':')[2]
         assert notes == [f'{relpath}: Stale link [[{link}]] (use [[{fix}]])']
     else:
-        folder = verdict.partition(':')[2]
+        folder, _sep, index = verdict.partition(':')[2].partition(':')
+        hint = ''
+        if index:
+            hint = f', and link [[{index}]] if a wiki indexes the folder'
         assert notes == [
             f'{relpath}: Link [[{link}]] points outside the wiki (add {folder!r}'
-            ' to links.external in .wiki/settings.json to allow it)'
+            f' to links.external in .wiki/settings.json to allow it{hint})'
         ]
 
 
 @page_index
-@pytest.mark.parametrize('anchor', ['', '#context'], ids=['bare', 'anchored'])
-def test_lint_external_link_parity_across_pages_and_indexes(
+@bare_anchored
+def test_lint_reads_external_links_alike_in_pages_and_indexes(
     tmp_path: pathlib.Path,
     kind: str,
     anchor: str,
@@ -344,8 +439,8 @@ def test_lint_external_link_parity_across_pages_and_indexes(
     body = (
         f'See [[../../src/main.py{anchor}|Main]] and'
         f' [[../../src/gone.py{anchor}|Gone]], then'
-        f' [[../../src/gone.py{anchor}|Gone]] again, and'
-        f' [[../../docs/y{anchor}|Doc]].\n\n'
+        f' [[../../src/gone.py{anchor}|Gone]] again,'
+        f' [[../../docs/y{anchor}|Doc]], and [[../../docs/y{anchor}|Doc]].\n\n'
         f'| a | b |\n|---|---|\n| [[../../src/gone2.py{anchor}\\|Gone]] | c |'
     )
     text = page.read_text(encoding='utf-8').replace(marker, body)
@@ -353,18 +448,18 @@ def test_lint_external_link_parity_across_pages_and_indexes(
     _set_links_external(root, ['../src'])
     wiki = Wiki(root)
 
+    # the live link is silent; stale and outside targets note once each
     notices = _capture_notices(wiki)
     assert wiki.lint() == []
     notes = sorted(event.description for event in notices if '[[' in event.description)
-    assert notes == sorted(
-        [
-            f'notes/{name}: Stale link [[../../src/gone.py{anchor}|Gone]]',
-            f'notes/{name}: Stale link [[../../src/gone2.py{anchor}\\|Gone]]',
-            f'notes/{name}: Link [[../../docs/y{anchor}|Doc]] points outside the'
-            " wiki (add '../docs' to links.external in .wiki/settings.json to"
-            ' allow it)',
-        ]
-    )
+    expected = [
+        f'notes/{name}: Stale link [[../../src/gone.py{anchor}|Gone]]',
+        f'notes/{name}: Stale link [[../../src/gone2.py{anchor}\\|Gone]]',
+        f'notes/{name}: Link [[../../docs/y{anchor}|Doc]] points outside the'
+        " wiki (add '../docs' to links.external in .wiki/settings.json to"
+        ' allow it)',
+    ]
+    assert notes == sorted(expected)
 
 
 def test_lint_relative_prefix_names_both_readings(tmp_path: pathlib.Path) -> None:
@@ -380,34 +475,27 @@ def test_lint_relative_prefix_names_both_readings(tmp_path: pathlib.Path) -> Non
     _make_wiki(root, folders={'folder_a': ['file_a'], 'folder_b': ['file_b']})
     _plant(tmp_path, {'folder_b/file_b.md', 'folder_b/file_b.py'})
     page = root / 'folder_a' / 'file_a.md'
-    page.write_text(
-        page.read_text(encoding='utf-8').replace(
-            'Content for file_a.',
-            'See [[../folder_b/file_b]] and [[../folder_b/file_b.py]].',
-        ),
-        encoding='utf-8',
-    )
+    body = 'See [[../folder_b/file_b]] and [[../folder_b/file_b.py]].'
+    text = page.read_text(encoding='utf-8').replace('Content for file_a.', body)
+    page.write_text(text, encoding='utf-8')
     _set_links_external(root, ['..'])
     wiki = Wiki(root)
 
+    # each reading that exists is offered: two for file_b, one for file_b.py
     notices = _capture_notices(wiki)
     issues = wiki.lint()
     assert issues == [
         'folder_a/file_a.md: Link [[../folder_b/file_b]] points inside the wiki'
         " through './' or '../' (use [[folder_b/file_b]], or"
-        ' [[../../folder_b/file_b]] for the file outside the wiki)',
+        ' [[../../folder_b/file_b]] for the path outside the wiki)',
         'folder_a/file_a.md: Link [[../folder_b/file_b.py]] points inside the'
         " wiki through './' or '../' (use [[../../folder_b/file_b.py]] for the"
-        ' file outside the wiki)',
+        ' path outside the wiki)',
     ]
-    assert [issue.fields.get('canonical') for issue in issues] == [
-        'folder_b/file_b',
-        None,
-    ]
-    assert [issue.fields['external'] for issue in issues] == [
-        '../../folder_b/file_b',
-        '../../folder_b/file_b.py',
-    ]
+    canonicals = [issue.fields.get('canonical') for issue in issues]
+    assert canonicals == ['folder_b/file_b', None]
+    externals = [issue.fields['external'] for issue in issues]
+    assert externals == ['../../folder_b/file_b', '../../folder_b/file_b.py']
     assert not any('[[' in event.description for event in notices)
 
 
@@ -419,40 +507,35 @@ def test_lint_stale_external_link_suggests_page_relative_spelling(
     Read from the wiki root, a target written one folder short reaches
     the file the author meant, so the note names its page-relative
     spelling; so does an absolute target under an allowlisted folder. A
-    target reaching nothing either way stays a bare stale note, and one
-    that lands inside the wiki is the relative-link issue with the same
-    spelling offered.
+    target reaching nothing either way -- missing, or climbed one folder
+    too far -- stays a bare stale note.
     """
-    root = tmp_path / 'wiki'
+    root = tmp_path / 'ws' / 'wiki'
     _make_wiki(root, folders={'notes': ['meeting']})
     _plant(tmp_path, {'src/main.py'})
     absolute = tmp_path.resolve() / 'src' / 'main.py'
     page = root / 'notes' / 'meeting.md'
-    page.write_text(
-        page.read_text(encoding='utf-8').replace(
-            'Content for meeting.',
-            f'See [[../../src/gone.py]], [[{absolute}]], [[../../../src/main.py]],'
-            ' and [[../src/main.py]].',
-        ),
-        encoding='utf-8',
+    body = (
+        f'See [[../../src/main.py]], [[{absolute}]], [[../../../../src/main.py]],'
+        ' and [[../../../src/gone.py]].'
     )
-    _set_links_external(root, ['../src'])
+    text = page.read_text(encoding='utf-8').replace('Content for meeting.', body)
+    page.write_text(text, encoding='utf-8')
+    _set_links_external(root, ['../../src'])
     wiki = Wiki(root)
 
+    # the short and absolute targets are steered; the missing and over-climbed
+    # ones stay bare
     notices = _capture_notices(wiki)
-    issues = wiki.lint()
-    assert issues == [
-        'notes/meeting.md: Link [[../src/main.py]] points inside the wiki through'
-        " './' or '../' (use [[../../src/main.py]] for the file outside the wiki)"
-    ]
+    assert wiki.lint() == []
     notes = sorted(event.description for event in notices if '[[' in event.description)
-    assert notes == sorted(
-        [
-            'notes/meeting.md: Stale link [[../../../src/main.py]]',
-            'notes/meeting.md: Stale link [[../../src/gone.py]]',
-            f'notes/meeting.md: Stale link [[{absolute}]] (use [[../../src/main.py]])',
-        ]
-    )
+    expected = [
+        'notes/meeting.md: Stale link [[../../src/main.py]] (use [[../../../src/main.py]])',
+        'notes/meeting.md: Stale link [[../../../../src/main.py]]',
+        'notes/meeting.md: Stale link [[../../../src/gone.py]]',
+        f'notes/meeting.md: Stale link [[{absolute}]] (use [[../../../src/main.py]])',
+    ]
+    assert notes == sorted(expected)
 
 
 @pytest.mark.parametrize(
@@ -490,12 +573,14 @@ def test_lint_external_links_spare_samples_and_regions(
     _set_links_external(root, ['../src'])
     wiki = Wiki(root)
 
+    # the three rules fire from prose alone
     notices = _capture_notices(wiki)
     issues = [issue for issue in wiki.lint() if 'points inside the wiki' in issue]
     stale = [event for event in notices if 'Stale link' in event.description]
     outside = [event for event in notices if 'points outside' in event.description]
     expected = 1 if noted else 0
-    assert [len(issues), len(stale), len(outside)] == [expected] * 3
+    counts = [len(issues), len(stale), len(outside)]
+    assert counts == [expected] * 3
 
 
 def test_lint_external_symlink_probe_follows_its_text(tmp_path: pathlib.Path) -> None:
@@ -505,22 +590,37 @@ def test_lint_external_symlink_probe_follows_its_text(tmp_path: pathlib.Path) ->
     and is live when its destination exists, a dangling one notes stale,
     and a symlinked page inside the wiki pointing outside is live too --
     the posture every link probe already takes, since only a stat
-    follows.
+    follows. A symlink loop, under the entry or as a marker folder on the
+    way up, reads as missing on every interpreter; a link back into the
+    wiki through a symlink alias of it stays stale, since no entry could
+    admit the alias.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root)
     _plant(tmp_path, {'src/', 'elsewhere/real.md', 'outside/real.md'})
     (tmp_path / 'src' / 'alias.md').symlink_to(tmp_path / 'elsewhere' / 'real.md')
     (tmp_path / 'src' / 'dangling.md').symlink_to(tmp_path / 'elsewhere' / 'nope.md')
+    (tmp_path / 'src' / 'loop').symlink_to('loop')
+    (tmp_path / '.wiki').symlink_to('.wiki')
+    (tmp_path / 'alias').symlink_to(root, target_is_directory=True)
     (root / 'alias.md').symlink_to(tmp_path / 'outside' / 'real.md')
-    _link_from(root, 'root', '../src/alias]], [[../src/dangling]], and [[alias')
+    links = (
+        '../src/alias]], [[../src/dangling]], [[../src/loop/x]],'
+        ' [[../alias/_index]], and [[alias'
+    )
+    _link_from(root, 'root', links)
     _set_links_external(root, ['../src'])
     wiki = Wiki(root)
 
+    # the dangling symlink, the loop, and the alias into the wiki note stale
     notices = _capture_notices(wiki)
     assert wiki.lint() == []
     notes = [event.description for event in notices if '[[' in event.description]
-    assert notes == ['_index.md: Stale link [[../src/dangling]]']
+    assert notes == [
+        '_index.md: Stale link [[../src/dangling]]',
+        '_index.md: Stale link [[../src/loop/x]]',
+        '_index.md: Stale link [[../alias/_index]]',
+    ]
 
 
 def test_links_resolve_from_the_real_root(tmp_path: pathlib.Path) -> None:
@@ -533,15 +633,17 @@ def test_links_resolve_from_the_real_root(tmp_path: pathlib.Path) -> None:
     real = tmp_path / 'ws' / 'wiki'
     _make_wiki(real)
     _plant(tmp_path / 'ws', {'src/main.py'})
-    (tmp_path / 'other').mkdir()
+    # an empty src beside the alias would draw the stale note or no folder note
+    _plant(tmp_path / 'other', {'src/'})
     (tmp_path / 'other' / 'wiki').symlink_to(real, target_is_directory=True)
     _link_from(real, 'root', '../src/main.py')
     _set_links_external(real, ['../src'])
     wiki = Wiki(tmp_path / 'other' / 'wiki')
 
+    # the entry joins the real parent, so the link is live and nothing notes
     notices = _capture_notices(wiki)
     assert wiki.lint() == []
-    assert not any('[[' in event.description for event in notices)
+    assert notices == []
 
 
 @_needs_unprivileged
@@ -567,6 +669,7 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
     _link_from(root, 'root', links)
     _set_links_external(root, ['../src', '../math', '../parent/inner'])
     wiki = Wiki(root)
+    # the probes run against locked paths, restored after the lint
     locked = [
         tmp_path / 'src' / 'locked',
         tmp_path / 'src' / 'secret.txt',
@@ -581,10 +684,11 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
     finally:
         for path in locked:
             os.chmod(path, 0o700)
+    # a target under an unsearchable folder or carrying a NUL reads as missing,
+    # an unreadable file is live, and the entry under the locked parent is noted
     assert issues == []
-    assert sorted(
-        event.description for event in notices if 'link' in event.description
-    ) == [
+    notes = [event.description for event in notices if 'link' in event.description]
+    assert sorted(notes) == [
         '_index.md: Stale link [[../math/g2/a\x00b]]',
         '_index.md: Stale link [[../src/a\x00b]]',
         '_index.md: Stale link [[../src/locked/x]]',
@@ -600,6 +704,7 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
 @pytest.mark.parametrize(
     argnames=('external', 'link', 'verdict'),
     argvalues=[
+        # an entry naming the wiki itself
         (['../math'], '../math/lemmas', 'live'),
         (['../math'], '../math/lemmas.md', 'live'),
         (['../math'], '../math/g2/_index', 'live'),
@@ -613,7 +718,7 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
         (['../math/g2'], '../math/g2', 'issue:../math/g2/_index'),
         (['../math/g2'], '../math/g2/topic', 'live'),
         # an absolute target is steered to the index page the folder links by
-        (['../math'], '{abs}/math/g2', 'stale-fix:../math/g2/_index'),
+        (['../math'], '{absolute}/math/g2', 'stale-fix:../math/g2/_index'),
     ],
     ids=[
         'page-stem',
@@ -650,11 +755,12 @@ def test_lint_other_wiki_targets_follow_its_rules(
     root = tmp_path / 'wiki'
     _make_wiki(root)
     _make_sibling_wiki(tmp_path / 'math')
-    link = link.format(abs=tmp_path.resolve())
+    link = link.format(absolute=tmp_path.resolve())
     _link_from(root, 'root', link)
     _set_links_external(root, external)
     wiki = Wiki(root)
 
+    # the other wiki's own rules decide the verdict
     notices = _capture_notices(wiki)
     issues = wiki.lint()
     notes = [event.description for event in notices if '[[' in event.description]
@@ -671,13 +777,19 @@ def test_lint_other_wiki_targets_follow_its_rules(
         assert issues == [
             f'_index.md: Link [[{link}]] targets a folder, not a page (use [[{fix}]])'
         ]
-        assert issues[0].kind == 'directory_link'
+        issue, *_ = issues
+        assert issue.kind == 'directory_link'
         assert notes == []
 
 
 @pytest.mark.parametrize(
     argnames='fault',
-    argvalues=['malformed', pytest.param('unreadable', marks=_needs_unprivileged)],
+    argvalues=[
+        'malformed',
+        'looped-marker',
+        pytest.param('unreadable-file', marks=_needs_unprivileged),
+        pytest.param('unreadable-folder', marks=_needs_unprivileged),
+    ],
 )
 def test_lint_other_wiki_unreadable_settings_fail_loudly(
     tmp_path: pathlib.Path,
@@ -686,28 +798,76 @@ def test_lint_other_wiki_unreadable_settings_fail_loudly(
     """A settings file lint cannot read in an allowlisted wiki fails naming it.
 
     Another wiki's settings are read as the host's are -- user-editable
-    input that fails loudly, malformed or unreadable alike -- and the
-    error names which wiki's file it is, so the two
-    ``.wiki/settings.json`` are never confused.
+    input that fails loudly, malformed or unreadable alike, a looped
+    marker symlink and the marker folder itself included -- and the error
+    names which wiki's file it is, so the two ``.wiki/settings.json`` are
+    never confused, without that file's absolute path.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root)
     _make_sibling_wiki(tmp_path / 'math')
     settings = tmp_path / 'math' / '.wiki' / 'settings.json'
+    locked = None
     if fault == 'malformed':
         settings.write_text('{', encoding='utf-8')
+    elif fault == 'looped-marker':
+        settings.unlink()
+        settings.symlink_to(settings.name)
+    elif fault == 'unreadable-file':
+        locked = settings
     else:
-        os.chmod(settings, 0o000)
+        locked = settings.parent
+    if locked is not None:
+        os.chmod(locked, 0o000)
     _link_from(root, 'root', '../math/g2')
     _set_links_external(root, ['../math'])
 
+    # the error names the other wiki's settings file
     match = r"links\.external wiki '\.\./math'"
     try:
         with pytest.raises(ValueError, match=match) as excinfo:
             Wiki(root).lint()
     finally:
-        os.chmod(settings, 0o644)
-    assert 'settings.json' in str(excinfo.value)
+        if locked is not None:
+            os.chmod(locked, 0o700)
+    message = str(excinfo.value)
+    assert 'settings.json' in message
+    assert str(tmp_path.resolve()) not in message
+
+
+def test_lint_other_wiki_broken_settings_spare_unrelated_links(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Only a link whose verdict needs the other wiki fails on its settings.
+
+    A prefixed link that lands inside the host is the relative-link issue
+    whatever the other wiki says, and an absolute target is never live;
+    their suggestions would consult that wiki for the spelling a folder
+    there links by, and are dropped when its settings will not read,
+    rather than failing the run -- while a page there by stem is still
+    named, since that needs none of its rules.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting']})
+    _make_sibling_wiki(tmp_path / 'math')
+    (tmp_path / 'math' / '.wiki' / 'settings.json').write_text('{', encoding='utf-8')
+    absolute = tmp_path.resolve() / 'math' / 'g2'
+    links = f'../math/g2]], [[../math/lemmas]], and [[{absolute}'
+    _link_from(root, 'nested', links)
+    _set_links_external(root, ['../math'])
+    wiki = Wiki(root)
+
+    # the verdicts stand, with no spelling that needs the unreadable wiki
+    notices = _capture_notices(wiki)
+    issues = wiki.lint()
+    assert issues == [
+        'notes/meeting.md: Link [[../math/g2]] points inside the wiki through'
+        " './' or '../'",
+        'notes/meeting.md: Link [[../math/lemmas]] points inside the wiki through'
+        " './' or '../' (use [[../../math/lemmas]] for the path outside the wiki)",
+    ]
+    notes = [event.description for event in notices if '[[' in event.description]
+    assert notes == [f'notes/meeting.md: Stale link [[{absolute}]]']
 
 
 def test_links_other_wiki_runs_no_hook(tmp_path: pathlib.Path) -> None:
@@ -715,7 +875,8 @@ def test_links_other_wiki_runs_no_hook(tmp_path: pathlib.Path) -> None:
 
     A ``.wiki/wiki.py`` hook loads only through the CLI's trust check;
     the instance lint builds for an allowlisted wiki is the plain class,
-    so a hook planted there is never imported.
+    so a hook planted there is never imported; the folder it judges
+    reports once however often the prose repeats it.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root)
@@ -725,11 +886,14 @@ def test_links_other_wiki_runs_no_hook(tmp_path: pathlib.Path) -> None:
         "import pathlib\npathlib.Path(__file__).with_name('EXECUTED').touch()\n",
         encoding='utf-8',
     )
-    _link_from(root, 'root', '../math/g2')
+    _link_from(root, 'root', '../math/g2]] and again [[../math/g2')
     _set_links_external(root, ['../math'])
 
+    # lint judges the folder once, without importing the hook
     issues = Wiki(root).lint()
-    assert any('targets a folder' in issue for issue in issues)
+    folder_issues = [issue for issue in issues if 'targets a folder' in issue]
+    folder_issue_count = len(folder_issues)
+    assert folder_issue_count == 1
     assert not (tmp_path / 'math' / '.wiki' / 'EXECUTED').exists()
 
 
@@ -755,20 +919,32 @@ def test_links_other_wiki_notices_ride_the_host_funnel(
     (tmp_path / 'nobin').mkdir()
     monkeypatch.setenv('PATH', str(tmp_path / 'nobin'))
 
+    # the fence note lands in the host's capture, not on the guest's logger
     notices = _capture_notices(wiki)
     issues = wiki.lint()
     assert any('targets a folder' in issue for issue in issues)
     fence = [
         event for event in notices if type(event).__name__ == 'GitFenceUnavailableEvent'
     ]
-    assert len(fence) == 1
+    fence_count = len(fence)
+    assert fence_count == 1
 
 
-@pytest.mark.parametrize('exemption', ['home', 'config-home'])
+@pytest.mark.parametrize(
+    argnames=('exemption', 'readable'),
+    argvalues=[
+        ('home', True),
+        ('config-home', True),
+        pytest.param('home', False, marks=_needs_unprivileged),
+        pytest.param('config-home', False, marks=_needs_unprivileged),
+    ],
+    ids=['home', 'config-home', 'home-unreadable', 'config-home-unreadable'],
+)
 def test_links_home_marker_is_not_a_wiki(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
     exemption: str,
+    readable: bool,
 ) -> None:
     """A settings marker at the home or config home never makes a wiki.
 
@@ -776,12 +952,13 @@ def test_links_home_marker_is_not_a_wiki(
     ``WIKI_CONFIG_DIR``), so a wiki beneath the home directory with its
     parent allowlisted would otherwise judge every neighbor by a wiki
     rooted at home: an indexed-looking folder beside it stays a plain
-    folder, live in the bare form.
+    folder, live in the bare form -- whether or not that ``.wiki`` folder
+    can be read.
     """
     home = tmp_path / 'home'
     root = home / 'wiki'
     _make_wiki(root)
-    # a marker and an indexed-looking folder beside the wiki, at "home"
+    # a marker and an indexed-looking folder beside the wiki, at 'home'
     _plant(home, {'sub/_index.md'})
     (home / '.wiki').mkdir()
     (home / '.wiki' / 'settings.json').write_text('{}\n', encoding='utf-8')
@@ -789,13 +966,46 @@ def test_links_home_marker_is_not_a_wiki(
         monkeypatch.setenv('HOME', str(home))
     else:
         monkeypatch.setenv('WIKI_CONFIG_DIR', str(home / '.wiki'))
+    if not readable:
+        os.chmod(home / '.wiki', 0o000)
     _link_from(root, 'root', '../sub')
     _set_links_external(root, ['..'])
     wiki = Wiki(root)
 
+    # the marker makes no wiki, so the bare folder link is live
     notices = _capture_notices(wiki)
-    assert wiki.lint() == []
+    try:
+        issues = wiki.lint()
+    finally:
+        os.chmod(home / '.wiki', 0o700)
+    assert issues == []
     assert not any('[[' in event.description for event in notices)
+
+
+def test_links_home_symlink_loop_never_raises(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A home directory that is a symlink loop leaves the guest lookup intact.
+
+    The exemptions resolve the home and config home through ``realpath``,
+    which returns a looped path where ``Path.resolve()`` raises before
+    3.13, so another wiki's rules still apply on every interpreter.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _make_sibling_wiki(tmp_path / 'math')
+    (tmp_path / 'loop').symlink_to('loop')
+    monkeypatch.setenv('HOME', str(tmp_path / 'loop'))
+    _link_from(root, 'root', '../math/g2')
+    _set_links_external(root, ['../math'])
+
+    # the sibling wiki's folder is still the directory-link issue
+    issues = Wiki(root).lint()
+    assert issues == [
+        '_index.md: Link [[../math/g2]] targets a folder, not a page'
+        ' (use [[../math/g2/_index]])'
+    ]
 
 
 # ------ missing entries
@@ -812,15 +1022,11 @@ def test_lint_missing_external_folder_notes_once(tmp_path: pathlib.Path) -> None
     root = tmp_path / 'wiki'
     _make_wiki(root, folders={'notes': ['meeting', 'other']})
     (tmp_path / 'src').mkdir()
+    body = 'See [[../../missing/x]] and [[../../missing/y]].'
     for name in ('meeting', 'other'):
         page = root / 'notes' / f'{name}.md'
-        page.write_text(
-            page.read_text(encoding='utf-8').replace(
-                f'Content for {name}.',
-                'See [[../../missing/x]] and [[../../missing/y]].',
-            ),
-            encoding='utf-8',
-        )
+        text = page.read_text(encoding='utf-8').replace(f'Content for {name}.', body)
+        page.write_text(text, encoding='utf-8')
     _set_links_external(root, ['../src', '../missing', '../missing/'])
     wiki = Wiki(root)
 
@@ -831,24 +1037,36 @@ def test_lint_missing_external_folder_notes_once(tmp_path: pathlib.Path) -> None
     missing = [
         event for event in notices if type(event).__name__ == 'LinkFolderMissingEvent'
     ]
-    assert [event.description for event in missing] == [
+    notes = [event.description for event in missing]
+    assert notes == [
         "links.external entry '../missing' names no folder on this machine;"
         ' links into it are not checked'
     ]
-    assert missing[0].folder == '../missing'
+    note, *_ = missing
+    assert note.folder == '../missing'
     # a scoped run names it once again
     notices.clear()
     assert wiki.lint('notes') == []
-    assert sum(1 for event in notices if 'names no folder' in event.description) == 1
+    note_count = sum(1 for event in notices if 'names no folder' in event.description)
+    assert note_count == 1
 
 
 # ------ root boundary
 
 
-@pytest.mark.parametrize(
-    argnames='operation',
-    argvalues=['read', 'match', 'map', 'search', 'update', 'lint', 'new'],
-)
+# the name-taking operations, by name; each callable takes the wiki
+_OUTSIDE_CALLS = {
+    'read': lambda wiki: wiki.read('../outside/secret'),
+    'match': lambda wiki: wiki.match('Secret', name='../outside'),
+    'map': lambda wiki: wiki.map('../outside'),
+    'search': lambda wiki: wiki.search('Secret', name='../outside'),
+    'update': lambda wiki: wiki.update('../outside'),
+    'lint': lambda wiki: wiki.lint('../outside'),
+    'new': lambda wiki: wiki.new('../outside/page', desc='A page.', content='Body.'),
+}
+
+
+@pytest.mark.parametrize('operation', sorted(_OUTSIDE_CALLS))
 def test_links_external_never_widens_root_boundary(
     tmp_path: pathlib.Path,
     operation: str,
@@ -869,18 +1087,11 @@ def test_links_external_never_widens_root_boundary(
     _set_links_external(root, ['..'])
     wiki = Wiki(root)
 
-    calls = {
-        'read': lambda: wiki.read('../outside/secret'),
-        'match': lambda: wiki.match('Secret', name='../outside'),
-        'map': lambda: wiki.map('../outside'),
-        'search': lambda: wiki.search('Secret', name='../outside'),
-        'update': lambda: wiki.update('../outside'),
-        'lint': lambda: wiki.lint('../outside'),
-        'new': lambda: wiki.new('../outside/page', desc='A page.', content='Body.'),
-    }
+    # every name-taking operation refuses the outside target, touching nothing
     with pytest.raises(ValueError, match='outside wiki root'):
-        calls[operation]()
-    assert sorted(path.name for path in outside.iterdir()) == ['secret.md']
+        _OUTSIDE_CALLS[operation](wiki)
+    names = sorted(path.name for path in outside.iterdir())
+    assert names == ['secret.md']
     assert secret.read_text(encoding='utf-8') == 'Secret content.\n'
 
 
@@ -909,6 +1120,7 @@ def test_links_external_never_admits_index_rows(tmp_path: pathlib.Path) -> None:
     _set_links_external(root, ['..'])
     wiki = Wiki(root)
 
+    # the row is a broken link to lint, and update prunes it unread
     issues = wiki.lint()
     assert 'sub/_index.md: Broken link [[../secret|leaked]]' in issues
     wiki.update()
@@ -939,10 +1151,8 @@ def _link_from(root: pathlib.Path, page: str, link: str) -> str:
     else:
         path = root / 'notes' / 'meeting.md'
         marker = 'Content for meeting.'
-    path.write_text(
-        path.read_text(encoding='utf-8').replace(marker, f'See [[{link}]] now.'),
-        encoding='utf-8',
-    )
+    text = path.read_text(encoding='utf-8').replace(marker, f'See [[{link}]] now.')
+    path.write_text(text, encoding='utf-8')
     return path.relative_to(root).as_posix()
 
 
@@ -955,3 +1165,15 @@ def _make_sibling_wiki(path: pathlib.Path) -> None:
     )
     _set_exclude_patterns(path, ['vendor'])
     Wiki(path).update()
+
+
+def _set_links_external(path: pathlib.Path, folders: list[str]) -> None:
+    """Write ``links.external`` into an existing wiki's ``settings.json``.
+
+    Policies are cached per instance, so construct a fresh ``Wiki``
+    after calling this.
+    """
+    settings = path / '.wiki' / 'settings.json'
+    data = json.loads(settings.read_text(encoding='utf-8'))
+    data['links'] = {'external': folders}
+    settings.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')

--- a/tests/test_core/test_links.py
+++ b/tests/test_core/test_links.py
@@ -7,8 +7,9 @@ mis-depth or absolute link is steered to, the note naming the entry to
 add for a real file under no allowlisted folder, the once-per-run note
 for an entry naming no folder on this machine, sample and region
 masking, the symlink probe posture, another wiki's folders judged by its
-own settings, and the unchanged root boundary of the name-taking
-operations and the generated index rows. The in-wiki relative-prefix
+own settings (its notices riding the host's funnel; a marker at the home
+or config home never a wiki), and the unchanged root boundary of the
+name-taking operations and the generated index rows. The in-wiki relative-prefix
 issue is covered beside the link tests in ``test_lint``.
 """
 
@@ -24,7 +25,10 @@ from wiki.core.wiki import Wiki
 
 from ._helpers import (
     _capture_notices,
+    _git_repo,
     _make_wiki,
+    _needs_git,
+    _needs_unprivileged,
     _set_exclude_patterns,
     _set_links_external,
     page_index,
@@ -43,8 +47,10 @@ __all__ = [
     'test_links_resolve_from_the_real_root',
     'test_lint_external_probe_never_raises',
     'test_lint_other_wiki_targets_follow_its_rules',
-    'test_lint_other_wiki_malformed_settings_fail_loudly',
+    'test_lint_other_wiki_unreadable_settings_fail_loudly',
     'test_links_other_wiki_runs_no_hook',
+    'test_links_other_wiki_notices_ride_the_host_funnel',
+    'test_links_home_marker_is_not_a_wiki',
     'test_lint_missing_external_folder_notes_once',
     'test_links_external_never_widens_root_boundary',
     'test_links_external_never_admits_index_rows',
@@ -78,7 +84,7 @@ __all__ = [
         ({'external': ['{fsroot}']}, r'whole filesystem'),
         ({'external': ['src']}, r'inside the wiki root'),
         ({'external': ['../{root}/core']}, r'inside the wiki root'),
-        ({'external': ['../alias']}, r'aliases the wiki root'),
+        ({'external': ['../alias']}, r'through an alias'),
     ],
     ids=[
         'non-object-block',
@@ -126,14 +132,12 @@ def test_links_policy_rejects_invalid_settings(
     # folder name, and enough climbs to reach the filesystem root
     if isinstance(links, dict) and isinstance(links['external'], list):
         climbs = '/'.join(['..'] * len(root.parts))
-        links = {
-            'external': [
-                entry.format(root=root.name, fsroot=climbs)
-                if isinstance(entry, str)
-                else entry
-                for entry in links['external']
-            ]
-        }
+        external = []
+        for entry in links['external']:
+            if isinstance(entry, str):
+                entry = entry.format(root=root.name, fsroot=climbs)
+            external.append(entry)
+        links = {'external': external}
     settings = root / '.wiki' / 'settings.json'
     settings.write_text(json.dumps({'links': links}), encoding='utf-8')
 
@@ -235,6 +239,8 @@ def test_links_policy_accepts_missing_and_ancestor_folders(
             'stale-fix:../../src/main.py',
         ),
         ([], {'src/main.py'}, 'root', '{abs}/src/main.py', 'stale'),
+        # a '..' chain clamped at the filesystem root: no entry could admit it
+        (['../src'], set(), 'root', '{fsroot}', 'stale'),
     ],
     ids=[
         'literal-file',
@@ -261,6 +267,7 @@ def test_links_policy_accepts_missing_and_ancestor_folders(
         'no-block-missing',
         'absolute-under-entry',
         'absolute-not-allowlisted',
+        'clamped-at-filesystem-root',
     ],
 )
 def test_lint_external_target_verdicts(
@@ -278,13 +285,17 @@ def test_lint_external_target_verdicts(
     otherwise; under an entry naming no folder here it is skipped; under
     no entry a real file draws the note naming the entry to add, and a
     missing one the stale note; an absolute target is never live, but is
-    steered to its page-relative spelling when it lands under an entry.
-    Nothing here is a hard issue.
+    steered to its page-relative spelling when it lands under an entry; a
+    ``..`` chain clamped at the filesystem root is stale, since no entry
+    could admit it. Nothing here is a hard issue.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root, folders={'notes': ['meeting']})
     _plant(tmp_path, tree)
-    link = link.format(abs=tmp_path.resolve())
+    # the placeholders spell paths only the layout knows: the wiki's real
+    # location, and enough climbs to reach the filesystem root
+    climbs = '/'.join(['..'] * len(root.resolve().parts))
+    link = link.format(abs=tmp_path.resolve(), fsroot=climbs)
     relpath = _link_from(root, page, link)
     _set_links_external(root, external)
     wiki = Wiki(root)
@@ -337,9 +348,8 @@ def test_lint_external_link_parity_across_pages_and_indexes(
         f' [[../../docs/y{anchor}|Doc]].\n\n'
         f'| a | b |\n|---|---|\n| [[../../src/gone2.py{anchor}\\|Gone]] | c |'
     )
-    page.write_text(
-        page.read_text(encoding='utf-8').replace(marker, body), encoding='utf-8'
-    )
+    text = page.read_text(encoding='utf-8').replace(marker, body)
+    page.write_text(text, encoding='utf-8')
     _set_links_external(root, ['../src'])
     wiki = Wiki(root)
 
@@ -474,20 +484,18 @@ def test_lint_external_links_spare_samples_and_regions(
     _plant(tmp_path, {'src/', 'docs/y.md'})
     links = '[[../../src/gone.py]] [[../../docs/y]] [[./sibling]]'
     page = root / 'notes' / 'meeting.md'
-    page.write_text(
-        page.read_text(encoding='utf-8').replace(
-            'Content for meeting.', body.format(links=links)
-        ),
-        encoding='utf-8',
-    )
+    body = body.format(links=links)
+    text = page.read_text(encoding='utf-8').replace('Content for meeting.', body)
+    page.write_text(text, encoding='utf-8')
     _set_links_external(root, ['../src'])
     wiki = Wiki(root)
 
     notices = _capture_notices(wiki)
     issues = [issue for issue in wiki.lint() if 'points inside the wiki' in issue]
-    stale = [e for e in notices if 'Stale link' in e.description]
-    outside = [e for e in notices if 'points outside' in e.description]
-    assert (len(issues), len(stale), len(outside)) == (int(noted),) * 3
+    stale = [event for event in notices if 'Stale link' in event.description]
+    outside = [event for event in notices if 'points outside' in event.description]
+    expected = 1 if noted else 0
+    assert [len(issues), len(stale), len(outside)] == [expected] * 3
 
 
 def test_lint_external_symlink_probe_follows_its_text(tmp_path: pathlib.Path) -> None:
@@ -536,29 +544,28 @@ def test_links_resolve_from_the_real_root(tmp_path: pathlib.Path) -> None:
     assert not any('[[' in event.description for event in notices)
 
 
-@pytest.mark.skipif(
-    os.geteuid() == 0, reason='permission denial needs an unprivileged user'
-)
+@_needs_unprivileged
 def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
     """A path outside the wiki that cannot be stat-ed reads as missing.
 
     A link into a directory the user cannot search notes stale under an
     allowlisted folder and stays a bare stale note under none; a file the
-    user cannot read is live, since only a stat follows; an entry beneath
-    an unreadable parent draws the folder note. None of it raises, on any
-    interpreter the package supports.
+    user cannot read is live, since only a stat follows; a target carrying
+    a NUL byte is stale under a plain folder and inside another wiki
+    alike; an entry beneath an unreadable parent draws the folder note.
+    None of it raises, on any interpreter the package supports.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root)
-    _plant(
-        tmp_path, {'src/locked/', 'src/secret.txt', 'unlisted/locked/', 'parent/inner/'}
+    _make_sibling_wiki(tmp_path / 'math')
+    tree = {'src/locked/', 'src/secret.txt', 'unlisted/locked/', 'parent/inner/'}
+    _plant(tmp_path, tree)
+    links = (
+        '../src/locked/x]], [[../src/secret.txt]], [[../src/a\x00b]],'
+        ' [[../math/g2/a\x00b]], and [[../unlisted/locked/x'
     )
-    _link_from(
-        root,
-        'root',
-        '../src/locked/x]], [[../src/secret.txt]], and [[../unlisted/locked/x',
-    )
-    _set_links_external(root, ['../src', '../parent/inner'])
+    _link_from(root, 'root', links)
+    _set_links_external(root, ['../src', '../math', '../parent/inner'])
     wiki = Wiki(root)
     locked = [
         tmp_path / 'src' / 'locked',
@@ -578,6 +585,8 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
     assert sorted(
         event.description for event in notices if 'link' in event.description
     ) == [
+        '_index.md: Stale link [[../math/g2/a\x00b]]',
+        '_index.md: Stale link [[../src/a\x00b]]',
         '_index.md: Stale link [[../src/locked/x]]',
         '_index.md: Stale link [[../unlisted/locked/x]]',
         "links.external entry '../parent/inner' names no folder on this machine;"
@@ -589,16 +598,22 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=('link', 'verdict'),
+    argnames=('external', 'link', 'verdict'),
     argvalues=[
-        ('../math/lemmas', 'live'),
-        ('../math/lemmas.md', 'live'),
-        ('../math/g2/_index', 'live'),
-        ('../math/g2', 'issue:../math/g2/_index'),
-        ('../math', 'issue:../math/_index'),
-        ('../math/vendor', 'live'),
-        ('../math/gone', 'stale'),
-        ('../math/g2#top|G', 'issue:../math/g2/_index#top|G'),
+        (['../math'], '../math/lemmas', 'live'),
+        (['../math'], '../math/lemmas.md', 'live'),
+        (['../math'], '../math/g2/_index', 'live'),
+        (['../math'], '../math/g2', 'issue:../math/g2/_index'),
+        (['../math'], '../math', 'issue:../math/_index'),
+        (['../math'], '../math/vendor', 'live'),
+        (['../math'], '../math/gone', 'stale'),
+        (['../math'], '../math/g2#top|G', 'issue:../math/g2/_index#top|G'),
+        # an ancestor entry, and one inside the wiki, reach the same rules
+        (['..'], '../math/g2', 'issue:../math/g2/_index'),
+        (['../math/g2'], '../math/g2', 'issue:../math/g2/_index'),
+        (['../math/g2'], '../math/g2/topic', 'live'),
+        # an absolute target is steered to the index page the folder links by
+        (['../math'], '{abs}/math/g2', 'stale-fix:../math/g2/_index'),
     ],
     ids=[
         'page-stem',
@@ -609,10 +624,15 @@ def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
         'excluded-folder',
         'missing-page',
         'anchor-and-alias',
+        'ancestor-entry',
+        'entry-inside-wiki-folder',
+        'entry-inside-wiki-page',
+        'absolute-indexed-folder',
     ],
 )
 def test_lint_other_wiki_targets_follow_its_rules(
     tmp_path: pathlib.Path,
+    external: list[str],
     link: str,
     verdict: str,
 ) -> None:
@@ -621,14 +641,18 @@ def test_lint_other_wiki_targets_follow_its_rules(
     Its pages link by stem, a folder it indexes is the same directory-link
     issue as at home (naming its ``_index`` page, anchor and alias riding
     along), a folder its ``exclude.patterns`` keeps out of its walk is
-    live in the bare form, and a missing page is stale. Nothing of that
-    wiki runs; its settings are read like the host's.
+    live in the bare form, and a missing page is stale -- whether the
+    entry names the wiki, an ancestor of it, or a folder inside it. An
+    absolute target landing on an indexed folder is steered to the index
+    page. Nothing of that wiki runs; its settings are read like the
+    host's.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root)
     _make_sibling_wiki(tmp_path / 'math')
+    link = link.format(abs=tmp_path.resolve())
     _link_from(root, 'root', link)
-    _set_links_external(root, ['../math'])
+    _set_links_external(root, external)
     wiki = Wiki(root)
 
     notices = _capture_notices(wiki)
@@ -638,6 +662,10 @@ def test_lint_other_wiki_targets_follow_its_rules(
         assert (issues, notes) == ([], [])
     elif verdict == 'stale':
         assert (issues, notes) == ([], [f'_index.md: Stale link [[{link}]]'])
+    elif verdict.startswith('stale-fix:'):
+        fix = verdict.partition(':')[2]
+        expected = f'_index.md: Stale link [[{link}]] (use [[{fix}]])'
+        assert (issues, notes) == ([], [expected])
     else:
         fix = verdict.partition(':')[2]
         assert issues == [
@@ -647,24 +675,38 @@ def test_lint_other_wiki_targets_follow_its_rules(
         assert notes == []
 
 
-def test_lint_other_wiki_malformed_settings_fail_loudly(tmp_path: pathlib.Path) -> None:
-    """A malformed settings file in an allowlisted wiki fails lint naming it.
+@pytest.mark.parametrize(
+    argnames='fault',
+    argvalues=['malformed', pytest.param('unreadable', marks=_needs_unprivileged)],
+)
+def test_lint_other_wiki_unreadable_settings_fail_loudly(
+    tmp_path: pathlib.Path,
+    fault: str,
+) -> None:
+    """A settings file lint cannot read in an allowlisted wiki fails naming it.
 
     Another wiki's settings are read as the host's are -- user-editable
-    input that fails loudly -- and the error names which wiki's file it
-    is, so the two ``.wiki/settings.json`` are never confused.
+    input that fails loudly, malformed or unreadable alike -- and the
+    error names which wiki's file it is, so the two
+    ``.wiki/settings.json`` are never confused.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root)
     _make_sibling_wiki(tmp_path / 'math')
-    (tmp_path / 'math' / '.wiki' / 'settings.json').write_text('{', encoding='utf-8')
+    settings = tmp_path / 'math' / '.wiki' / 'settings.json'
+    if fault == 'malformed':
+        settings.write_text('{', encoding='utf-8')
+    else:
+        os.chmod(settings, 0o000)
     _link_from(root, 'root', '../math/g2')
     _set_links_external(root, ['../math'])
 
-    with pytest.raises(
-        ValueError, match=r"links\.external wiki '\.\./math'"
-    ) as excinfo:
-        Wiki(root).lint()
+    match = r"links\.external wiki '\.\./math'"
+    try:
+        with pytest.raises(ValueError, match=match) as excinfo:
+            Wiki(root).lint()
+    finally:
+        os.chmod(settings, 0o644)
     assert 'settings.json' in str(excinfo.value)
 
 
@@ -689,6 +731,71 @@ def test_links_other_wiki_runs_no_hook(tmp_path: pathlib.Path) -> None:
     issues = Wiki(root).lint()
     assert any('targets a folder' in issue for issue in issues)
     assert not (tmp_path / 'math' / '.wiki' / 'EXECUTED').exists()
+
+
+@_needs_git
+def test_links_other_wiki_notices_ride_the_host_funnel(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A note the other wiki's rules raise reaches the host's notice hook.
+
+    Judging a folder consults that wiki's gitignore fence; with git
+    unavailable inside its repository the fence is narrated, and the note
+    lands in the host's ``on_notice`` -- where a capturing host counts
+    it -- rather than on the guest instance's own logger.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _make_sibling_wiki(tmp_path / 'math')
+    _git_repo(tmp_path / 'math')
+    _link_from(root, 'root', '../math/g2')
+    _set_links_external(root, ['../math'])
+    wiki = Wiki(root)
+    (tmp_path / 'nobin').mkdir()
+    monkeypatch.setenv('PATH', str(tmp_path / 'nobin'))
+
+    notices = _capture_notices(wiki)
+    issues = wiki.lint()
+    assert any('targets a folder' in issue for issue in issues)
+    fence = [
+        event for event in notices if type(event).__name__ == 'GitFenceUnavailableEvent'
+    ]
+    assert len(fence) == 1
+
+
+@pytest.mark.parametrize('exemption', ['home', 'config-home'])
+def test_links_home_marker_is_not_a_wiki(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exemption: str,
+) -> None:
+    """A settings marker at the home or config home never makes a wiki.
+
+    The trust store lives at ``~/.wiki/settings.json`` (or under
+    ``WIKI_CONFIG_DIR``), so a wiki beneath the home directory with its
+    parent allowlisted would otherwise judge every neighbor by a wiki
+    rooted at home: an indexed-looking folder beside it stays a plain
+    folder, live in the bare form.
+    """
+    home = tmp_path / 'home'
+    root = home / 'wiki'
+    _make_wiki(root)
+    # a marker and an indexed-looking folder beside the wiki, at "home"
+    _plant(home, {'sub/_index.md'})
+    (home / '.wiki').mkdir()
+    (home / '.wiki' / 'settings.json').write_text('{}\n', encoding='utf-8')
+    if exemption == 'home':
+        monkeypatch.setenv('HOME', str(home))
+    else:
+        monkeypatch.setenv('WIKI_CONFIG_DIR', str(home / '.wiki'))
+    _link_from(root, 'root', '../sub')
+    _set_links_external(root, ['..'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    assert not any('[[' in event.description for event in notices)
 
 
 # ------ missing entries
@@ -754,7 +861,7 @@ def test_links_external_never_widens_root_boundary(
     outside tree is untouched.
     """
     root = tmp_path / 'wiki'
-    wiki = _make_wiki(root)
+    _make_wiki(root)
     outside = tmp_path / 'outside'
     outside.mkdir()
     secret = outside / 'secret.md'
@@ -786,7 +893,7 @@ def test_links_external_never_admits_index_rows(tmp_path: pathlib.Path) -> None:
     index.
     """
     root = tmp_path / 'wiki'
-    wiki = _make_wiki(root, folders={'sub': ['child']})
+    _make_wiki(root, folders={'sub': ['child']})
     (tmp_path / 'secret.md').write_text(
         '---\nname: secret\ndesc: LEAKED SECRET\n---\n\n# secret\n\nx.\n',
         encoding='utf-8',

--- a/tests/test_core/test_links.py
+++ b/tests/test_core/test_links.py
@@ -1,13 +1,21 @@
 """Behavioral tests for the external link allowlist.
 
 ``links.external`` (``.wiki/settings.json``): policy validation and the
-init-seed refusal, the entries accepted without a folder on disk, and
-the once-per-run note for an entry naming no folder on this machine.
+init-seed refusal, the verdicts for targets under an allowlisted folder
+(pages by stem, literal files, folders), the page-relative spelling a
+mis-depth or absolute link is steered to, the note naming the entry to
+add for a real file under no allowlisted folder, the once-per-run note
+for an entry naming no folder on this machine, sample and region
+masking, the symlink probe posture, another wiki's folders judged by its
+own settings, and the unchanged root boundary of the name-taking
+operations and the generated index rows. The in-wiki relative-prefix
+issue is covered beside the link tests in ``test_lint``.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 
 import pytest
@@ -17,14 +25,29 @@ from wiki.core.wiki import Wiki
 from ._helpers import (
     _capture_notices,
     _make_wiki,
+    _set_exclude_patterns,
     _set_links_external,
+    page_index,
 )
 
 __all__ = [
     'test_links_policy_rejects_invalid_settings',
     'test_init_rejects_invalid_links_seed',
     'test_links_policy_accepts_missing_and_ancestor_folders',
+    'test_lint_external_target_verdicts',
+    'test_lint_external_link_parity_across_pages_and_indexes',
+    'test_lint_relative_prefix_names_both_readings',
+    'test_lint_stale_external_link_suggests_page_relative_spelling',
+    'test_lint_external_links_spare_samples_and_regions',
+    'test_lint_external_symlink_probe_follows_its_text',
+    'test_links_resolve_from_the_real_root',
+    'test_lint_external_probe_never_raises',
+    'test_lint_other_wiki_targets_follow_its_rules',
+    'test_lint_other_wiki_malformed_settings_fail_loudly',
+    'test_links_other_wiki_runs_no_hook',
     'test_lint_missing_external_folder_notes_once',
+    'test_links_external_never_widens_root_boundary',
+    'test_links_external_never_admits_index_rows',
 ]
 
 
@@ -101,7 +124,7 @@ def test_links_policy_rejects_invalid_settings(
     (tmp_path / 'alias').symlink_to(root, target_is_directory=True)
     # the placeholders spell paths only the layout knows: the root's own
     # folder name, and enough climbs to reach the filesystem root
-    if isinstance(links, dict):
+    if isinstance(links, dict) and isinstance(links['external'], list):
         climbs = '/'.join(['..'] * len(root.parts))
         links = {
             'external': [
@@ -110,8 +133,6 @@ def test_links_policy_rejects_invalid_settings(
                 else entry
                 for entry in links['external']
             ]
-            if isinstance(links['external'], list)
-            else links['external']
         }
     settings = root / '.wiki' / 'settings.json'
     settings.write_text(json.dumps({'links': links}), encoding='utf-8')
@@ -164,6 +185,512 @@ def test_links_policy_accepts_missing_and_ancestor_folders(
     assert Wiki(root).lint() == []
 
 
+# ------ external targets
+
+
+@pytest.mark.parametrize(
+    argnames=('external', 'tree', 'page', 'link', 'verdict'),
+    argvalues=[
+        # a literal file under an allowlisted folder
+        (['../src'], {'src/main.py'}, 'root', '../src/main.py', 'live'),
+        # the same file from a nested page climbs once more
+        (['../src'], {'src/main.py'}, 'nested', '../../src/main.py', 'live'),
+        # a markdown file by its explicit name, and by stem
+        (['../docs'], {'docs/guide.md'}, 'root', '../docs/guide.md', 'live'),
+        (['../docs'], {'docs/guide.md'}, 'root', '../docs/guide', 'live'),
+        # a plain folder, with or without a stray index file
+        (['../src'], {'src/pkg/'}, 'root', '../src/pkg', 'live'),
+        (['../src'], {'src/pkg/_index.md'}, 'root', '../src/pkg', 'live'),
+        # the allowlisted folder itself
+        (['../src'], {'src/'}, 'root', '../src', 'live'),
+        # a dot-prefixed leaf, and segments with spaces and colons
+        (['../dotdir'], {'dotdir/.zshrc'}, 'root', '../dotdir/.zshrc', 'live'),
+        (['../sp ace'], {'sp ace/a:b.md'}, 'root', '../sp ace/a:b', 'live'),
+        # a trailing slash on the entry, and an ancestor entry
+        (['../src/'], {'src/main.py'}, 'root', '../src/main.py', 'live'),
+        (['..'], {'README.md'}, 'root', '../README.md', 'live'),
+        # an absent entry beside an ancestor: skipped in either order
+        (['..', '../missing'], set(), 'root', '../missing/x', 'skip'),
+        (['../missing', '..'], set(), 'root', '../missing/x', 'skip'),
+        # an entry naming a file names no folder, and shadows an ancestor
+        (['../README.md'], {'README.md'}, 'root', '../README.md', 'skip'),
+        (['..', '../README.md'], {'README.md'}, 'root', '../README.md', 'skip'),
+        # a missing file under a present folder
+        (['../src'], {'src/'}, 'root', '../src/gone.py', 'stale'),
+        # a real file, folder, or normalized path under no entry
+        (['../src'], {'docs/guide.md'}, 'root', '../docs/guide', 'outside:../docs'),
+        (['../src'], {'docs/'}, 'root', '../docs', 'outside:../docs'),
+        (['../src'], {'docs/x.md'}, 'root', '../src/../docs/x', 'outside:../docs'),
+        # nothing at all under no entry
+        (['../src'], set(), 'root', '../docs/guide', 'stale'),
+        # no block: a real file is the outside note, a missing one stale
+        ([], {'src/main.py'}, 'root', '../src/main.py', 'outside:../src'),
+        ([], set(), 'root', '../src/main.py', 'stale'),
+        # an absolute target is never live; under an entry its fix is spelled
+        (
+            ['../src'],
+            {'src/main.py'},
+            'nested',
+            '{abs}/src/main.py',
+            'stale-fix:../../src/main.py',
+        ),
+        ([], {'src/main.py'}, 'root', '{abs}/src/main.py', 'stale'),
+    ],
+    ids=[
+        'literal-file',
+        'nested-page-depth',
+        'page-explicit-md',
+        'page-stem',
+        'plain-folder',
+        'plain-folder-with-stray-index',
+        'entry-itself',
+        'dot-leaf',
+        'spaces-and-colon',
+        'trailing-slash-entry',
+        'ancestor-entry',
+        'overlap-order-a',
+        'overlap-order-b',
+        'file-entry',
+        'file-entry-shadows-ancestor',
+        'missing-file',
+        'not-allowlisted-exists',
+        'not-allowlisted-folder-target',
+        'normalizes-out',
+        'not-allowlisted-missing',
+        'no-block-exists',
+        'no-block-missing',
+        'absolute-under-entry',
+        'absolute-not-allowlisted',
+    ],
+)
+def test_lint_external_target_verdicts(
+    tmp_path: pathlib.Path,
+    external: list[str],
+    tree: set[str],
+    page: str,
+    link: str,
+    verdict: str,
+) -> None:
+    """A link leaving the wiki is judged by the folders the allowlist names.
+
+    Under an allowlisted folder present on this machine a target is live
+    when the file, its ``.md`` form, or the folder exists, and stale
+    otherwise; under an entry naming no folder here it is skipped; under
+    no entry a real file draws the note naming the entry to add, and a
+    missing one the stale note; an absolute target is never live, but is
+    steered to its page-relative spelling when it lands under an entry.
+    Nothing here is a hard issue.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting']})
+    _plant(tmp_path, tree)
+    link = link.format(abs=tmp_path.resolve())
+    relpath = _link_from(root, page, link)
+    _set_links_external(root, external)
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    notes = [
+        event.description
+        for event in notices
+        if 'names no folder' not in event.description
+    ]
+    if verdict in ('live', 'skip'):
+        assert notes == []
+    elif verdict == 'stale':
+        assert notes == [f'{relpath}: Stale link [[{link}]]']
+    elif verdict.startswith('stale-fix:'):
+        fix = verdict.partition(':')[2]
+        assert notes == [f'{relpath}: Stale link [[{link}]] (use [[{fix}]])']
+    else:
+        folder = verdict.partition(':')[2]
+        assert notes == [
+            f'{relpath}: Link [[{link}]] points outside the wiki (add {folder!r}'
+            ' to links.external in .wiki/settings.json to allow it)'
+        ]
+
+
+@page_index
+@pytest.mark.parametrize('anchor', ['', '#context'], ids=['bare', 'anchored'])
+def test_lint_external_link_parity_across_pages_and_indexes(
+    tmp_path: pathlib.Path,
+    kind: str,
+    anchor: str,
+) -> None:
+    """External links read alike in a page body and an index body.
+
+    A live link is silent, a target notes once however often the prose
+    repeats it, and the alias, anchor, and a table's escaped pipe ride
+    into every note so the fix stays copy-pasteable.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting']})
+    _plant(tmp_path, {'src/main.py', 'docs/y.md'})
+    name = 'meeting.md' if kind == 'page' else '_index.md'
+    marker = 'Content for meeting.' if kind == 'page' else 'Overview of notes.'
+    page = root / 'notes' / name
+    body = (
+        f'See [[../../src/main.py{anchor}|Main]] and'
+        f' [[../../src/gone.py{anchor}|Gone]], then'
+        f' [[../../src/gone.py{anchor}|Gone]] again, and'
+        f' [[../../docs/y{anchor}|Doc]].\n\n'
+        f'| a | b |\n|---|---|\n| [[../../src/gone2.py{anchor}\\|Gone]] | c |'
+    )
+    page.write_text(
+        page.read_text(encoding='utf-8').replace(marker, body), encoding='utf-8'
+    )
+    _set_links_external(root, ['../src'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    notes = sorted(event.description for event in notices if '[[' in event.description)
+    assert notes == sorted(
+        [
+            f'notes/{name}: Stale link [[../../src/gone.py{anchor}|Gone]]',
+            f'notes/{name}: Stale link [[../../src/gone2.py{anchor}\\|Gone]]',
+            f'notes/{name}: Link [[../../docs/y{anchor}|Doc]] points outside the'
+            " wiki (add '../docs' to links.external in .wiki/settings.json to"
+            ' allow it)',
+        ]
+    )
+
+
+def test_lint_relative_prefix_names_both_readings(tmp_path: pathlib.Path) -> None:
+    """A prefixed link inside the wiki names both files it could mean.
+
+    Read from the page's folder the text lands on a page inside the wiki;
+    read from the wiki root it would reach a file under an allowlisted
+    folder. The issue offers the prefix-free spelling for the first and
+    the page-relative spelling for the second, so the author picks the
+    file they meant, and only the readings that exist are offered.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'folder_a': ['file_a'], 'folder_b': ['file_b']})
+    _plant(tmp_path, {'folder_b/file_b.md', 'folder_b/file_b.py'})
+    page = root / 'folder_a' / 'file_a.md'
+    page.write_text(
+        page.read_text(encoding='utf-8').replace(
+            'Content for file_a.',
+            'See [[../folder_b/file_b]] and [[../folder_b/file_b.py]].',
+        ),
+        encoding='utf-8',
+    )
+    _set_links_external(root, ['..'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    issues = wiki.lint()
+    assert issues == [
+        'folder_a/file_a.md: Link [[../folder_b/file_b]] points inside the wiki'
+        " through './' or '../' (use [[folder_b/file_b]], or"
+        ' [[../../folder_b/file_b]] for the file outside the wiki)',
+        'folder_a/file_a.md: Link [[../folder_b/file_b.py]] points inside the'
+        " wiki through './' or '../' (use [[../../folder_b/file_b.py]] for the"
+        ' file outside the wiki)',
+    ]
+    assert [issue.fields.get('canonical') for issue in issues] == [
+        'folder_b/file_b',
+        None,
+    ]
+    assert [issue.fields['external'] for issue in issues] == [
+        '../../folder_b/file_b',
+        '../../folder_b/file_b.py',
+    ]
+    assert not any('[[' in event.description for event in notices)
+
+
+def test_lint_stale_external_link_suggests_page_relative_spelling(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A link that misses its allowlisted file is steered to the right spelling.
+
+    Read from the wiki root, a target written one folder short reaches
+    the file the author meant, so the note names its page-relative
+    spelling; so does an absolute target under an allowlisted folder. A
+    target reaching nothing either way stays a bare stale note, and one
+    that lands inside the wiki is the relative-link issue with the same
+    spelling offered.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting']})
+    _plant(tmp_path, {'src/main.py'})
+    absolute = tmp_path.resolve() / 'src' / 'main.py'
+    page = root / 'notes' / 'meeting.md'
+    page.write_text(
+        page.read_text(encoding='utf-8').replace(
+            'Content for meeting.',
+            f'See [[../../src/gone.py]], [[{absolute}]], [[../../../src/main.py]],'
+            ' and [[../src/main.py]].',
+        ),
+        encoding='utf-8',
+    )
+    _set_links_external(root, ['../src'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    issues = wiki.lint()
+    assert issues == [
+        'notes/meeting.md: Link [[../src/main.py]] points inside the wiki through'
+        " './' or '../' (use [[../../src/main.py]] for the file outside the wiki)"
+    ]
+    notes = sorted(event.description for event in notices if '[[' in event.description)
+    assert notes == sorted(
+        [
+            'notes/meeting.md: Stale link [[../../../src/main.py]]',
+            'notes/meeting.md: Stale link [[../../src/gone.py]]',
+            f'notes/meeting.md: Stale link [[{absolute}]] (use [[../../src/main.py]])',
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=('body', 'noted'),
+    argvalues=[
+        ('```\n{links}\n```', False),
+        ('a `{links}` span', False),
+        ('<!-- {links} -->', False),
+        ('para\n\n    {links}', False),
+        ('<!-- start: no-lint -->\n{links}\n<!-- end: no-lint -->', False),
+        ('See {links} now.', True),
+    ],
+    ids=['fenced', 'inline', 'comment', 'indented', 'region', 'prose'],
+)
+def test_lint_external_links_spare_samples_and_regions(
+    tmp_path: pathlib.Path,
+    body: str,
+    noted: bool,
+) -> None:
+    """Masks and regions spare every external link rule, prose sees them all.
+
+    A stale allowlisted target, a real file under no entry, and a
+    prefixed target landing inside the wiki each fire from plain prose
+    only; inside a code sample, an HTML comment, or a ``no-lint`` region
+    none of them does, as the in-wiki rules behave.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting', 'sibling']})
+    _plant(tmp_path, {'src/', 'docs/y.md'})
+    links = '[[../../src/gone.py]] [[../../docs/y]] [[./sibling]]'
+    page = root / 'notes' / 'meeting.md'
+    page.write_text(
+        page.read_text(encoding='utf-8').replace(
+            'Content for meeting.', body.format(links=links)
+        ),
+        encoding='utf-8',
+    )
+    _set_links_external(root, ['../src'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    issues = [issue for issue in wiki.lint() if 'points inside the wiki' in issue]
+    stale = [e for e in notices if 'Stale link' in e.description]
+    outside = [e for e in notices if 'points outside' in e.description]
+    assert (len(issues), len(stale), len(outside)) == (int(noted),) * 3
+
+
+def test_lint_external_symlink_probe_follows_its_text(tmp_path: pathlib.Path) -> None:
+    """Containment reads the link's text; existence follows the symlink.
+
+    A symlink under an allowlisted folder counts as inside by its text
+    and is live when its destination exists, a dangling one notes stale,
+    and a symlinked page inside the wiki pointing outside is live too --
+    the posture every link probe already takes, since only a stat
+    follows.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _plant(tmp_path, {'src/', 'elsewhere/real.md', 'outside/real.md'})
+    (tmp_path / 'src' / 'alias.md').symlink_to(tmp_path / 'elsewhere' / 'real.md')
+    (tmp_path / 'src' / 'dangling.md').symlink_to(tmp_path / 'elsewhere' / 'nope.md')
+    (root / 'alias.md').symlink_to(tmp_path / 'outside' / 'real.md')
+    _link_from(root, 'root', '../src/alias]], [[../src/dangling]], and [[alias')
+    _set_links_external(root, ['../src'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    notes = [event.description for event in notices if '[[' in event.description]
+    assert notes == ['_index.md: Stale link [[../src/dangling]]']
+
+
+def test_links_resolve_from_the_real_root(tmp_path: pathlib.Path) -> None:
+    """Entries join onto the wiki's real location, not the path it was opened by.
+
+    The root is resolved at construction, so ``..`` in an entry is the
+    real parent: a wiki opened through a symlink elsewhere still finds
+    the folder beside its real self, and nothing beside the alias.
+    """
+    real = tmp_path / 'ws' / 'wiki'
+    _make_wiki(real)
+    _plant(tmp_path / 'ws', {'src/main.py'})
+    (tmp_path / 'other').mkdir()
+    (tmp_path / 'other' / 'wiki').symlink_to(real, target_is_directory=True)
+    _link_from(real, 'root', '../src/main.py')
+    _set_links_external(real, ['../src'])
+    wiki = Wiki(tmp_path / 'other' / 'wiki')
+
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    assert not any('[[' in event.description for event in notices)
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason='permission denial needs an unprivileged user'
+)
+def test_lint_external_probe_never_raises(tmp_path: pathlib.Path) -> None:
+    """A path outside the wiki that cannot be stat-ed reads as missing.
+
+    A link into a directory the user cannot search notes stale under an
+    allowlisted folder and stays a bare stale note under none; a file the
+    user cannot read is live, since only a stat follows; an entry beneath
+    an unreadable parent draws the folder note. None of it raises, on any
+    interpreter the package supports.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _plant(
+        tmp_path, {'src/locked/', 'src/secret.txt', 'unlisted/locked/', 'parent/inner/'}
+    )
+    _link_from(
+        root,
+        'root',
+        '../src/locked/x]], [[../src/secret.txt]], and [[../unlisted/locked/x',
+    )
+    _set_links_external(root, ['../src', '../parent/inner'])
+    wiki = Wiki(root)
+    locked = [
+        tmp_path / 'src' / 'locked',
+        tmp_path / 'src' / 'secret.txt',
+        tmp_path / 'unlisted' / 'locked',
+        tmp_path / 'parent',
+    ]
+    for path in locked:
+        os.chmod(path, 0o000)
+    try:
+        notices = _capture_notices(wiki)
+        issues = wiki.lint()
+    finally:
+        for path in locked:
+            os.chmod(path, 0o700)
+    assert issues == []
+    assert sorted(
+        event.description for event in notices if 'link' in event.description
+    ) == [
+        '_index.md: Stale link [[../src/locked/x]]',
+        '_index.md: Stale link [[../unlisted/locked/x]]',
+        "links.external entry '../parent/inner' names no folder on this machine;"
+        ' links into it are not checked',
+    ]
+
+
+# ------ other wikis
+
+
+@pytest.mark.parametrize(
+    argnames=('link', 'verdict'),
+    argvalues=[
+        ('../math/lemmas', 'live'),
+        ('../math/lemmas.md', 'live'),
+        ('../math/g2/_index', 'live'),
+        ('../math/g2', 'issue:../math/g2/_index'),
+        ('../math', 'issue:../math/_index'),
+        ('../math/vendor', 'live'),
+        ('../math/gone', 'stale'),
+        ('../math/g2#top|G', 'issue:../math/g2/_index#top|G'),
+    ],
+    ids=[
+        'page-stem',
+        'page-explicit-md',
+        'index-form',
+        'indexed-folder',
+        'wiki-root',
+        'excluded-folder',
+        'missing-page',
+        'anchor-and-alias',
+    ],
+)
+def test_lint_other_wiki_targets_follow_its_rules(
+    tmp_path: pathlib.Path,
+    link: str,
+    verdict: str,
+) -> None:
+    """A target inside another wiki is judged by that wiki's own settings.
+
+    Its pages link by stem, a folder it indexes is the same directory-link
+    issue as at home (naming its ``_index`` page, anchor and alias riding
+    along), a folder its ``exclude.patterns`` keeps out of its walk is
+    live in the bare form, and a missing page is stale. Nothing of that
+    wiki runs; its settings are read like the host's.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _make_sibling_wiki(tmp_path / 'math')
+    _link_from(root, 'root', link)
+    _set_links_external(root, ['../math'])
+    wiki = Wiki(root)
+
+    notices = _capture_notices(wiki)
+    issues = wiki.lint()
+    notes = [event.description for event in notices if '[[' in event.description]
+    if verdict == 'live':
+        assert (issues, notes) == ([], [])
+    elif verdict == 'stale':
+        assert (issues, notes) == ([], [f'_index.md: Stale link [[{link}]]'])
+    else:
+        fix = verdict.partition(':')[2]
+        assert issues == [
+            f'_index.md: Link [[{link}]] targets a folder, not a page (use [[{fix}]])'
+        ]
+        assert issues[0].kind == 'directory_link'
+        assert notes == []
+
+
+def test_lint_other_wiki_malformed_settings_fail_loudly(tmp_path: pathlib.Path) -> None:
+    """A malformed settings file in an allowlisted wiki fails lint naming it.
+
+    Another wiki's settings are read as the host's are -- user-editable
+    input that fails loudly -- and the error names which wiki's file it
+    is, so the two ``.wiki/settings.json`` are never confused.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _make_sibling_wiki(tmp_path / 'math')
+    (tmp_path / 'math' / '.wiki' / 'settings.json').write_text('{', encoding='utf-8')
+    _link_from(root, 'root', '../math/g2')
+    _set_links_external(root, ['../math'])
+
+    with pytest.raises(
+        ValueError, match=r"links\.external wiki '\.\./math'"
+    ) as excinfo:
+        Wiki(root).lint()
+    assert 'settings.json' in str(excinfo.value)
+
+
+def test_links_other_wiki_runs_no_hook(tmp_path: pathlib.Path) -> None:
+    """Judging another wiki's folders never runs that wiki's code.
+
+    A ``.wiki/wiki.py`` hook loads only through the CLI's trust check;
+    the instance lint builds for an allowlisted wiki is the plain class,
+    so a hook planted there is never imported.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    _make_sibling_wiki(tmp_path / 'math')
+    hook = tmp_path / 'math' / '.wiki' / 'wiki.py'
+    hook.write_text(
+        "import pathlib\npathlib.Path(__file__).with_name('EXECUTED').touch()\n",
+        encoding='utf-8',
+    )
+    _link_from(root, 'root', '../math/g2')
+    _set_links_external(root, ['../math'])
+
+    issues = Wiki(root).lint()
+    assert any('targets a folder' in issue for issue in issues)
+    assert not (tmp_path / 'math' / '.wiki' / 'EXECUTED').exists()
+
+
 # ------ missing entries
 
 
@@ -173,17 +700,27 @@ def test_lint_missing_external_folder_notes_once(tmp_path: pathlib.Path) -> None
     The note names the entry as written, fires whether or not any link
     reaches under it, collapses repeated spellings of one folder, and
     repeats once for a scoped run -- an environment condition reported
-    once, not a stale link reported per page.
+    once -- while the links into the entry draw nothing at all.
     """
     root = tmp_path / 'wiki'
-    wiki = _make_wiki(root, folders={'notes': ['meeting', 'other']})
+    _make_wiki(root, folders={'notes': ['meeting', 'other']})
     (tmp_path / 'src').mkdir()
+    for name in ('meeting', 'other'):
+        page = root / 'notes' / f'{name}.md'
+        page.write_text(
+            page.read_text(encoding='utf-8').replace(
+                f'Content for {name}.',
+                'See [[../../missing/x]] and [[../../missing/y]].',
+            ),
+            encoding='utf-8',
+        )
     _set_links_external(root, ['../src', '../missing', '../missing/'])
     wiki = Wiki(root)
 
-    # one note for the absent entry, none for the present one
+    # one note for the absent entry, none for the present one or the links
     notices = _capture_notices(wiki)
     assert wiki.lint() == []
+    assert not any('[[' in event.description for event in notices)
     missing = [
         event for event in notices if type(event).__name__ == 'LinkFolderMissingEvent'
     ]
@@ -196,3 +733,118 @@ def test_lint_missing_external_folder_notes_once(tmp_path: pathlib.Path) -> None
     notices.clear()
     assert wiki.lint('notes') == []
     assert sum(1 for event in notices if 'names no folder' in event.description) == 1
+
+
+# ------ root boundary
+
+
+@pytest.mark.parametrize(
+    argnames='operation',
+    argvalues=['read', 'match', 'map', 'search', 'update', 'lint', 'new'],
+)
+def test_links_external_never_widens_root_boundary(
+    tmp_path: pathlib.Path,
+    operation: str,
+) -> None:
+    """An allowlisted folder is a lint rule, never a grant to the operations.
+
+    With the whole parent allowlisted, every name-taking operation still
+    refuses a target outside the root -- the allowlist changes what lint
+    checks, not what the wiki may read, write, or index -- and the
+    outside tree is untouched.
+    """
+    root = tmp_path / 'wiki'
+    wiki = _make_wiki(root)
+    outside = tmp_path / 'outside'
+    outside.mkdir()
+    secret = outside / 'secret.md'
+    secret.write_text('Secret content.\n', encoding='utf-8')
+    _set_links_external(root, ['..'])
+    wiki = Wiki(root)
+
+    calls = {
+        'read': lambda: wiki.read('../outside/secret'),
+        'match': lambda: wiki.match('Secret', name='../outside'),
+        'map': lambda: wiki.map('../outside'),
+        'search': lambda: wiki.search('Secret', name='../outside'),
+        'update': lambda: wiki.update('../outside'),
+        'lint': lambda: wiki.lint('../outside'),
+        'new': lambda: wiki.new('../outside/page', desc='A page.', content='Body.'),
+    }
+    with pytest.raises(ValueError, match='outside wiki root'):
+        calls[operation]()
+    assert sorted(path.name for path in outside.iterdir()) == ['secret.md']
+    assert secret.read_text(encoding='utf-8') == 'Secret content.\n'
+
+
+def test_links_external_never_admits_index_rows(tmp_path: pathlib.Path) -> None:
+    """Generated rows stay filesystem-derived under any allowlist.
+
+    An injected row escaping the root is a broken link to lint and is
+    pruned by update without its target ever being read: the allowlist
+    admits prose links, never a foreign file's ``desc:`` into a tracked
+    index.
+    """
+    root = tmp_path / 'wiki'
+    wiki = _make_wiki(root, folders={'sub': ['child']})
+    (tmp_path / 'secret.md').write_text(
+        '---\nname: secret\ndesc: LEAKED SECRET\n---\n\n# secret\n\nx.\n',
+        encoding='utf-8',
+    )
+    sub_index = root / 'sub' / '_index.md'
+    text = sub_index.read_text(encoding='utf-8')
+    text = text.replace(
+        '[[sub/child|child]]',
+        '[[../secret|leaked]]: ...\n[[sub/child|child]]',
+        1,
+    )
+    sub_index.write_text(text, encoding='utf-8')
+    _set_links_external(root, ['..'])
+    wiki = Wiki(root)
+
+    issues = wiki.lint()
+    assert 'sub/_index.md: Broken link [[../secret|leaked]]' in issues
+    wiki.update()
+    updated = sub_index.read_text(encoding='utf-8')
+    assert '../secret' not in updated
+    assert 'LEAKED SECRET' not in updated
+
+
+# ------ helpers
+
+
+def _plant(base: pathlib.Path, entries: set[str]) -> None:
+    """Create the files, and folders (trailing ``/``), that ``entries`` name."""
+    for entry in sorted(entries):
+        target = base / entry
+        if entry.endswith('/'):
+            target.mkdir(parents=True, exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text('x\n', encoding='utf-8')
+
+
+def _link_from(root: pathlib.Path, page: str, link: str) -> str:
+    """Write ``[[link]]`` into the root index or the nested page; return its relpath."""
+    if page == 'root':
+        path = root / '_index.md'
+        marker = 'Root overview.'
+    else:
+        path = root / 'notes' / 'meeting.md'
+        marker = 'Content for meeting.'
+    path.write_text(
+        path.read_text(encoding='utf-8').replace(marker, f'See [[{link}]] now.'),
+        encoding='utf-8',
+    )
+    return path.relative_to(root).as_posix()
+
+
+def _make_sibling_wiki(path: pathlib.Path) -> None:
+    """Create a wiki beside the one under test: a page, an indexed folder, an excluded one."""
+    _make_wiki(path, folders={'g2': ['topic'], 'vendor': ['v']})
+    (path / 'lemmas.md').write_text(
+        '---\nname: lemmas\ndesc: Lemmas.\n---\n\n# lemmas\n\nText.\n',
+        encoding='utf-8',
+    )
+    _set_exclude_patterns(path, ['vendor'])
+    Wiki(path).update()

--- a/tests/test_core/test_links.py
+++ b/tests/test_core/test_links.py
@@ -1,0 +1,198 @@
+"""Behavioral tests for the external link allowlist.
+
+``links.external`` (``.wiki/settings.json``): policy validation and the
+init-seed refusal, the entries accepted without a folder on disk, and
+the once-per-run note for an entry naming no folder on this machine.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from wiki.core.wiki import Wiki
+
+from ._helpers import (
+    _capture_notices,
+    _make_wiki,
+    _set_links_external,
+)
+
+__all__ = [
+    'test_links_policy_rejects_invalid_settings',
+    'test_init_rejects_invalid_links_seed',
+    'test_links_policy_accepts_missing_and_ancestor_folders',
+    'test_lint_missing_external_folder_notes_once',
+]
+
+
+# ------ policy validation
+
+
+@pytest.mark.parametrize(
+    argnames=('links', 'match'),
+    argvalues=[
+        ('vendor', r'links block must be a JSON object'),
+        ({'external': '../src'}, r'links\.external must be a list'),
+        ({'external': [5]}, r'entry must be a string'),
+        ({'external': ['']}, r'empty or whitespace-only'),
+        ({'external': ['   ']}, r'empty or whitespace-only'),
+        ({'external': ['/']}, r'empty or whitespace-only'),
+        ({'external': ['/etc']}, r'absolute'),
+        ({'external': ['~/x']}, r'absolute'),
+        ({'external': ['..\\x']}, r'separator'),
+        ({'external': ['../c#']}, r'no wikilink target can carry'),
+        ({'external': ['../a|b']}, r'no wikilink target can carry'),
+        ({'external': ['../a]b']}, r'no wikilink target can carry'),
+        ({'external': ['../a\x00b']}, r'no wikilink target can carry'),
+        ({'external': ['..//x']}, r'empty segment'),
+        ({'external': ['../x/./y']}, r"'\.' segments"),
+        ({'external': ['.']}, r"'\.' segments"),
+        ({'external': ['../a/../b']}, r'only at the start'),
+        ({'external': ['core/..']}, r'only at the start'),
+        ({'external': ['{fsroot}']}, r'whole filesystem'),
+        ({'external': ['src']}, r'inside the wiki root'),
+        ({'external': ['../{root}/core']}, r'inside the wiki root'),
+        ({'external': ['../alias']}, r'aliases the wiki root'),
+    ],
+    ids=[
+        'non-object-block',
+        'non-list-external',
+        'non-string-entry',
+        'empty',
+        'whitespace-only',
+        'slash-alone',
+        'absolute',
+        'home-tilde',
+        'backslash',
+        'anchor-char',
+        'pipe-char',
+        'bracket-char',
+        'nul',
+        'empty-segment',
+        'dot-segment',
+        'root-dot',
+        'interior-dot-dot',
+        'lands-on-root',
+        'filesystem-root',
+        'inside-root',
+        'reenters-root',
+        'root-alias',
+    ],
+)
+def test_links_policy_rejects_invalid_settings(
+    tmp_path: pathlib.Path,
+    links: object,
+    match: str,
+) -> None:
+    """A malformed ``links`` block fails loudly, naming the file and key.
+
+    ``settings.json`` is user-editable input: a wrong-typed block or an
+    entry outside the folder grammar (absolute and home paths, escapes,
+    characters no wikilink target can carry, ``.`` and interior ``..``
+    segments, the filesystem root, and any spelling of a folder inside
+    the wiki -- lexical or through a symlink alias) raises ``ValueError``
+    through any command that reads the policy, links or none.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'core': ['design']})
+    (tmp_path / 'alias').symlink_to(root, target_is_directory=True)
+    # the placeholders spell paths only the layout knows: the root's own
+    # folder name, and enough climbs to reach the filesystem root
+    if isinstance(links, dict):
+        climbs = '/'.join(['..'] * len(root.parts))
+        links = {
+            'external': [
+                entry.format(root=root.name, fsroot=climbs)
+                if isinstance(entry, str)
+                else entry
+                for entry in links['external']
+            ]
+            if isinstance(links['external'], list)
+            else links['external']
+        }
+    settings = root / '.wiki' / 'settings.json'
+    settings.write_text(json.dumps({'links': links}), encoding='utf-8')
+
+    # a fresh instance fails loudly, naming the settings file
+    with pytest.raises(ValueError, match=match) as excinfo:
+        Wiki(root).lint()
+    assert 'links' in str(excinfo.value)
+    assert 'settings.json' in str(excinfo.value)
+
+
+def test_init_rejects_invalid_links_seed(tmp_path: pathlib.Path) -> None:
+    """A rejected ``links`` seed aborts ``init`` before writing anything.
+
+    The links policy is read lazily (first inside lint's folder check),
+    so init touches it up front: a bad seed must fail before the
+    settings file, the root index, or any sweep write lands.
+    """
+    root = tmp_path / 'wiki'
+    with pytest.raises(ValueError, match=r'links\.external'):
+        Wiki(root).init(settings={'links': {'external': ['src']}})
+    assert not root.exists()
+
+
+@pytest.mark.parametrize(
+    argnames='folders',
+    argvalues=[
+        ['../missing'],
+        ['..'],
+        ['../src/'],
+        ['../src', '../src/'],
+    ],
+    ids=['absent-folder', 'ancestor', 'trailing-slash', 'repeated'],
+)
+def test_links_policy_accepts_missing_and_ancestor_folders(
+    tmp_path: pathlib.Path,
+    folders: list[str],
+) -> None:
+    """An entry need not exist on disk, and an ancestor of the root is legal.
+
+    A cross-repository entry is absent on a partial checkout, so presence
+    is a lint note rather than a load-time error; the enclosing repository
+    is the natural single entry for a same-repository wiki; a trailing
+    slash and a repeated spelling name the same folder.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root)
+    (tmp_path / 'src').mkdir()
+    _set_links_external(root, folders)
+    assert Wiki(root).lint() == []
+
+
+# ------ missing entries
+
+
+def test_lint_missing_external_folder_notes_once(tmp_path: pathlib.Path) -> None:
+    """An entry naming no folder on this machine draws one note per lint run.
+
+    The note names the entry as written, fires whether or not any link
+    reaches under it, collapses repeated spellings of one folder, and
+    repeats once for a scoped run -- an environment condition reported
+    once, not a stale link reported per page.
+    """
+    root = tmp_path / 'wiki'
+    wiki = _make_wiki(root, folders={'notes': ['meeting', 'other']})
+    (tmp_path / 'src').mkdir()
+    _set_links_external(root, ['../src', '../missing', '../missing/'])
+    wiki = Wiki(root)
+
+    # one note for the absent entry, none for the present one
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    missing = [
+        event for event in notices if type(event).__name__ == 'LinkFolderMissingEvent'
+    ]
+    assert [event.description for event in missing] == [
+        "links.external entry '../missing' names no folder on this machine;"
+        ' links into it are not checked'
+    ]
+    assert missing[0].folder == '../missing'
+    # a scoped run names it once again
+    notices.clear()
+    assert wiki.lint('notes') == []
+    assert sum(1 for event in notices if 'names no folder' in event.description) == 1

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -88,7 +88,7 @@ __all__ = [
     'test_lint_relative_prefix_inside_wiki_is_issue',
     'test_lint_relative_root_link_names_the_index_page',
     'test_lint_relative_root_link_steers_to_index_before_update',
-    'test_lint_link_text_ignores_padding_and_a_stray_bracket',
+    'test_lint_link_text_ignores_padding_but_not_a_stray_bracket',
     'test_lint_stale_prefix_free_link_names_a_raw_file',
     'test_lint_directory_link_is_issue_naming_index_form',
     'test_lint_link_rules_spare_samples_not_prose',
@@ -2022,22 +2022,23 @@ def test_lint_relative_root_link_steers_to_index_before_update(
     argvalues=[
         ('[[ overview ]]', []),
         ('[[overview\t]]', []),
-        ('[[[overview]]', []),
+        ('[[[overview]]', ['notes/meeting.md: Stale link [[[overview]]']),
         ('[[overview\n]]', ['notes/meeting.md: Stale link [[overview\n]]']),
         ('[[ ]]', []),
     ],
     ids=['spaces', 'tab', 'stray-bracket', 'line-break', 'blank'],
 )
-def test_lint_link_text_ignores_padding_and_a_stray_bracket(
+def test_lint_link_text_ignores_padding_but_not_a_stray_bracket(
     tmp_path: pathlib.Path,
     text: str,
     stale: list[str],
 ) -> None:
-    """Spaces, tabs, and a stray bracket around a target are not part of it.
+    """Spaces and tabs around a target are not part of it; a bracket is junk.
 
-    ``[[ overview ]]`` and ``[[[overview]]`` link the root page; a link
-    broken across a line break is still the text as written, and stale;
-    a target of only spaces is no link at all, as ``[[]]`` never was.
+    ``[[ overview ]]`` links the root page, while ``[[[overview]]`` carries
+    a ``[`` no name can, so it is stale as written; a link broken across a
+    line break is still the text as written, and stale; a target of only
+    spaces is no link at all, as ``[[]]`` never was.
     """
     _make_wiki(tmp_path, folders={'notes': ['meeting']})
     (tmp_path / 'overview.md').write_text(
@@ -2050,7 +2051,7 @@ def test_lint_link_text_ignores_padding_and_a_stray_bracket(
     page.write_text(body, encoding='utf-8')
     wiki = Wiki(tmp_path)
 
-    # the padded spellings are live; the broken one notes stale
+    # the padded spellings are live; the bracketed and broken ones note stale
     notices = _capture_notices(wiki)
     assert wiki.lint() == []
     notes = [

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -13,6 +13,7 @@ import os
 import pathlib
 import re
 import shutil
+from typing import Optional
 
 import pytest
 
@@ -82,9 +83,7 @@ __all__ = [
     'test_lint_survives_index_deleted_mid_check',
     'test_quoted_placeholder_desc_is_soft',
     'test_long_desc_is_note_only',
-    'test_lint_stale_body_link_names_canonical',
-    'test_lint_stale_directory_link_suggests_index_form',
-    'test_lint_stale_link_to_unindexed_folder_suggests_bare_form',
+    'test_lint_relative_prefix_inside_wiki_is_issue',
     'test_lint_directory_link_is_issue_naming_index_form',
     'test_lint_link_rules_spare_samples_not_prose',
     'test_lint_directory_link_keeps_display_text',
@@ -281,12 +280,13 @@ def test_lint_issues_are_typed(tmp_path: pathlib.Path) -> None:
         encoding='utf-8',
     )
     # a period-less desc, an unparseable stamp, both wrap mangles, a
-    # directory link, and a dangling region marker on one messy page
+    # directory link, a relative link, and a dangling region marker on
+    # one messy page
     (tmp_path / 'data' / 'messy.md').write_text(
         '---\nname: messy\ndesc: No trailing period\n'
         'created: not-a-stamp\n---\n\n# messy\n\n'
         'a twenty-\nclass system, that\n+ wraps into a marker.\n\n'
-        'See [[core]] for more.\n\n<!-- start: no-lint -->\n',
+        'See [[core]] and [[./keep]] for more.\n\n<!-- start: no-lint -->\n',
         encoding='utf-8',
     )
     # frontmatter a strict YAML reader rejects
@@ -351,6 +351,7 @@ def test_lint_issues_are_typed(tmp_path: pathlib.Path) -> None:
         'missing_title',
         'nested_wiki_root',
         'region_marker',
+        'relative_link',
         'requires_update',
         'shadowed_page',
         'symlink_link_target',
@@ -1849,85 +1850,65 @@ def test_long_desc_is_note_only(tmp_path: pathlib.Path) -> None:
 # ------ body links and structure
 
 
+@page_index
 @pytest.mark.parametrize('anchor', ['', '#context'], ids=['bare', 'anchored'])
-def test_lint_stale_body_link_names_canonical(
+@pytest.mark.parametrize(
+    argnames=('link', 'fix'),
+    argvalues=[
+        # the root page, written as if relative to the page's folder
+        ('../overview', 'overview'),
+        # a sibling page through './'
+        ('./sibling', 'notes/sibling'),
+        # an indexed folder: the fix is its index page
+        ('../core', 'core/_index'),
+        # an excluded folder keeps its bare form
+        ('../vendor', 'vendor'),
+        # a raw file at the root
+        ('../Makefile', 'Makefile'),
+        # the root itself
+        ('..', '_index'),
+        # an interior '..' segment reads the same way
+        ('sibling/../sibling', 'notes/sibling'),
+        # nothing exists there: the issue stands without a fix
+        ('./gone', None),
+    ],
+    ids=[
+        'page',
+        'dot-sibling',
+        'indexed-folder',
+        'excluded-folder',
+        'raw-file',
+        'root',
+        'interior',
+        'missing',
+    ],
+)
+def test_lint_relative_prefix_inside_wiki_is_issue(
     tmp_path: pathlib.Path,
+    kind: str,
     anchor: str,
+    link: str,
+    fix: Optional[str],
 ) -> None:
-    """A folder-relative body link is noted with its root-relative fix.
+    """A ``./`` or ``../`` link that lands inside the wiki is a hard issue.
 
-    An anchor suffix rides along on the suggestion: dropping it would make
-    a user applying the fix verbatim silently lose the anchor.
+    A prefixed target is read from the page's folder, as Obsidian and
+    markdown read it, and means "outside the wiki"; one that resolves
+    inside is written wrong, so lint fails it and names the prefix-free
+    form -- a page by stem, an indexed folder's ``_index`` page, an
+    excluded folder's bare form, a raw file's path -- with the anchor and
+    alias riding along, and no fix when nothing exists there. The link is
+    never also noted as stale.
     """
-    _make_wiki(tmp_path, folders={'notes': ['meeting']})
-    wiki = Wiki(tmp_path)
-    # a page that exists at root, and a folder-relative link to it from a subpage
+    _make_wiki(
+        tmp_path,
+        folders={'notes': ['meeting', 'sibling'], 'core': ['design']},
+    )
     (tmp_path / 'overview.md').write_text(
         '---\nname: overview\ndesc: An overview.\n---\n\n# overview\n\nText.\n',
         encoding='utf-8',
     )
-    meeting = tmp_path / 'notes' / 'meeting.md'
-    meeting.write_text(
-        meeting.read_text(encoding='utf-8').replace(
-            'Content for meeting.',
-            f'See [[../overview{anchor}]] for context.',
-        ),
-        encoding='utf-8',
-    )
-    wiki.update()
-    # the stale link is noted with the canonical [[overview]] as the fix
-    notices = _capture_notices(wiki)
-    wiki.lint()
-    stale = [
-        event.description
-        for event in notices
-        if f'Stale link [[../overview{anchor}]]' in event.description
-    ]
-    assert stale
-    assert all(f'(use [[overview{anchor}]])' in note for note in stale)
-
-
-def test_lint_stale_directory_link_suggests_index_form(
-    tmp_path: pathlib.Path,
-) -> None:
-    """A folder-relative link to a folder suggests its ``_index`` page.
-
-    Suggesting the bare folder would steer the author straight into the
-    directory-link hard issue; the canonical fix is the index page.
-    """
-    wiki = _make_wiki(tmp_path, folders={'core': ['design'], 'notes': ['meeting']})
-    meeting = tmp_path / 'notes' / 'meeting.md'
-    meeting.write_text(
-        meeting.read_text(encoding='utf-8').replace(
-            'Content for meeting.',
-            'See [[../core]] for context.',
-        ),
-        encoding='utf-8',
-    )
-    wiki.update()
-    # the stale note names the folder's index page as the fix
-    notices = _capture_notices(wiki)
-    assert wiki.lint() == []
-    stale = [
-        event.description
-        for event in notices
-        if 'Stale link [[../core]]' in event.description
-    ]
-    assert stale
-    assert all('(use [[core/_index]])' in note for note in stale)
-
-
-def test_lint_stale_link_to_unindexed_folder_suggests_bare_form(
-    tmp_path: pathlib.Path,
-) -> None:
-    """A folder-relative link to an unindexed folder suggests the bare form.
-
-    A pattern-excluded folder is never walked, so an index it carries on
-    disk is not maintained -- steering prose at it would contradict the
-    index block's own report that the path is not indexed. The bare
-    folder form is the shape lint leaves live for an unindexed target.
-    """
-    _make_wiki(tmp_path, folders={'notes': ['meeting']})
+    (tmp_path / 'Makefile').write_text('all:\n', encoding='utf-8')
     # a folder carrying an index on disk that the walk will not enter
     vendor = tmp_path / 'vendor'
     vendor.mkdir()
@@ -1935,27 +1916,29 @@ def test_lint_stale_link_to_unindexed_folder_suggests_bare_form(
         '---\nname: vendored\ndesc: A vendored index.\n---\n\n# vendored\n\n***\n',
         encoding='utf-8',
     )
-    # reference the excluded folder with a folder-relative link
-    meeting = tmp_path / 'notes' / 'meeting.md'
-    meeting.write_text(
-        meeting.read_text(encoding='utf-8').replace(
-            'Content for meeting.',
-            'See [[../vendor]] for context.',
+    _set_exclude_patterns(tmp_path, ['vendor'])
+    name = 'meeting.md' if kind == 'page' else '_index.md'
+    marker = 'Content for meeting.' if kind == 'page' else 'Overview of notes.'
+    page = tmp_path / 'notes' / name
+    page.write_text(
+        page.read_text(encoding='utf-8').replace(
+            marker, f'See [[{link}{anchor}|Here]] for context.'
         ),
         encoding='utf-8',
     )
-    _set_exclude_patterns(tmp_path, ['vendor'])
+    Wiki(tmp_path).update()
+
+    # the issue names the prefix-free spelling; the link never also notes
     wiki = Wiki(tmp_path)
-    # the stale note names the bare folder, not its unmaintained index
     notices = _capture_notices(wiki)
-    assert wiki.lint() == []
-    stale = [
-        event.description
-        for event in notices
-        if 'Stale link [[../vendor]]' in event.description
+    flagged = [issue for issue in wiki.lint() if 'points inside the wiki' in issue]
+    tail = '' if fix is None else f' (use [[{fix}{anchor}|Here]])'
+    assert flagged == [
+        f'notes/{name}: Link [[{link}{anchor}|Here]] points inside the wiki'
+        f" through './' or '../'{tail}"
     ]
-    assert stale
-    assert all('(use [[vendor]])' in note for note in stale)
+    assert flagged[0].kind == 'relative_link'
+    assert not any('Stale link' in event.description for event in notices)
 
 
 @page_index

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -9,6 +9,7 @@ hard-issue vs soft-note split.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import re
 import shutil
@@ -95,6 +96,7 @@ __all__ = [
     'test_lint_directory_link_to_unindexed_folder_is_live',
     'test_lint_flags_folder_shadowing_page',
     'test_lint_accepts_anchor_links',
+    'test_lint_link_probes_never_raise',
 ]
 
 
@@ -2312,3 +2314,69 @@ def test_lint_accepts_anchor_links(tmp_path: pathlib.Path) -> None:
     ]
     assert len(stale) == 1
     assert 'missing' in stale[0]
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason='permission denial needs an unprivileged user'
+)
+@pytest.mark.parametrize(
+    argnames=('surface', 'target'),
+    argvalues=[
+        # a prose target past the filesystem's name length limit
+        ('prose', 'a' * 300),
+        # a prose target under a directory the user cannot search
+        ('prose', '.locked/page'),
+        # a generated row's target past the name length limit
+        ('row', 'a' * 300),
+    ],
+    ids=['prose-long', 'prose-unreadable', 'row-long'],
+)
+def test_lint_link_probes_never_raise(
+    tmp_path: pathlib.Path,
+    surface: str,
+    target: str,
+) -> None:
+    """A link target the filesystem cannot stat reads as missing.
+
+    Link text is authored prose, so a name past the filesystem's length
+    limit or a path under an unreadable directory reaches the probes;
+    each reads as a missing target -- a stale note for prose, a broken
+    link for a generated row -- rather than surfacing the ``OSError``
+    that ``pathlib`` re-raises on interpreters before 3.14.
+    """
+    wiki = _make_wiki(tmp_path, folders={'notes': ['meeting']})
+    locked = tmp_path / '.locked'
+    locked.mkdir()
+    if surface == 'prose':
+        meeting = tmp_path / 'notes' / 'meeting.md'
+        meeting.write_text(
+            meeting.read_text(encoding='utf-8').replace(
+                'Content for meeting.', f'See [[{target}]] now.'
+            ),
+            encoding='utf-8',
+        )
+    else:
+        # inject the row into the root index's generated block
+        root_index = tmp_path / '_index.md'
+        text = root_index.read_text(encoding='utf-8')
+        text = text.replace(
+            '[[notes/_index|notes/]]',
+            f'[[{target}|long]]: ...\n[[notes/_index|notes/]]',
+            1,
+        )
+        root_index.write_text(text, encoding='utf-8')
+    os.chmod(locked, 0o000)
+    try:
+        notices = _capture_notices(wiki)
+        issues = wiki.lint()
+    finally:
+        os.chmod(locked, 0o700)
+    if surface == 'prose':
+        assert issues == []
+        stale = [
+            event.description for event in notices if 'Stale link' in event.description
+        ]
+        assert stale == [f'notes/meeting.md: Stale link [[{target}]]']
+    else:
+        broken = [issue for issue in issues if 'Broken link' in issue]
+        assert broken == [f'_index.md: Broken link [[{target}|long]]']

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -27,6 +27,7 @@ from ._helpers import (
     _git_repo,
     _make_wiki,
     _needs_git,
+    _needs_unprivileged,
     _set_exclude_patterns,
     page_index,
 )
@@ -84,6 +85,7 @@ __all__ = [
     'test_quoted_placeholder_desc_is_soft',
     'test_long_desc_is_note_only',
     'test_lint_relative_prefix_inside_wiki_is_issue',
+    'test_lint_relative_root_link_names_the_index_page',
     'test_lint_directory_link_is_issue_naming_index_form',
     'test_lint_link_rules_spare_samples_not_prose',
     'test_lint_directory_link_keeps_display_text',
@@ -1920,12 +1922,9 @@ def test_lint_relative_prefix_inside_wiki_is_issue(
     name = 'meeting.md' if kind == 'page' else '_index.md'
     marker = 'Content for meeting.' if kind == 'page' else 'Overview of notes.'
     page = tmp_path / 'notes' / name
-    page.write_text(
-        page.read_text(encoding='utf-8').replace(
-            marker, f'See [[{link}{anchor}|Here]] for context.'
-        ),
-        encoding='utf-8',
-    )
+    body = f'See [[{link}{anchor}|Here]] for context.'
+    text = page.read_text(encoding='utf-8').replace(marker, body)
+    page.write_text(text, encoding='utf-8')
     Wiki(tmp_path).update()
 
     # the issue names the prefix-free spelling; the link never also notes
@@ -1939,6 +1938,31 @@ def test_lint_relative_prefix_inside_wiki_is_issue(
     ]
     assert flagged[0].kind == 'relative_link'
     assert not any('Stale link' in event.description for event in notices)
+
+
+def test_lint_relative_root_link_names_the_index_page(tmp_path: pathlib.Path) -> None:
+    """A prefixed link to the wiki root itself is steered to its index page.
+
+    ``[[.]]`` from a root page and ``[[..]]`` from a nested one land on
+    the root, whose fix is ``_index`` -- never the stem of a file beside
+    the wiki that shares the root folder's name.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting']})
+    (tmp_path / 'wiki.md').write_text('x\n', encoding='utf-8')
+    for page, link in (('_index.md', '.'), ('notes/meeting.md', '..')):
+        path = root / page
+        marker = 'Root overview.' if page == '_index.md' else 'Content for meeting.'
+        text = path.read_text(encoding='utf-8').replace(marker, f'See [[{link}]] now.')
+        path.write_text(text, encoding='utf-8')
+
+    issues = Wiki(root).lint()
+    assert sorted(issues) == [
+        "_index.md: Link [[.]] points inside the wiki through './' or '../'"
+        ' (use [[_index]])',
+        "notes/meeting.md: Link [[..]] points inside the wiki through './' or '../'"
+        ' (use [[_index]])',
+    ]
 
 
 @page_index
@@ -2299,9 +2323,7 @@ def test_lint_accepts_anchor_links(tmp_path: pathlib.Path) -> None:
     assert 'missing' in stale[0]
 
 
-@pytest.mark.skipif(
-    os.geteuid() == 0, reason='permission denial needs an unprivileged user'
-)
+@_needs_unprivileged
 @pytest.mark.parametrize(
     argnames=('surface', 'target'),
     argvalues=[
@@ -2332,12 +2354,9 @@ def test_lint_link_probes_never_raise(
     locked.mkdir()
     if surface == 'prose':
         meeting = tmp_path / 'notes' / 'meeting.md'
-        meeting.write_text(
-            meeting.read_text(encoding='utf-8').replace(
-                'Content for meeting.', f'See [[{target}]] now.'
-            ),
-            encoding='utf-8',
-        )
+        body = f'See [[{target}]] now.'
+        text = meeting.read_text(encoding='utf-8').replace('Content for meeting.', body)
+        meeting.write_text(text, encoding='utf-8')
     else:
         # inject the row into the root index's generated block
         root_index = tmp_path / '_index.md'

--- a/tests/test_core/test_lint.py
+++ b/tests/test_core/test_lint.py
@@ -29,6 +29,7 @@ from ._helpers import (
     _needs_git,
     _needs_unprivileged,
     _set_exclude_patterns,
+    bare_anchored,
     page_index,
 )
 
@@ -86,6 +87,9 @@ __all__ = [
     'test_long_desc_is_note_only',
     'test_lint_relative_prefix_inside_wiki_is_issue',
     'test_lint_relative_root_link_names_the_index_page',
+    'test_lint_relative_root_link_steers_to_index_before_update',
+    'test_lint_link_text_ignores_padding_and_a_stray_bracket',
+    'test_lint_stale_prefix_free_link_names_a_raw_file',
     'test_lint_directory_link_is_issue_naming_index_form',
     'test_lint_link_rules_spare_samples_not_prose',
     'test_lint_directory_link_keeps_display_text',
@@ -281,9 +285,8 @@ def test_lint_issues_are_typed(tmp_path: pathlib.Path) -> None:
         '---\nname: malformed\ndesc: A page.\n\n# malformed\n\nBody.\n',
         encoding='utf-8',
     )
-    # a period-less desc, an unparseable stamp, both wrap mangles, a
-    # directory link, a relative link, and a dangling region marker on
-    # one messy page
+    # a period-less desc, an unparseable stamp, both wrap mangles, a directory
+    # link, a relative link, and a dangling region marker on one messy page
     (tmp_path / 'data' / 'messy.md').write_text(
         '---\nname: messy\ndesc: No trailing period\n'
         'created: not-a-stamp\n---\n\n# messy\n\n'
@@ -1853,12 +1856,14 @@ def test_long_desc_is_note_only(tmp_path: pathlib.Path) -> None:
 
 
 @page_index
-@pytest.mark.parametrize('anchor', ['', '#context'], ids=['bare', 'anchored'])
+@bare_anchored
 @pytest.mark.parametrize(
     argnames=('link', 'fix'),
     argvalues=[
         # the root page, written as if relative to the page's folder
         ('../overview', 'overview'),
+        # a root page missed through './', named from the root
+        ('./overview', 'overview'),
         # a sibling page through './'
         ('./sibling', 'notes/sibling'),
         # an indexed folder: the fix is its index page
@@ -1871,17 +1876,21 @@ def test_long_desc_is_note_only(tmp_path: pathlib.Path) -> None:
         ('..', '_index'),
         # an interior '..' segment reads the same way
         ('sibling/../sibling', 'notes/sibling'),
+        # a folder the walk reaches whose index is not minted yet
+        ('../drafts', 'drafts/_index'),
         # nothing exists there: the issue stands without a fix
         ('./gone', None),
     ],
     ids=[
         'page',
+        'dot-root-page',
         'dot-sibling',
         'indexed-folder',
         'excluded-folder',
         'raw-file',
         'root',
         'interior',
+        'unminted-folder',
         'missing',
     ],
 )
@@ -1898,9 +1907,11 @@ def test_lint_relative_prefix_inside_wiki_is_issue(
     markdown read it, and means "outside the wiki"; one that resolves
     inside is written wrong, so lint fails it and names the prefix-free
     form -- a page by stem, an indexed folder's ``_index`` page, an
-    excluded folder's bare form, a raw file's path -- with the anchor and
-    alias riding along, and no fix when nothing exists there. The link is
-    never also noted as stale.
+    excluded folder's bare form, a raw file's path, or the page the text
+    names when read from the root -- with the anchor and alias riding
+    along, and no fix when nothing exists either way. The link
+    reports once however often the prose repeats it, and is never also
+    noted as stale.
     """
     _make_wiki(
         tmp_path,
@@ -1922,10 +1933,12 @@ def test_lint_relative_prefix_inside_wiki_is_issue(
     name = 'meeting.md' if kind == 'page' else '_index.md'
     marker = 'Content for meeting.' if kind == 'page' else 'Overview of notes.'
     page = tmp_path / 'notes' / name
-    body = f'See [[{link}{anchor}|Here]] for context.'
+    body = f'See [[{link}{anchor}|Here]] and [[{link}{anchor}|Here]] again.'
     text = page.read_text(encoding='utf-8').replace(marker, body)
     page.write_text(text, encoding='utf-8')
     Wiki(tmp_path).update()
+    # a folder created after the update, its index not minted yet
+    (tmp_path / 'drafts').mkdir()
 
     # the issue names the prefix-free spelling; the link never also notes
     wiki = Wiki(tmp_path)
@@ -1945,23 +1958,132 @@ def test_lint_relative_root_link_names_the_index_page(tmp_path: pathlib.Path) ->
 
     ``[[.]]`` from a root page and ``[[..]]`` from a nested one land on
     the root, whose fix is ``_index`` -- never the stem of a file beside
-    the wiki that shares the root folder's name.
+    the wiki that shares the root folder's name; a link re-entering the
+    wiki through that folder name (``[[../wiki/overview]]``) is steered to
+    the prefix-free page.
     """
     root = tmp_path / 'wiki'
     _make_wiki(root, folders={'notes': ['meeting']})
     (tmp_path / 'wiki.md').write_text('x\n', encoding='utf-8')
-    for page, link in (('_index.md', '.'), ('notes/meeting.md', '..')):
+    (root / 'overview.md').write_text(
+        '---\nname: overview\ndesc: An overview.\n---\n\n# overview\n\nText.\n',
+        encoding='utf-8',
+    )
+    Wiki(root).update()
+    links = {
+        '_index.md': 'See [[.]] and [[../wiki/overview]] now.',
+        'notes/meeting.md': 'See [[..]] now.',
+    }
+    for page, body in links.items():
         path = root / page
         marker = 'Root overview.' if page == '_index.md' else 'Content for meeting.'
-        text = path.read_text(encoding='utf-8').replace(marker, f'See [[{link}]] now.')
+        text = path.read_text(encoding='utf-8').replace(marker, body)
         path.write_text(text, encoding='utf-8')
 
+    # the root links are steered to the index page; the re-entry to the page it names
     issues = Wiki(root).lint()
-    assert sorted(issues) == [
+    expected = [
         "_index.md: Link [[.]] points inside the wiki through './' or '../'"
         ' (use [[_index]])',
+        "_index.md: Link [[../wiki/overview]] points inside the wiki through './' or"
+        " '../' (use [[overview]])",
         "notes/meeting.md: Link [[..]] points inside the wiki through './' or '../'"
         ' (use [[_index]])',
+    ]
+    assert sorted(issues) == sorted(expected)
+
+
+def test_lint_relative_root_link_steers_to_index_before_update(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The root's fix is its index page even while that page is missing.
+
+    A root whose ``_index.md`` has not been minted yet still links by it;
+    the bare ``.`` form would be the relative-link issue itself.
+    """
+    root = tmp_path / 'wiki'
+    _make_wiki(root, folders={'notes': ['meeting']})
+    (root / '_index.md').unlink()
+    page = root / 'notes' / 'meeting.md'
+    text = page.read_text(encoding='utf-8').replace(
+        'Content for meeting.', 'See [[..]].'
+    )
+    page.write_text(text, encoding='utf-8')
+
+    issues = [issue for issue in Wiki(root).lint() if 'points inside the wiki' in issue]
+    assert issues == [
+        "notes/meeting.md: Link [[..]] points inside the wiki through './' or '../'"
+        ' (use [[_index]])'
+    ]
+
+
+@pytest.mark.parametrize(
+    argnames=('text', 'stale'),
+    argvalues=[
+        ('[[ overview ]]', []),
+        ('[[overview\t]]', []),
+        ('[[[overview]]', []),
+        ('[[overview\n]]', ['notes/meeting.md: Stale link [[overview\n]]']),
+        ('[[ ]]', []),
+    ],
+    ids=['spaces', 'tab', 'stray-bracket', 'line-break', 'blank'],
+)
+def test_lint_link_text_ignores_padding_and_a_stray_bracket(
+    tmp_path: pathlib.Path,
+    text: str,
+    stale: list[str],
+) -> None:
+    """Spaces, tabs, and a stray bracket around a target are not part of it.
+
+    ``[[ overview ]]`` and ``[[[overview]]`` link the root page; a link
+    broken across a line break is still the text as written, and stale;
+    a target of only spaces is no link at all, as ``[[]]`` never was.
+    """
+    _make_wiki(tmp_path, folders={'notes': ['meeting']})
+    (tmp_path / 'overview.md').write_text(
+        '---\nname: overview\ndesc: An overview.\n---\n\n# overview\n\nText.\n',
+        encoding='utf-8',
+    )
+    Wiki(tmp_path).update()
+    page = tmp_path / 'notes' / 'meeting.md'
+    body = page.read_text(encoding='utf-8').replace('Content for meeting.', text)
+    page.write_text(body, encoding='utf-8')
+    wiki = Wiki(tmp_path)
+
+    # the padded spellings are live; the broken one notes stale
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    notes = [
+        event.description for event in notices if 'Stale link' in event.description
+    ]
+    assert notes == stale
+
+
+def test_lint_stale_prefix_free_link_names_a_raw_file(tmp_path: pathlib.Path) -> None:
+    """A prefix-free miss that names a raw file beside the page is steered to it.
+
+    ``[[data.csv]]`` from ``notes/meeting.md`` reads from the wiki root,
+    where nothing exists; read from the page's folder it lands on a real
+    file, so the stale note names that file's root-relative spelling, as
+    it does for a page.
+    """
+    _make_wiki(tmp_path, folders={'notes': ['meeting']})
+    (tmp_path / 'notes' / 'data.csv').write_text('a,b\n', encoding='utf-8')
+    Wiki(tmp_path).update()
+    page = tmp_path / 'notes' / 'meeting.md'
+    body = 'See [[data.csv]] now.'
+    text = page.read_text(encoding='utf-8').replace('Content for meeting.', body)
+    page.write_text(text, encoding='utf-8')
+    wiki = Wiki(tmp_path)
+
+    # the note names the raw file's root-relative spelling
+    notices = _capture_notices(wiki)
+    assert wiki.lint() == []
+    notes = [
+        event.description for event in notices if 'Stale link' in event.description
+    ]
+    assert notes == [
+        'notes/meeting.md: Stale link [[data.csv]] (use [[notes/data.csv]])'
     ]
 
 
@@ -2373,6 +2495,7 @@ def test_lint_link_probes_never_raise(
         issues = wiki.lint()
     finally:
         os.chmod(locked, 0o700)
+    # a prose target draws a stale note; a generated row is a broken link
     if surface == 'prose':
         assert issues == []
         stale = [

--- a/tests/test_core/test_wiki.py
+++ b/tests/test_core/test_wiki.py
@@ -204,6 +204,7 @@ def test_init_seeds_custom_settings(tmp_path: pathlib.Path) -> None:
         {'titles': {'required': 'yes'}},
         {'map': {'desc_limit': 'wide'}},
         {'exclude': {'patterns': ['!vendor']}},
+        {'links': {'external': ['src']}},
     ],
     ids=[
         'bad-naming',
@@ -211,6 +212,7 @@ def test_init_seeds_custom_settings(tmp_path: pathlib.Path) -> None:
         'bad-titles',
         'bad-map',
         'bad-exclude',
+        'bad-links',
     ],
 )
 def test_init_rejects_bad_settings_before_writing(

--- a/tests/test_core/test_wiki.py
+++ b/tests/test_core/test_wiki.py
@@ -274,6 +274,7 @@ def test_init_refuses_conflict_markers(tmp_path: pathlib.Path) -> None:
     argnames=('content', 'match'),
     argvalues=[
         ('{bad json', r'Malformed JSON'),
+        ('{"a": ' + '[' * 1_000_000 + ']' * 1_000_000 + '}', r'Malformed JSON'),
         ('[]', r'must be a JSON object'),
         ('{"naming": "strict"}', r'naming block must be a JSON object'),
         ('{"naming": {"validate": "identifier"}}', r'validate must be a list'),
@@ -292,6 +293,7 @@ def test_init_refuses_conflict_markers(tmp_path: pathlib.Path) -> None:
     ],
     ids=[
         'malformed-json',
+        'nested-past-recursion-limit',
         'non-object-top-level',
         'non-object-naming',
         'non-list-validate',

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -5371,7 +5371,7 @@ class Wiki:
         # directives are comments and would not survive it
         stripped = wiki.util.markdown.mask_comments(stripped)
         stripped = wiki.util.markdown.mask_indented_code(stripped)
-        for match in re.finditer(r'\[\[([^\]\[|]+)(?:\|([^\]]*))?', stripped):
+        for match in re.finditer(r'\[\[([^\]|]+)(?:\|([^\]]*))?', stripped):
             # the masked scan preserves line structure, so the match
             # offset maps straight to its source line
             lineno = stripped.count('\n', 0, match.start()) + 1
@@ -5390,6 +5390,15 @@ class Wiki:
             page_target, hash_sign, heading = target.strip(' \t').partition('#')
             anchor = hash_sign + heading
             if not page_target:
+                continue
+            # a target carrying '[' is junk no name can carry (a stray bracket,
+            # or one swallowed from the text): never live, never read from the
+            # page's folder, so the stale note quotes it as written
+            if '[' in page_target:
+                if target in reported:
+                    continue
+                reported.add(target)
+                self.on_link_stale(path=str(relpath), target=target + alias)
                 continue
             # a './' or '../' target is read from the page's folder, as
             # Obsidian and markdown read it, and must leave the wiki; a

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -117,9 +117,9 @@ class Wiki:
         #: instance out -- typed notes a machine consumer (``lint --json``)
         #: folds into its report beside the engine's own
         self.resolver_notices: list[Event] = []
-        # the wikis links.external folders admit, constructed once per
-        # instance as targets under them come up in the link scan
-        self._link_wikis: dict[pathlib.Path, Wiki] = {}
+        # the verdict on each folder the link scan has climbed through: the
+        # wiki rooted there, or None for a plain folder, judged once per instance
+        self._link_wikis: dict[pathlib.Path, Optional[Wiki]] = {}
 
     @functools.cached_property
     def _root_name(self: Wiki) -> str:
@@ -463,11 +463,9 @@ class Wiki:
                 f' {external!r} in {WIKI_SETTINGS}.'
             )
         # contain each folder lexically, keeping its text as written so a
-        # note names its cause; the grammar mirrors exclude.patterns (one
-        # trailing '/' stripped, '/' the separator, no '.' segments) except
-        # that leading '..' segments are the point -- a folder inside the
-        # root needs no allowlist -- and no entry may name the whole
-        # filesystem or reach the root through an alias
+        # note names its cause; the segment grammar mirrors exclude.patterns,
+        # except that leading '..' segments are the point (a folder inside the
+        # root needs no allowlist)
         result = []
         for folder in external:
             if not isinstance(folder, str):
@@ -506,7 +504,7 @@ class Wiki:
             elif joined.is_relative_to(self._root):
                 reason = 'inside the wiki root (in-wiki links need no allowlist)'
             elif pathlib.Path(os.path.realpath(joined)).is_relative_to(self._root):
-                reason = 'aliases the wiki root'
+                reason = 'resolves inside the wiki root through an alias'
             else:
                 reason = None
             if reason is not None:
@@ -1365,8 +1363,7 @@ class Wiki:
         suppresses the positional rules (conflict markers, escaped
         wikilinks, wrap mangles, stale, outside, directory, and relative
         links) for the lines it wraps; file-level checks ignore regions,
-        and a nested or
-        dangling region marker is itself a hard issue.
+        and a nested or dangling region marker is itself a hard issue.
 
         Placeholder and oversized descriptions, empty content sections,
         stale links in user content (index bodies and pages -- the
@@ -3203,13 +3200,23 @@ class Wiki:
     def _is_link_wiki_root(self: Wiki, path: pathlib.Path) -> bool:
         """Return ``True`` if ``path`` holds another wiki's settings marker.
 
-        The home directory and the config home are exempt, as the CLI's
-        root resolution exempts them: the trust store lives at
+        The home directory and the config home are exempt, the two
+        exemptions of the CLI's ``_is_wiki_root`` (``wiki/cli/utils.py``;
+        keep the pair in lockstep): the trust store lives at
         ``~/.wiki/settings.json`` (or under ``WIKI_CONFIG_DIR``), so a
         home that read as a root would answer for every folder beneath
         it.
         """
-        if path.resolve() == pathlib.Path.home().resolve():
+        # a path no filesystem can hold (an embedded NUL) is no wiki root:
+        # resolve raises where the os.path probes return False
+        try:
+            resolved = path.resolve()
+        except ValueError:
+            return False
+        # compare resolved on both sides: an unresolved home or config home
+        # under a symlink would never match and the trust store would read
+        # as a wiki root
+        if resolved == pathlib.Path.home().resolve():
             return False
         override = os.environ.get(WIKI_CONFIG_DIR)
         if override:
@@ -3223,35 +3230,67 @@ class Wiki:
     def _link_wiki(
         self: Wiki,
         path: pathlib.Path,
-        folder: pathlib.Path,
     ) -> Optional[tuple[pathlib.Path, Wiki]]:
-        """Return the wiki enclosing external ``path`` under ``folder``, or ``None``.
+        """Return the wiki enclosing external ``path``, or ``None``.
 
         The root is the nearest ancestor holding the settings marker, as
         the CLI resolves any root; nested wikis are refused everywhere, so
-        the first marker up the chain is the root, and the walk stops at
-        the allowlisted ``folder`` -- an entry inside a wiki admits its
-        files as plain files. The instance is the plain class (a hook
-        loads only through the CLI's trust check), constructed once per
-        instance, and its settings are read as the host's are: a
-        malformed block fails the run naming the wiki. Returns the
-        marker's folder beside the instance, whose own root is resolved.
+        the first marker up the chain is the root, and the walk runs to
+        the filesystem root -- an entry inside a wiki still hands its
+        files to that wiki's rules. The instance is the plain class (a
+        hook loads only through the CLI's trust check), and its notices
+        ride the host's funnel. Returns the marker's folder beside the
+        instance, whose own root is resolved.
         """
         for ancestor in (path, *path.parents):
-            if self._is_link_wiki_root(ancestor):
-                if ancestor not in self._link_wikis:
+            # judge each folder once per instance: the wiki rooted there, or
+            # None for a plain folder
+            if ancestor not in self._link_wikis:
+                guest = None
+                if self._is_link_wiki_root(ancestor):
+                    # the guest's notices (its gitignore fence, say) ride the
+                    # host's funnel, where a capturing host sees them
                     guest = Wiki(ancestor)
+                    guest.on_notice = self.on_notice
+                    # read the guest's settings as the host's: a malformed or
+                    # unreadable block fails the run naming the wiki
                     try:
                         guest._exclude_policy  # noqa: B018
-                    except ValueError as e:
+                    except (OSError, ValueError) as e:
                         relative = os.path.relpath(ancestor, self._root)
                         raise ValueError(
                             f'links.external wiki {relative!r}: {e}'
                         ) from e
-                    self._link_wikis[ancestor] = guest
-                return ancestor, self._link_wikis[ancestor]
-            if ancestor == folder:
-                return None
+                self._link_wikis[ancestor] = guest
+            guest = self._link_wikis[ancestor]
+            if guest is not None:
+                return ancestor, guest
+        return None
+
+    def _external_index_target(
+        self: Wiki,
+        joined: pathlib.Path,
+        page: pathlib.Path,
+    ) -> Optional[str]:
+        """Return the ``_index`` form of a folder another wiki indexes, or ``None``.
+
+        ``joined`` is an external target read from ``page``'s folder; when
+        the wiki enclosing it indexes that folder -- judged by the instance
+        built from that wiki's settings, exclusions included -- the folder
+        is the directory link there as at home, and the fix is its index
+        page spelled from ``page``'s folder, the base the link reads from.
+        """
+        guest = self._link_wiki(joined)
+        if guest is None:
+            return None
+        guest_root, guest_wiki = guest
+        index_path = joined / WIKI_INDEX
+        # re-root onto the guest's resolved root, the base its probes contain
+        # against, while joined keeps the lexical text the link wrote
+        inner = guest_wiki._root / joined.relative_to(guest_root)
+        if os.path.isfile(index_path) and guest_wiki._is_indexed_dir(inner):
+            index_target = pathlib.Path(os.path.relpath(index_path, page.parent))
+            return index_target.with_suffix('').as_posix()
         return None
 
     def _external_spelling(
@@ -3265,18 +3304,29 @@ class Wiki:
         absolute target; when it lands under an allowlisted folder present
         on this machine and names a real file, page, or folder there, the
         fix is the same path spelled from ``page``'s folder, the form the
-        scan reads. ``None`` otherwise: a target that reaches nothing has
-        no fix to suggest.
+        scan reads -- a folder another wiki indexes by its index page, the
+        directory-link rule's fix. ``None`` otherwise: a target that
+        reaches nothing has no fix to suggest.
         """
         if reading.is_relative_to(self._root):
             return None
         folder = self._external_folder(reading)
         if (folder is None) or not os.path.isdir(folder):
             return None
+        # the ladder the scan reads by: a page by stem, a folder another wiki
+        # indexes by its index page there, then the literal file or folder;
+        # the page form is spelled through the parent, since with_name refuses
+        # the filesystem root a chain of '..' can reach
         page_form = reading.parent / (reading.name + '.md')
-        if not (os.path.exists(page_form) or os.path.exists(reading)):
-            return None
-        return pathlib.Path(os.path.relpath(reading, page.parent)).as_posix()
+        spelling = pathlib.Path(os.path.relpath(reading, page.parent))
+        if os.path.exists(page_form):
+            return spelling.as_posix()
+        index_target = self._external_index_target(reading, page)
+        if index_target is not None:
+            return index_target
+        if os.path.exists(reading):
+            return spelling.as_posix()
+        return None
 
     def _is_symlink_skipped(self: Wiki, target: str) -> bool:
         """Return ``True`` if link ``target`` names a symlinked file on disk.
@@ -5154,8 +5204,15 @@ class Wiki:
         exists there (an unresolvable target has no fix to suggest). The
         probes go through ``os.path``, as the link scan's do.
         """
-        if os.path.exists(resolved.with_name(resolved.name + '.md')):
+        # only suggest a target that actually exists (as a page, folder, or
+        # file); the root's stem would name a file beside the wiki, so the
+        # root reads as its index page below
+        page_form = resolved.with_name(resolved.name + '.md')
+        if (resolved != self._root) and os.path.exists(page_form):
             return resolved.relative_to(self._root).as_posix()
+        # a folder the walk indexes canonicalizes to its index page -- the
+        # bare folder form is the directory-link hard issue -- while an
+        # unindexed folder keeps the bare form, the shape lint leaves live
         if os.path.isfile(resolved / WIKI_INDEX) and self._is_indexed_dir(resolved):
             index_target = resolved / WIKI_INDEX
             return index_target.relative_to(self._root).with_suffix('').as_posix()
@@ -5190,38 +5247,23 @@ class Wiki:
         """Check wikilinks in content; return the hard issues.
 
         Two spellings, one rule each: a prefix-free target is read from
-        the wiki root and must name something inside it; a target with a
-        ``.`` or ``..`` segment is read from the page's folder, as
-        Obsidian and markdown read it, and must leave the wiki -- one
-        that lands inside is a hard issue naming the prefix-free form
-        (and the file the text reaches when read from the root, if an
-        allowlisted one exists there). A directory link -- a target
-        naming a folder rather than the folder's index page -- renders
-        but resolves to nothing when followed, so it is a hard issue
-        naming the ``/_index`` form as the fix; only a folder a walk
-        reaches qualifies -- this wiki's, or that of another wiki a
-        ``links.external`` folder admits, judged by its own settings --
-        since a dot-prefixed, symlinked, or ``exclude.patterns`` segment
-        keeps its whole subtree out of the index. Outside the wiki a
-        target is live under an allowlisted folder present on this
-        machine when the file, its ``.md`` form, or the folder exists; a
-        target under an entry naming no folder here is left to the
-        run-level note; a real file under no allowlisted folder is a soft
-        note naming the entry to add (``on_link_outside``). A stale link
-        in user content is a soft note (``on_link_stale``), not an issue:
-        prose references pages that come and go, and the generated index
-        link block's broken-link check is the hard surface; the note
-        names the fix when a reading resolves -- the page-relative
-        spelling of an allowlisted file a prefixed or absolute target
-        missed, or the root-relative form a prefix-free target's
-        folder-relative reading names. Either way a target reports once
-        per file, and a link's display text rides into the suggested fix
-        so the replacement keeps its label. Wikilinks in a code sample --
-        fenced, inline, or four-space indented -- and in an HTML comment
-        are not links to follow, so no rule sees them. Lines inside a
-        well-formed ``no-lint`` region are exempt too; the region is
-        parsed from the scanned content itself, so the region must wrap
-        the link lines.
+        the wiki root and must name something inside it; a ``./`` or
+        ``../`` target is read from the page's folder, as Obsidian and
+        markdown read it, and must leave the wiki -- one that lands inside
+        is a hard issue naming the prefix-free form. A directory link (a
+        target naming an indexed folder rather than its ``_index`` page)
+        is a hard issue naming the ``/_index`` form, in this wiki or in an
+        allowlisted wiki judged by its own settings. Outside the wiki a
+        target is live under a present ``links.external`` folder when the
+        file, its ``.md`` form, or the folder exists; under an absent
+        entry it is left to the run-level note; a real file under no
+        entry draws the outside note (``on_link_outside``). A stale link
+        is a soft note (``on_link_stale``) -- the generated link block's
+        broken-link check is the hard surface -- naming the spelling that
+        would resolve when one does. A target reports once per file with
+        its display text riding into the fix; code samples, HTML comments,
+        and well-formed ``no-lint`` regions (parsed from this content) are
+        exempt from every rule.
         """
         # initialize issues and the targets already reported for this file:
         # the scan is content-local, so a repeat of a target carries no line
@@ -5262,17 +5304,21 @@ class Wiki:
                 continue
             # a './' or '../' target is read from the page's folder, as
             # Obsidian and markdown read it, and must leave the wiki; a
-            # prefix-free target is read from the root and must stay inside
+            # prefix-free target is read from the root and must stay inside;
+            # an absolute target is read as written
+            absolute = os.path.isabs(page_target)
             segments = page_target.split('/')
-            prefixed = ('.' in segments) or ('..' in segments)
+            prefixed = (not absolute) and (('.' in segments) or ('..' in segments))
             base = path.parent if prefixed else self._root
             joined = pathlib.Path(os.path.normpath(base / page_target))
+            # the page form is spelled through the parent: with_name refuses
+            # the filesystem root, which a chain of '..' can reach
+            page_form = joined.parent / (joined.name + '.md')
             if joined.is_relative_to(self._root):
-                # a prefixed target landing inside the wiki is a hard issue:
-                # the in-wiki form is prefix-free, the one spelling every
-                # reader resolves from the root, so name it -- and the file
-                # outside the wiki the text reaches when read from the root,
-                # if an allowlisted one exists
+                # a prefixed target landing inside the wiki is a hard issue naming
+                # the prefix-free form (the one spelling every reader resolves from
+                # the root) and the allowlisted file the text reaches when read
+                # from the root, if any
                 if prefixed:
                     if target in reported:
                         continue
@@ -5288,7 +5334,8 @@ class Wiki:
                             f'[[{external}{anchor}{alias}]] for the file outside'
                             ' the wiki'
                         )
-                    fix = f' (use {", or ".join(fixes)})' if fixes else ''
+                    options = ', or '.join(fixes)
+                    fix = f' (use {options})' if fixes else ''
                     fields = {'path': str(relpath), 'target': target}
                     if canonical is not None:
                         fields['canonical'] = canonical + anchor
@@ -5334,22 +5381,30 @@ class Wiki:
                     continue
                 if os.path.exists(self._root / page_target):
                     continue
-            elif not os.path.isabs(page_target):
+            elif not absolute:
                 folder = self._external_folder(joined)
                 if folder is None:
                     # a real file under no allowlisted folder: name the entry
                     # that would admit it rather than call the link stale
-                    page_form = joined.parent / (joined.name + '.md')
-                    if os.path.exists(page_form) or os.path.exists(joined):
+                    present = os.path.exists(page_form) or os.path.exists(joined)
+                    # the entry is the target when it is itself a folder, else
+                    # the folder holding it; a '..' chain clamped at the
+                    # filesystem root names an entry the policy refuses, and
+                    # that link stays stale
+                    if os.path.isdir(joined):
+                        holder = joined
+                    else:
+                        holder = joined.parent
+                    if present and (holder.parent != holder):
                         if target in reported:
                             continue
                         reported.add(target)
-                        holder = joined if os.path.isdir(joined) else joined.parent
                         entry = pathlib.Path(os.path.relpath(holder, self._root))
+                        entry = entry.as_posix()
                         self.on_link_outside(
                             path=str(relpath),
                             target=target + alias,
-                            folder=entry.as_posix(),
+                            folder=entry,
                         )
                         continue
                 elif not os.path.isdir(folder):
@@ -5358,49 +5413,36 @@ class Wiki:
                     continue
                 else:
                     # a page by stem is live wherever it lies
-                    if os.path.exists(joined.parent / (joined.name + '.md')):
+                    if os.path.exists(page_form):
                         continue
                     # inside another wiki its own rules apply, exclusions
-                    # included: a folder that wiki indexes is the directory
-                    # link, judged by the instance built from its settings
-                    guest = self._link_wiki(joined, folder)
-                    if guest is not None:
-                        guest_root, guest_wiki = guest
-                        index_path = joined / WIKI_INDEX
-                        inner = guest_wiki._root / joined.relative_to(guest_root)
-                        if os.path.isfile(index_path) and guest_wiki._is_indexed_dir(
-                            inner
-                        ):
-                            if target in reported:
-                                continue
-                            reported.add(target)
-                            index_target = pathlib.Path(
-                                os.path.relpath(index_path, path.parent)
-                            )
-                            index_target = index_target.with_suffix('').as_posix()
-                            result.append(
-                                Issue(
-                                    f'{relpath}: Link [[{target}{alias}]] targets a'
-                                    ' folder, not a page'
-                                    f' (use [[{index_target}{anchor}{alias}]])',
-                                    kind='directory_link',
-                                    path=str(relpath),
-                                    target=target,
-                                    canonical=index_target + anchor,
-                                )
-                            )
+                    # included: a folder that wiki indexes is the directory link
+                    index_target = self._external_index_target(joined, path)
+                    if index_target is not None:
+                        if target in reported:
                             continue
+                        reported.add(target)
+                        result.append(
+                            Issue(
+                                f'{relpath}: Link [[{target}{alias}]] targets a'
+                                ' folder, not a page'
+                                f' (use [[{index_target}{anchor}{alias}]])',
+                                kind='directory_link',
+                                path=str(relpath),
+                                target=target,
+                                canonical=index_target + anchor,
+                            )
+                        )
+                        continue
                     # the literal file or folder is there
                     if os.path.exists(joined):
                         continue
             if target in reported:
                 continue
             reported.add(target)
-            # name the fix when a reading resolves: a prefixed or absolute
-            # target read from the wiki root that lands on an allowlisted file
-            # gets its page-relative spelling; a prefix-free miss keeps the
-            # root-relative form of its folder-relative reading
-            if os.path.isabs(page_target):
+            # name the fix when a reading resolves: the page-relative spelling
+            # of an allowlisted file the text missed, else the root-relative form
+            if absolute:
                 canonical = self._external_spelling(joined, path)
             elif prefixed:
                 reading = pathlib.Path(os.path.normpath(self._root / page_target))

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -3043,7 +3043,8 @@ class Wiki:
             probe = pathlib.Path(joined)
             if not probe.is_relative_to(self._root):
                 continue
-            if probe.is_symlink():
+            # os.path reads an unstat-able target as missing (see the scan)
+            if os.path.islink(joined):
                 return True
         return False
 
@@ -3066,7 +3067,8 @@ class Wiki:
             probe = pathlib.Path(joined)
             if not probe.is_relative_to(self._root):
                 continue
-            if not probe.exists():
+            # os.path reads an unstat-able target as missing (see the scan)
+            if not os.path.exists(joined):
                 continue
             if pattern := self._excluded_by(probe):
                 return pattern
@@ -3090,7 +3092,8 @@ class Wiki:
             probe = pathlib.Path(joined)
             if not probe.is_relative_to(self._root):
                 continue
-            if not probe.exists():
+            # os.path reads an unstat-able target as missing (see the scan)
+            if not os.path.exists(joined):
                 continue
             if self._is_gitignored(probe):
                 return True
@@ -4909,16 +4912,17 @@ class Wiki:
         resolved = pathlib.Path(joined)
         if not resolved.is_relative_to(self._root):
             return None
-        # only suggest a target that actually exists (as a page or folder)
-        if resolved.with_name(resolved.name + '.md').exists():
+        # only suggest a target that actually exists (as a page or folder);
+        # os.path stats read an unstat-able path as missing, as the scan does
+        if os.path.exists(resolved.with_name(resolved.name + '.md')):
             return resolved.relative_to(self._root).as_posix()
         # a folder the walk indexes canonicalizes to its index page -- the
         # bare folder form is the directory-link hard issue -- while an
         # unindexed folder keeps the bare form, the shape lint leaves live
-        if (resolved / WIKI_INDEX).is_file() and self._is_indexed_dir(resolved):
+        if os.path.isfile(resolved / WIKI_INDEX) and self._is_indexed_dir(resolved):
             index_target = resolved / WIKI_INDEX
             return index_target.relative_to(self._root).with_suffix('').as_posix()
-        if resolved.is_dir():
+        if os.path.isdir(resolved):
             return resolved.relative_to(self._root).as_posix()
         return None
 
@@ -4987,14 +4991,18 @@ class Wiki:
             # root ('..' segments) is stale even when a file exists above it
             joined = pathlib.Path(os.path.normpath(self._root / page_target))
             if joined.is_relative_to(self._root):
-                if (self._root / (page_target + '.md')).exists():
+                # probe through os.path: a link target is authored text, so a
+                # path the filesystem cannot stat (a name past its length
+                # limit, an unreadable directory) is a missing target, never
+                # a crash -- pathlib re-raises those errors before 3.14
+                if os.path.exists(self._root / (page_target + '.md')):
                     continue
                 # a directory link names the folder, not the folder's index
                 # page a follow would need -- a hard issue naming the fix,
                 # scoped to folders the walk reaches: an unindexed subtree
                 # has no maintained index to steer prose at
                 index_path = joined / WIKI_INDEX
-                if index_path.is_file() and self._is_indexed_dir(joined):
+                if os.path.isfile(index_path) and self._is_indexed_dir(joined):
                     if target in reported:
                         continue
                     reported.add(target)
@@ -5012,7 +5020,7 @@ class Wiki:
                         )
                     )
                     continue
-                if (self._root / page_target).exists():
+                if os.path.exists(self._root / page_target):
                     continue
             if target in reported:
                 continue

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -23,6 +23,7 @@ import wiki.util
 from wiki.constants import (
     OFFLINE_MODE,
     WIKI_CACHE,
+    WIKI_CONFIG_DIR,
     WIKI_DIR,
     WIKI_INDEX,
     WIKI_SETTINGS,
@@ -116,6 +117,9 @@ class Wiki:
         #: instance out -- typed notes a machine consumer (``lint --json``)
         #: folds into its report beside the engine's own
         self.resolver_notices: list[Event] = []
+        # the wikis links.external folders admit, constructed once per
+        # instance as targets under them come up in the link scan
+        self._link_wikis: dict[pathlib.Path, Wiki] = {}
 
     @functools.cached_property
     def _root_name(self: Wiki) -> str:
@@ -1346,26 +1350,34 @@ class Wiki:
           pattern, and one the enclosing repo's gitignore fences is
           named as gitignored), directory links in user content (a
           wikilink target naming a folder rather than the folder's
-          ``_index`` page, flagged with the ``/_index`` form as the
-          fix), and -- under ``titles.required`` -- a missing or
-          unfilled ``title:``.
+          ``_index`` page -- in this wiki, or in another wiki a
+          ``links.external`` folder admits, judged by that wiki's own
+          settings -- flagged with the ``/_index`` form as the fix),
+          relative links inside the wiki (a ``./`` or ``../`` target,
+          read from the page's folder, that lands inside the wiki;
+          flagged with the prefix-free form as the fix), and -- under
+          ``titles.required`` -- a missing or unfilled ``title:``.
 
         Every line begins with the relevant path; an out-of-date file's
         diff follows its ``Requires update`` header, indented.
 
         A ``<!-- start: no-lint -->`` ... ``<!-- end: no-lint -->`` region
         suppresses the positional rules (conflict markers, escaped
-        wikilinks, wrap mangles, stale and directory links) for the lines
-        it wraps; file-level checks ignore regions, and a nested or
+        wikilinks, wrap mangles, stale, outside, directory, and relative
+        links) for the lines it wraps; file-level checks ignore regions,
+        and a nested or
         dangling region marker is itself a hard issue.
 
         Placeholder and oversized descriptions, empty content sections,
         stale links in user content (index bodies and pages -- the
-        generated link block's broken-link check is the hard surface),
-        a ``links.external`` entry naming no folder on this machine
-        (noted once per run; links into it go unchecked), and CRLF line
-        endings (which the next ``update`` normalizes) are soft notes
-        (stderr) and do not count as issues.
+        generated link block's broken-link check is the hard surface; a
+        target outside the root resolves only under a folder
+        ``links.external`` allowlists), a link to a real file outside
+        every allowlisted folder (noted with the entry to add), a
+        ``links.external`` entry naming no folder on this machine (noted
+        once per run; links into it go unchecked), and CRLF line endings
+        (which the next ``update`` normalizes) are soft notes (stderr)
+        and do not count as issues.
 
         Args:
             name: Restrict scope to named subtree (relative
@@ -2605,6 +2617,26 @@ class Wiki:
             event = LinkStaleEvent(message, **kwargs)
         return self.on_notice(event, logging_level=logging_level)
 
+    def on_link_outside(
+        self: Wiki,
+        message: Optional[str] = None,
+        *,
+        logging_level: int = logging.INFO,
+        event: Optional[LinkOutsideEvent] = None,
+        **kwargs: Any,
+    ) -> Event:
+        """Handle an outside-link notice event.
+
+        Constructs a ``LinkOutsideEvent`` from ``message`` and the
+        payload kwargs (the live-site path) unless a pre-built ``event``
+        is passed through, then delegates to ``on_notice``. Override in
+        subclasses to intercept this notice kind alone; override
+        ``on_notice`` to intercept every notice.
+        """
+        if event is None:
+            event = LinkOutsideEvent(message, **kwargs)
+        return self.on_notice(event, logging_level=logging_level)
+
     def on_link_folder_missing(
         self: Wiki,
         message: Optional[str] = None,
@@ -3151,6 +3183,100 @@ class Wiki:
             if self._is_excluded_dir(current):
                 return False
         return True
+
+    def _external_folder(self: Wiki, path: pathlib.Path) -> Optional[pathlib.Path]:
+        """Return the ``links.external`` folder holding ``path``, or ``None``.
+
+        Containment is lexical, like every link probe: a link means what
+        its text says, and only a stat follows. The most specific entry
+        wins, so an ancestor beside an absent sibling never answers for
+        the sibling's targets.
+        """
+        holders = []
+        for _folder, joined in self._links_policy:
+            if path.is_relative_to(joined):
+                holders.append(joined)
+        if not holders:
+            return None
+        return max(holders, key=lambda folder: len(folder.parts))
+
+    def _is_link_wiki_root(self: Wiki, path: pathlib.Path) -> bool:
+        """Return ``True`` if ``path`` holds another wiki's settings marker.
+
+        The home directory and the config home are exempt, as the CLI's
+        root resolution exempts them: the trust store lives at
+        ``~/.wiki/settings.json`` (or under ``WIKI_CONFIG_DIR``), so a
+        home that read as a root would answer for every folder beneath
+        it.
+        """
+        if path.resolve() == pathlib.Path.home().resolve():
+            return False
+        override = os.environ.get(WIKI_CONFIG_DIR)
+        if override:
+            config_home = pathlib.Path(override).expanduser()
+        else:
+            config_home = pathlib.Path.home() / WIKI_DIR
+        if (path / WIKI_DIR).resolve() == config_home.resolve():
+            return False
+        return os.path.isfile(path / WIKI_SETTINGS)
+
+    def _link_wiki(
+        self: Wiki,
+        path: pathlib.Path,
+        folder: pathlib.Path,
+    ) -> Optional[tuple[pathlib.Path, Wiki]]:
+        """Return the wiki enclosing external ``path`` under ``folder``, or ``None``.
+
+        The root is the nearest ancestor holding the settings marker, as
+        the CLI resolves any root; nested wikis are refused everywhere, so
+        the first marker up the chain is the root, and the walk stops at
+        the allowlisted ``folder`` -- an entry inside a wiki admits its
+        files as plain files. The instance is the plain class (a hook
+        loads only through the CLI's trust check), constructed once per
+        instance, and its settings are read as the host's are: a
+        malformed block fails the run naming the wiki. Returns the
+        marker's folder beside the instance, whose own root is resolved.
+        """
+        for ancestor in (path, *path.parents):
+            if self._is_link_wiki_root(ancestor):
+                if ancestor not in self._link_wikis:
+                    guest = Wiki(ancestor)
+                    try:
+                        guest._exclude_policy  # noqa: B018
+                    except ValueError as e:
+                        relative = os.path.relpath(ancestor, self._root)
+                        raise ValueError(
+                            f'links.external wiki {relative!r}: {e}'
+                        ) from e
+                    self._link_wikis[ancestor] = guest
+                return ancestor, self._link_wikis[ancestor]
+            if ancestor == folder:
+                return None
+        return None
+
+    def _external_spelling(
+        self: Wiki,
+        reading: pathlib.Path,
+        page: pathlib.Path,
+    ) -> Optional[str]:
+        """Return the page-relative spelling of the allowlisted file ``reading`` names.
+
+        ``reading`` is a target read as if from the wiki root, or an
+        absolute target; when it lands under an allowlisted folder present
+        on this machine and names a real file, page, or folder there, the
+        fix is the same path spelled from ``page``'s folder, the form the
+        scan reads. ``None`` otherwise: a target that reaches nothing has
+        no fix to suggest.
+        """
+        if reading.is_relative_to(self._root):
+            return None
+        folder = self._external_folder(reading)
+        if (folder is None) or not os.path.isdir(folder):
+            return None
+        page_form = reading.parent / (reading.name + '.md')
+        if not (os.path.exists(page_form) or os.path.exists(reading)):
+            return None
+        return pathlib.Path(os.path.relpath(reading, page.parent)).as_posix()
 
     def _is_symlink_skipped(self: Wiki, target: str) -> bool:
         """Return ``True`` if link ``target`` names a symlinked file on disk.
@@ -5019,6 +5145,24 @@ class Wiki:
                 )
         return result
 
+    def _root_relative_form(self: Wiki, resolved: pathlib.Path) -> Optional[str]:
+        """Return the root-relative target an in-root path is linked by, or ``None``.
+
+        A page links by stem, a folder the walk indexes by its ``_index``
+        page (the bare folder form is the directory-link hard issue), and
+        any other folder or file by its bare path; ``None`` when nothing
+        exists there (an unresolvable target has no fix to suggest). The
+        probes go through ``os.path``, as the link scan's do.
+        """
+        if os.path.exists(resolved.with_name(resolved.name + '.md')):
+            return resolved.relative_to(self._root).as_posix()
+        if os.path.isfile(resolved / WIKI_INDEX) and self._is_indexed_dir(resolved):
+            index_target = resolved / WIKI_INDEX
+            return index_target.relative_to(self._root).with_suffix('').as_posix()
+        if os.path.exists(resolved):
+            return resolved.relative_to(self._root).as_posix()
+        return None
+
     def _canonical_link_target(
         self: Wiki,
         path: pathlib.Path,
@@ -5026,31 +5170,17 @@ class Wiki:
     ) -> Optional[str]:
         """Return the root-relative form of a folder-relative wikilink target.
 
-        Resolves ``target`` (e.g. ``../overview``) from ``path``'s folder and
-        expresses it relative to the wiki root, the form wikilinks use. Returns
-        the canonical target when it resolves inside the root -- a page, the
-        ``_index`` page of an indexed folder that has one, or any other
-        folder's bare form -- else ``None`` (an unresolvable target has no fix
-        to suggest).
+        Resolves ``target`` (e.g. ``overview``) from ``path``'s folder and
+        expresses it relative to the wiki root, the form prefix-free
+        wikilinks use. Returns the canonical target when it resolves
+        inside the root (see :meth:`_root_relative_form`) -- else ``None``.
         """
         # resolve the folder-relative target without touching the filesystem
         joined = os.path.normpath(path.parent / target)
         resolved = pathlib.Path(joined)
         if not resolved.is_relative_to(self._root):
             return None
-        # only suggest a target that actually exists (as a page or folder);
-        # os.path stats read an unstat-able path as missing, as the scan does
-        if os.path.exists(resolved.with_name(resolved.name + '.md')):
-            return resolved.relative_to(self._root).as_posix()
-        # a folder the walk indexes canonicalizes to its index page -- the
-        # bare folder form is the directory-link hard issue -- while an
-        # unindexed folder keeps the bare form, the shape lint leaves live
-        if os.path.isfile(resolved / WIKI_INDEX) and self._is_indexed_dir(resolved):
-            index_target = resolved / WIKI_INDEX
-            return index_target.relative_to(self._root).with_suffix('').as_posix()
-        if os.path.isdir(resolved):
-            return resolved.relative_to(self._root).as_posix()
-        return None
+        return self._root_relative_form(resolved)
 
     def _lint_stale_links(
         self: Wiki,
@@ -5059,22 +5189,39 @@ class Wiki:
     ) -> list[Issue]:
         """Check wikilinks in content; return the hard issues.
 
-        A directory link -- a target naming a folder rather than the
-        folder's index page -- renders but resolves to nothing when
-        followed, so it is a hard issue naming the ``/_index`` form as
-        the fix; only a folder the walk reaches qualifies, since a
-        dot-prefixed, symlinked, or ``exclude.patterns`` segment keeps
-        its whole subtree out of the index. A stale link in user content
-        is a soft note (``on_link_stale``), not an issue: prose
-        references pages that come and go, and the generated index link
-        block's broken-link check is the hard surface. Either way a
-        target reports once per file, and a link's display text rides
-        into the suggested fix so the replacement keeps its label.
-        Wikilinks in a code sample -- fenced, inline, or four-space
-        indented -- and in an HTML comment are not links to follow, so
-        neither rule sees them. Lines inside a well-formed ``no-lint``
-        region are exempt too; the region is parsed from the scanned
-        content itself, so the region must wrap the link lines.
+        Two spellings, one rule each: a prefix-free target is read from
+        the wiki root and must name something inside it; a target with a
+        ``.`` or ``..`` segment is read from the page's folder, as
+        Obsidian and markdown read it, and must leave the wiki -- one
+        that lands inside is a hard issue naming the prefix-free form
+        (and the file the text reaches when read from the root, if an
+        allowlisted one exists there). A directory link -- a target
+        naming a folder rather than the folder's index page -- renders
+        but resolves to nothing when followed, so it is a hard issue
+        naming the ``/_index`` form as the fix; only a folder a walk
+        reaches qualifies -- this wiki's, or that of another wiki a
+        ``links.external`` folder admits, judged by its own settings --
+        since a dot-prefixed, symlinked, or ``exclude.patterns`` segment
+        keeps its whole subtree out of the index. Outside the wiki a
+        target is live under an allowlisted folder present on this
+        machine when the file, its ``.md`` form, or the folder exists; a
+        target under an entry naming no folder here is left to the
+        run-level note; a real file under no allowlisted folder is a soft
+        note naming the entry to add (``on_link_outside``). A stale link
+        in user content is a soft note (``on_link_stale``), not an issue:
+        prose references pages that come and go, and the generated index
+        link block's broken-link check is the hard surface; the note
+        names the fix when a reading resolves -- the page-relative
+        spelling of an allowlisted file a prefixed or absolute target
+        missed, or the root-relative form a prefix-free target's
+        folder-relative reading names. Either way a target reports once
+        per file, and a link's display text rides into the suggested fix
+        so the replacement keeps its label. Wikilinks in a code sample --
+        fenced, inline, or four-space indented -- and in an HTML comment
+        are not links to follow, so no rule sees them. Lines inside a
+        well-formed ``no-lint`` region are exempt too; the region is
+        parsed from the scanned content itself, so the region must wrap
+        the link lines.
         """
         # initialize issues and the targets already reported for this file:
         # the scan is content-local, so a repeat of a target carries no line
@@ -5113,10 +5260,49 @@ class Wiki:
             anchor = target[len(page_target) :]
             if not page_target:
                 continue
-            # targets are root-relative by grammar, so a join that escapes the
-            # root ('..' segments) is stale even when a file exists above it
-            joined = pathlib.Path(os.path.normpath(self._root / page_target))
+            # a './' or '../' target is read from the page's folder, as
+            # Obsidian and markdown read it, and must leave the wiki; a
+            # prefix-free target is read from the root and must stay inside
+            segments = page_target.split('/')
+            prefixed = ('.' in segments) or ('..' in segments)
+            base = path.parent if prefixed else self._root
+            joined = pathlib.Path(os.path.normpath(base / page_target))
             if joined.is_relative_to(self._root):
+                # a prefixed target landing inside the wiki is a hard issue:
+                # the in-wiki form is prefix-free, the one spelling every
+                # reader resolves from the root, so name it -- and the file
+                # outside the wiki the text reaches when read from the root,
+                # if an allowlisted one exists
+                if prefixed:
+                    if target in reported:
+                        continue
+                    reported.add(target)
+                    canonical = self._root_relative_form(joined)
+                    reading = pathlib.Path(os.path.normpath(self._root / page_target))
+                    external = self._external_spelling(reading, path)
+                    fixes = []
+                    if canonical is not None:
+                        fixes.append(f'[[{canonical}{anchor}{alias}]]')
+                    if external is not None:
+                        fixes.append(
+                            f'[[{external}{anchor}{alias}]] for the file outside'
+                            ' the wiki'
+                        )
+                    fix = f' (use {", or ".join(fixes)})' if fixes else ''
+                    fields = {'path': str(relpath), 'target': target}
+                    if canonical is not None:
+                        fields['canonical'] = canonical + anchor
+                    if external is not None:
+                        fields['external'] = external + anchor
+                    result.append(
+                        Issue(
+                            f'{relpath}: Link [[{target}{alias}]] points inside'
+                            f" the wiki through './' or '../'{fix}",
+                            kind='relative_link',
+                            **fields,
+                        )
+                    )
+                    continue
                 # probe through os.path: a link target is authored text, so a
                 # path the filesystem cannot stat (a name past its length
                 # limit, an unreadable directory) is a missing target, never
@@ -5148,13 +5334,79 @@ class Wiki:
                     continue
                 if os.path.exists(self._root / page_target):
                     continue
+            elif not os.path.isabs(page_target):
+                folder = self._external_folder(joined)
+                if folder is None:
+                    # a real file under no allowlisted folder: name the entry
+                    # that would admit it rather than call the link stale
+                    page_form = joined.parent / (joined.name + '.md')
+                    if os.path.exists(page_form) or os.path.exists(joined):
+                        if target in reported:
+                            continue
+                        reported.add(target)
+                        holder = joined if os.path.isdir(joined) else joined.parent
+                        entry = pathlib.Path(os.path.relpath(holder, self._root))
+                        self.on_link_outside(
+                            path=str(relpath),
+                            target=target + alias,
+                            folder=entry.as_posix(),
+                        )
+                        continue
+                elif not os.path.isdir(folder):
+                    # an entry naming no folder on this machine leaves nothing
+                    # to check: the run-level note names it once
+                    continue
+                else:
+                    # a page by stem is live wherever it lies
+                    if os.path.exists(joined.parent / (joined.name + '.md')):
+                        continue
+                    # inside another wiki its own rules apply, exclusions
+                    # included: a folder that wiki indexes is the directory
+                    # link, judged by the instance built from its settings
+                    guest = self._link_wiki(joined, folder)
+                    if guest is not None:
+                        guest_root, guest_wiki = guest
+                        index_path = joined / WIKI_INDEX
+                        inner = guest_wiki._root / joined.relative_to(guest_root)
+                        if os.path.isfile(index_path) and guest_wiki._is_indexed_dir(
+                            inner
+                        ):
+                            if target in reported:
+                                continue
+                            reported.add(target)
+                            index_target = pathlib.Path(
+                                os.path.relpath(index_path, path.parent)
+                            )
+                            index_target = index_target.with_suffix('').as_posix()
+                            result.append(
+                                Issue(
+                                    f'{relpath}: Link [[{target}{alias}]] targets a'
+                                    ' folder, not a page'
+                                    f' (use [[{index_target}{anchor}{alias}]])',
+                                    kind='directory_link',
+                                    path=str(relpath),
+                                    target=target,
+                                    canonical=index_target + anchor,
+                                )
+                            )
+                            continue
+                    # the literal file or folder is there
+                    if os.path.exists(joined):
+                        continue
             if target in reported:
                 continue
             reported.add(target)
-            # a folder-relative link (e.g. [[../overview]]) is stale because
-            # wiki targets are root-relative; when it resolves to a real page
-            # from this file's folder, name the canonical form as the fix
-            canonical = self._canonical_link_target(path, page_target)
+            # name the fix when a reading resolves: a prefixed or absolute
+            # target read from the wiki root that lands on an allowlisted file
+            # gets its page-relative spelling; a prefix-free miss keeps the
+            # root-relative form of its folder-relative reading
+            if os.path.isabs(page_target):
+                canonical = self._external_spelling(joined, path)
+            elif prefixed:
+                reading = pathlib.Path(os.path.normpath(self._root / page_target))
+                canonical = self._external_spelling(reading, path)
+            else:
+                canonical = self._canonical_link_target(path, page_target)
             if (canonical is not None) and (canonical != page_target):
                 self.on_link_stale(
                     path=str(relpath),
@@ -5514,6 +5766,22 @@ class LinkStaleEvent(Event):
         return result
 
 
+class LinkOutsideEvent(Event):
+    """Emitted when lint notes a wikilink leaving the wiki for an unlisted file."""
+
+    path: str
+    target: str
+    folder: str
+
+    @property
+    def description(self: LinkOutsideEvent) -> str:
+        """Return the outside-link note line."""
+        return (
+            f'{self.path}: Link [[{self.target}]] points outside the wiki (add'
+            f' {self.folder!r} to links.external in {WIKI_SETTINGS} to allow it)'
+        )
+
+
 class LinkFolderMissingEvent(Event):
     """Emitted when lint finds a ``links.external`` entry naming no folder."""
 
@@ -5555,6 +5823,7 @@ _NOTICE_HOOKS = {
     ContentEmptyEvent: 'on_content_empty',
     CrlfNoticeEvent: 'on_crlf_notice',
     LinkStaleEvent: 'on_link_stale',
+    LinkOutsideEvent: 'on_link_outside',
     LinkFolderMissingEvent: 'on_link_folder_missing',
 }
 

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -156,7 +156,7 @@ class Wiki:
             return {}
         try:
             result = json.loads(path.read_text(encoding='utf-8'))
-        except json.JSONDecodeError as e:
+        except (ValueError, RecursionError) as e:
             raise ValueError(f'Malformed JSON in {WIKI_SETTINGS}: {e}') from e
         if not isinstance(result, dict):
             raise ValueError(f'{WIKI_SETTINGS} must be a JSON object.')
@@ -3181,6 +3181,16 @@ class Wiki:
                 return False
         return True
 
+    def _inside_root(self: Wiki, path: pathlib.Path) -> bool:
+        """Return ``True`` if the normalized absolute ``path`` lies under the wiki root.
+
+        Containment is by path components: ``is_relative_to`` spells every
+        ancestor of a path in full, a cost quadratic in the path's depth,
+        and a link's text (an unclosed link swallowing a page) can run to
+        thousands of segments.
+        """
+        return path.parts[: len(self._root.parts)] == self._root.parts
+
     def _external_folder(self: Wiki, path: pathlib.Path) -> Optional[pathlib.Path]:
         """Return the ``links.external`` folder holding ``path``, or ``None``.
 
@@ -3189,9 +3199,13 @@ class Wiki:
         wins, so an ancestor beside an absent sibling never answers for
         the sibling's targets.
         """
+        # contain by path components: both sides are normalized absolute
+        # paths, and the compare costs a fraction of is_relative_to over a
+        # long allowlist
+        parts = path.parts
         holders = []
         for _folder, joined in self._links_policy:
-            if path.is_relative_to(joined):
+            if parts[: len(joined.parts)] == joined.parts:
                 holders.append(joined)
         if not holders:
             return None
@@ -3205,27 +3219,40 @@ class Wiki:
         keep the pair in lockstep): the trust store lives at
         ``~/.wiki/settings.json`` (or under ``WIKI_CONFIG_DIR``), so a
         home that read as a root would answer for every folder beneath
-        it.
+        it. The marker folder is probed first: the CLI's twin climbs a
+        bounded chain from the working directory, while this one climbs a
+        link's every ancestor, so the realpath exemptions run only for a
+        folder holding one. Raises ``OSError`` for a marker present in a
+        visible folder that cannot be read -- an unreadable settings
+        file, not a plain folder.
         """
-        # a path no filesystem can hold (an embedded NUL) is no wiki root:
-        # resolve raises where the os.path probes return False
-        try:
-            resolved = path.resolve()
-        except ValueError:
+        # the marker folder first, through os.path: a path the filesystem
+        # cannot stat (a NUL, a symlink loop, a name past its length limit,
+        # an unsearchable ancestor) holds no marker
+        if not os.path.isdir(path / WIKI_DIR):
             return False
-        # compare resolved on both sides: an unresolved home or config home
-        # under a symlink would never match and the trust store would read
-        # as a wiki root
-        if resolved == pathlib.Path.home().resolve():
+        # compare through realpath on both sides: an unresolved home or config
+        # home under a symlink would never match and the trust store would
+        # read as a wiki root, and Path.resolve() raises on a symlink loop
+        # before 3.13 where realpath returns the path
+        home = pathlib.Path(os.path.realpath(pathlib.Path.home()))
+        if pathlib.Path(os.path.realpath(path)) == home:
             return False
-        override = os.environ.get(WIKI_CONFIG_DIR)
-        if override:
+        if override := os.environ.get(WIKI_CONFIG_DIR):
             config_home = pathlib.Path(override).expanduser()
         else:
             config_home = pathlib.Path.home() / WIKI_DIR
-        if (path / WIKI_DIR).resolve() == config_home.resolve():
+        config_home = pathlib.Path(os.path.realpath(config_home))
+        if pathlib.Path(os.path.realpath(path / WIKI_DIR)) == config_home:
             return False
-        return os.path.isfile(path / WIKI_SETTINGS)
+        # a marker absent from the visible folder is a plain folder; one the
+        # user cannot read is the caller's to report
+        marker = path / WIKI_SETTINGS
+        try:
+            os.stat(marker)
+        except FileNotFoundError:
+            return False
+        return os.path.isfile(marker)
 
     def _link_wiki(
         self: Wiki,
@@ -3237,35 +3264,55 @@ class Wiki:
         the CLI resolves any root; nested wikis are refused everywhere, so
         the first marker up the chain is the root, and the walk runs to
         the filesystem root -- an entry inside a wiki still hands its
-        files to that wiki's rules. The instance is the plain class (a
-        hook loads only through the CLI's trust check), and its notices
-        ride the host's funnel. Returns the marker's folder beside the
+        files to that wiki's rules. Returns the marker's folder beside the
         instance, whose own root is resolved.
         """
-        for ancestor in (path, *path.parents):
-            # judge each folder once per instance: the wiki rooted there, or
-            # None for a plain folder
+        # an absent ancestor holds no marker, so the walk starts at the deepest
+        # folder that exists, found from the filesystem root down without ever
+        # materializing the ancestors of a target thousands of segments long
+        # (an unclosed link swallowing a page), which pathlib spells in full
+        anchor, *parts = path.parts
+        deepest = pathlib.Path(anchor)
+        for part in parts:
+            candidate = deepest / part
+            if not os.path.isdir(candidate):
+                break
+            deepest = candidate
+        for ancestor in (deepest, *deepest.parents):
+            # judge each folder once per instance
             if ancestor not in self._link_wikis:
-                guest = None
-                if self._is_link_wiki_root(ancestor):
-                    # the guest's notices (its gitignore fence, say) ride the
-                    # host's funnel, where a capturing host sees them
-                    guest = Wiki(ancestor)
-                    guest.on_notice = self.on_notice
-                    # read the guest's settings as the host's: a malformed or
-                    # unreadable block fails the run naming the wiki
-                    try:
-                        guest._exclude_policy  # noqa: B018
-                    except (OSError, ValueError) as e:
-                        relative = os.path.relpath(ancestor, self._root)
-                        raise ValueError(
-                            f'links.external wiki {relative!r}: {e}'
-                        ) from e
-                self._link_wikis[ancestor] = guest
+                self._link_wikis[ancestor] = self._judge_link_wiki(ancestor)
             guest = self._link_wikis[ancestor]
             if guest is not None:
                 return ancestor, guest
         return None
+
+    def _judge_link_wiki(self: Wiki, folder: pathlib.Path) -> Optional[Wiki]:
+        """Return the wiki rooted at ``folder``, or ``None`` for a plain folder.
+
+        The instance is the plain class (a hook loads only through the
+        CLI's trust check), its notices (its gitignore fence, say) ride
+        the host's funnel where a capturing host sees them, and its
+        settings are read as the host's are: a malformed or unreadable
+        block -- or a marker the user cannot read -- fails the run naming
+        the wiki.
+        """
+        try:
+            if not self._is_link_wiki_root(folder):
+                return None
+            guest = Wiki(folder)
+            guest.on_notice = self.on_notice
+            guest._exclude_policy  # noqa: B018
+        except ValueError as e:
+            relpath = os.path.relpath(folder, self._root)
+            raise ValueError(f'links.external wiki {relpath!r}: {e}') from e
+        except OSError as e:
+            relpath = os.path.relpath(folder, self._root)
+            raise ValueError(
+                f'links.external wiki {relpath!r}: cannot read {WIKI_SETTINGS}'
+                f' ({e.strerror})'
+            ) from e
+        return guest
 
     def _external_index_target(
         self: Wiki,
@@ -3285,13 +3332,47 @@ class Wiki:
             return None
         guest_root, guest_wiki = guest
         index_path = joined / WIKI_INDEX
+        if not os.path.isfile(index_path):
+            return None
         # re-root onto the guest's resolved root, the base its probes contain
         # against, while joined keeps the lexical text the link wrote
         inner = guest_wiki._root / joined.relative_to(guest_root)
-        if os.path.isfile(index_path) and guest_wiki._is_indexed_dir(inner):
-            index_target = pathlib.Path(os.path.relpath(index_path, page.parent))
-            return index_target.with_suffix('').as_posix()
-        return None
+        if not guest_wiki._is_indexed_dir(inner):
+            return None
+        index_target = pathlib.Path(os.path.relpath(index_path, page.parent))
+        return index_target.with_suffix('').as_posix()
+
+    def _outside_entry(
+        self: Wiki,
+        joined: pathlib.Path,
+        page_form: pathlib.Path,
+    ) -> Optional[str]:
+        """Return the ``links.external`` entry that would admit ``joined``, or ``None``.
+
+        ``joined`` is a target outside the wiki that no entry covers, and
+        ``page_form`` its ``.md`` page form. The entry is the target when it
+        is itself a folder, else the folder holding it, spelled relative to
+        the wiki root; ``None`` when nothing real is there (the link is
+        stale) or when no entry could admit it -- a chain of ``..`` clamped
+        at the filesystem root, a symlink alias of the wiki itself, or a
+        folder name carrying a backslash names a folder the policy refuses.
+        """
+        if not (os.path.exists(page_form) or os.path.exists(joined)):
+            return None
+        if os.path.isdir(joined):
+            holder = joined
+        else:
+            holder = joined.parent
+        if holder.parent == holder:
+            return None
+        if self._inside_root(pathlib.Path(os.path.realpath(holder))):
+            return None
+        entry = pathlib.Path(os.path.relpath(holder, self._root))
+        spelling = entry.as_posix()
+        # a folder name carrying '\\' spells an entry the policy refuses
+        if '\\' in spelling:
+            return None
+        return spelling
 
     def _external_spelling(
         self: Wiki,
@@ -3308,7 +3389,7 @@ class Wiki:
         directory-link rule's fix. ``None`` otherwise: a target that
         reaches nothing has no fix to suggest.
         """
-        if reading.is_relative_to(self._root):
+        if self._inside_root(reading):
             return None
         folder = self._external_folder(reading)
         if (folder is None) or not os.path.isdir(folder):
@@ -3321,7 +3402,13 @@ class Wiki:
         spelling = pathlib.Path(os.path.relpath(reading, page.parent))
         if os.path.exists(page_form):
             return spelling.as_posix()
-        index_target = self._external_index_target(reading, page)
+        # a wiki whose settings will not read cannot say whether it indexes a
+        # folder there, so no hint is drawn from it; only a link whose own
+        # verdict needs that wiki fails the run naming it
+        try:
+            index_target = self._external_index_target(reading, page)
+        except ValueError:
+            return None
         if index_target is not None:
             return index_target
         if os.path.exists(reading):
@@ -5204,16 +5291,18 @@ class Wiki:
         exists there (an unresolvable target has no fix to suggest). The
         probes go through ``os.path``, as the link scan's do.
         """
-        # only suggest a target that actually exists (as a page, folder, or
-        # file); the root's stem would name a file beside the wiki, so the
-        # root reads as its index page below
-        page_form = resolved.with_name(resolved.name + '.md')
-        if (resolved != self._root) and os.path.exists(page_form):
+        # the root links by its index page even before update mints it: its
+        # bare form is the relative-link issue itself, and its stem would
+        # name a file beside the wiki
+        if resolved == self._root:
+            return pathlib.Path(WIKI_INDEX).stem
+        # only suggest a target that actually exists (as a page, folder, or file)
+        if os.path.exists(resolved.with_name(resolved.name + '.md')):
             return resolved.relative_to(self._root).as_posix()
         # a folder the walk indexes canonicalizes to its index page -- the
         # bare folder form is the directory-link hard issue -- while an
         # unindexed folder keeps the bare form, the shape lint leaves live
-        if os.path.isfile(resolved / WIKI_INDEX) and self._is_indexed_dir(resolved):
+        if os.path.isdir(resolved) and self._is_indexed_dir(resolved):
             index_target = resolved / WIKI_INDEX
             return index_target.relative_to(self._root).with_suffix('').as_posix()
         if os.path.exists(resolved):
@@ -5235,7 +5324,7 @@ class Wiki:
         # resolve the folder-relative target without touching the filesystem
         joined = os.path.normpath(path.parent / target)
         resolved = pathlib.Path(joined)
-        if not resolved.is_relative_to(self._root):
+        if not self._inside_root(resolved):
             return None
         return self._root_relative_form(resolved)
 
@@ -5282,7 +5371,7 @@ class Wiki:
         # directives are comments and would not survive it
         stripped = wiki.util.markdown.mask_comments(stripped)
         stripped = wiki.util.markdown.mask_indented_code(stripped)
-        for match in re.finditer(r'\[\[([^\]|]+)(?:\|([^\]]*))?', stripped):
+        for match in re.finditer(r'\[\[([^\]\[|]+)(?:\|([^\]]*))?', stripped):
             # the masked scan preserves line structure, so the match
             # offset maps straight to its source line
             lineno = stripped.count('\n', 0, match.start()) + 1
@@ -5298,8 +5387,8 @@ class Wiki:
             # drop an anchor suffix (#heading / #^block) for the existence check:
             # '#' is a denied name character, so the suffix always addresses
             # within the page (a bare [[#anchor]] is same-page, never stale)
-            page_target = target.partition('#')[0]
-            anchor = target[len(page_target) :]
+            page_target, hash_sign, heading = target.strip(' \t').partition('#')
+            anchor = hash_sign + heading
             if not page_target:
                 continue
             # a './' or '../' target is read from the page's folder, as
@@ -5311,10 +5400,10 @@ class Wiki:
             prefixed = (not absolute) and (('.' in segments) or ('..' in segments))
             base = path.parent if prefixed else self._root
             joined = pathlib.Path(os.path.normpath(base / page_target))
-            # the page form is spelled through the parent: with_name refuses
-            # the filesystem root, which a chain of '..' can reach
-            page_form = joined.parent / (joined.name + '.md')
-            if joined.is_relative_to(self._root):
+            # the page form is the text plus '.md', as the in-root probe reads
+            # it, so a trailing slash never names a page
+            page_form = pathlib.Path(os.path.normpath(base / (page_target + '.md')))
+            if self._inside_root(joined):
                 # a prefixed target landing inside the wiki is a hard issue naming
                 # the prefix-free form (the one spelling every reader resolves from
                 # the root) and the allowlisted file the text reaches when read
@@ -5325,13 +5414,17 @@ class Wiki:
                     reported.add(target)
                     canonical = self._root_relative_form(joined)
                     reading = pathlib.Path(os.path.normpath(self._root / page_target))
+                    # a miss from the page's folder may name a page from the root,
+                    # the in-wiki mirror of the outside alternative
+                    if (canonical is None) and self._inside_root(reading):
+                        canonical = self._root_relative_form(reading)
                     external = self._external_spelling(reading, path)
                     fixes = []
                     if canonical is not None:
                         fixes.append(f'[[{canonical}{anchor}{alias}]]')
                     if external is not None:
                         fixes.append(
-                            f'[[{external}{anchor}{alias}]] for the file outside'
+                            f'[[{external}{anchor}{alias}]] for the path outside'
                             ' the wiki'
                         )
                     options = ', or '.join(fixes)
@@ -5386,32 +5479,27 @@ class Wiki:
                 if folder is None:
                     # a real file under no allowlisted folder: name the entry
                     # that would admit it rather than call the link stale
-                    present = os.path.exists(page_form) or os.path.exists(joined)
-                    # the entry is the target when it is itself a folder, else
-                    # the folder holding it; a '..' chain clamped at the
-                    # filesystem root names an entry the policy refuses, and
-                    # that link stays stale
-                    if os.path.isdir(joined):
-                        holder = joined
-                    else:
-                        holder = joined.parent
-                    if present and (holder.parent != holder):
+                    entry = self._outside_entry(joined, page_form)
+                    if entry is not None:
                         if target in reported:
                             continue
                         reported.add(target)
-                        entry = pathlib.Path(os.path.relpath(holder, self._root))
-                        entry = entry.as_posix()
+                        # a folder holding an index file may be another wiki's,
+                        # where the link the entry admits is its index page
+                        canonical = None
+                        index_path = joined / WIKI_INDEX
+                        if os.path.isfile(index_path):
+                            spelling = os.path.relpath(index_path, path.parent)
+                            index_target = pathlib.Path(spelling).with_suffix('')
+                            canonical = index_target.as_posix() + anchor + alias
                         self.on_link_outside(
                             path=str(relpath),
                             target=target + alias,
                             folder=entry,
+                            canonical=canonical,
                         )
                         continue
-                elif not os.path.isdir(folder):
-                    # an entry naming no folder on this machine leaves nothing
-                    # to check: the run-level note names it once
-                    continue
-                else:
+                elif os.path.isdir(folder):
                     # a page by stem is live wherever it lies
                     if os.path.exists(page_form):
                         continue
@@ -5437,16 +5525,26 @@ class Wiki:
                     # the literal file or folder is there
                     if os.path.exists(joined):
                         continue
+                else:
+                    # an entry naming no folder on this machine leaves nothing
+                    # to check: the run-level note names it once
+                    continue
             if target in reported:
                 continue
             reported.add(target)
             # name the fix when a reading resolves: the page-relative spelling
-            # of an allowlisted file the text missed, else the root-relative form
-            if absolute:
+            # of an allowlisted file the text missed -- as written and
+            # normalized, else as read from the wiki root -- and for a
+            # prefix-free or in-root absolute miss the root-relative form
+            if absolute and self._inside_root(joined):
+                canonical = self._root_relative_form(joined)
+            elif absolute:
                 canonical = self._external_spelling(joined, path)
             elif prefixed:
-                reading = pathlib.Path(os.path.normpath(self._root / page_target))
-                canonical = self._external_spelling(reading, path)
+                canonical = self._external_spelling(joined, path)
+                if canonical is None:
+                    reading = pathlib.Path(os.path.normpath(self._root / page_target))
+                    canonical = self._external_spelling(reading, path)
             else:
                 canonical = self._canonical_link_target(path, page_target)
             if (canonical is not None) and (canonical != page_target):
@@ -5814,14 +5912,18 @@ class LinkOutsideEvent(Event):
     path: str
     target: str
     folder: str
+    canonical: Optional[str] = None
 
     @property
     def description(self: LinkOutsideEvent) -> str:
         """Return the outside-link note line."""
-        return (
+        result = (
             f'{self.path}: Link [[{self.target}]] points outside the wiki (add'
-            f' {self.folder!r} to links.external in {WIKI_SETTINGS} to allow it)'
+            f' {self.folder!r} to links.external in {WIKI_SETTINGS} to allow it'
         )
+        if self.canonical:
+            result += f', and link [[{self.canonical}]] if a wiki indexes the folder'
+        return result + ')'
 
 
 class LinkFolderMissingEvent(Event):

--- a/wiki/core/wiki.py
+++ b/wiki/core/wiki.py
@@ -432,6 +432,91 @@ class Wiki:
         return result
 
     @functools.cached_property
+    def _links_policy(self: Wiki) -> list[tuple[str, pathlib.Path]]:
+        """Return the ``links.external`` folders from ``settings.json``.
+
+        Validates the per-wiki ``links`` block (``external`` -- a list
+        of folder paths relative to the wiki root, each climbing out of
+        it with leading ``..`` segments) so a bad value fails loudly
+        with a file+key message rather than leaking a raw exception
+        from inside the link scan (settings.json is user input). Each
+        entry pairs the path as written with its folder joined onto the
+        root lexically -- never resolved, the containment every link
+        probe uses -- so a link means what its text says and a note can
+        name its cause; entries naming one folder collapse to the first
+        spelling.
+        """
+        # overlay the settings.json links block onto the default
+        override = self._settings.get('links', {})
+        if not isinstance(override, dict):
+            raise ValueError(
+                f'The links block must be a JSON object in {WIKI_SETTINGS}.'
+            )
+        external = override.get('external', [])
+        if not isinstance(external, list):
+            raise ValueError(
+                f'links.external must be a list of folder paths, got'
+                f' {external!r} in {WIKI_SETTINGS}.'
+            )
+        # contain each folder lexically, keeping its text as written so a
+        # note names its cause; the grammar mirrors exclude.patterns (one
+        # trailing '/' stripped, '/' the separator, no '.' segments) except
+        # that leading '..' segments are the point -- a folder inside the
+        # root needs no allowlist -- and no entry may name the whole
+        # filesystem or reach the root through an alias
+        result = []
+        for folder in external:
+            if not isinstance(folder, str):
+                raise ValueError(
+                    f'links.external entry must be a string, got'
+                    f' {folder!r} in {WIKI_SETTINGS}.'
+                )
+            stripped = folder[:-1] if folder.endswith('/') else folder
+            segments = stripped.split('/')
+            climb = 0
+            while (climb < len(segments)) and (segments[climb] == '..'):
+                climb += 1
+            joined = pathlib.Path(os.path.normpath(self._root / stripped))
+            if not stripped.strip():
+                reason = 'empty or whitespace-only path'
+            elif stripped.startswith(('/', '~')):
+                reason = (
+                    "absolute and '~' paths are not allowed"
+                    ' (use a path relative to the wiki root)'
+                )
+            elif '\\' in folder:
+                reason = "use '/' as the separator (no '\\')"
+            elif any(char in folder for char in '#|]\0'):
+                reason = (
+                    "contains '#', '|', ']', or a NUL character, which no"
+                    ' wikilink target can carry'
+                )
+            elif '' in segments:
+                reason = "empty segment ('//')"
+            elif '.' in segments:
+                reason = "'.' segments are not allowed"
+            elif '..' in segments[climb:]:
+                reason = "'..' segments are allowed only at the start"
+            elif joined.parent == joined:
+                reason = 'names the whole filesystem'
+            elif joined.is_relative_to(self._root):
+                reason = 'inside the wiki root (in-wiki links need no allowlist)'
+            elif pathlib.Path(os.path.realpath(joined)).is_relative_to(self._root):
+                reason = 'aliases the wiki root'
+            else:
+                reason = None
+            if reason is not None:
+                raise ValueError(
+                    f'Invalid links.external folder {folder!r}: {reason}'
+                    f' in {WIKI_SETTINGS}.'
+                )
+            # one folder, one entry: a repeated spelling adds nothing
+            if any(joined == seen for _folder, seen in result):
+                continue
+            result.append((folder, joined))
+        return result
+
+    @functools.cached_property
     def _gitignore_fence(self: Wiki) -> frozenset[str]:
         """Return the root-relative POSIX paths the repo's gitignore fences.
 
@@ -596,6 +681,20 @@ class Wiki:
             return
         self.on_merge_driver_unconfigured()
 
+    def _warn_missing_link_folders(self: Wiki) -> None:
+        """Note each ``links.external`` entry that names no folder on disk.
+
+        A sibling checkout the settings name may be absent on a clone,
+        or an entry may name a file: the links into it are neither live
+        nor stale, so lint names the entry once (soft) and the link scan
+        passes over targets under it rather than noting every one.
+        Reading the policy here also validates the block on every run,
+        links or none.
+        """
+        for folder, joined in self._links_policy:
+            if not os.path.isdir(joined):
+                self.on_link_folder_missing(folder=folder)
+
     def _name_violation(self: Wiki, name: str) -> Optional[str]:
         """Return the naming rule ``name`` breaks, or ``None`` if it is valid.
 
@@ -699,12 +798,13 @@ class Wiki:
         violation = self._name_violation(name)
         if violation is not None:
             raise ValueError(f'Invalid wiki name {name!r}: {violation}')
-        # the titles, map, and exclude policies are read lazily (first inside
-        # the plan, the map render, and the walk), so touch them here to
-        # reject a bad seed early
+        # the titles, map, exclude, and links policies are read lazily (first
+        # inside the plan, the map render, the walk, and lint's folder check),
+        # so touch them here to reject a bad seed early
         self._titles_required  # noqa: B018
         self._map_policy  # noqa: B018
         self._exclude_policy  # noqa: B018
+        self._links_policy  # noqa: B018
         # alias current timestamp
         now = self._utc_now()
         # initialize wiki root
@@ -1262,8 +1362,10 @@ class Wiki:
         Placeholder and oversized descriptions, empty content sections,
         stale links in user content (index bodies and pages -- the
         generated link block's broken-link check is the hard surface),
-        and CRLF line endings (which the next ``update`` normalizes)
-        are soft notes (stderr) and do not count as issues.
+        a ``links.external`` entry naming no folder on this machine
+        (noted once per run; links into it go unchecked), and CRLF line
+        endings (which the next ``update`` normalizes) are soft notes
+        (stderr) and do not count as issues.
 
         Args:
             name: Restrict scope to named subtree (relative
@@ -1291,6 +1393,10 @@ class Wiki:
         # clone's first merge pays for it
         self._warn_unconfigured_merge_driver()
         self._warn_untrackable_rows(folder)
+        # a links.external entry naming no folder on this machine is one note
+        # per run, not one per link; reading the policy here also fails a
+        # malformed block before the walk, links or none
+        self._warn_missing_link_folders()
         # compute what update would write (the source of truth for drift)
         now = self._utc_now()
         overlay, _, _ = self._plan(folder, now=now)
@@ -2497,6 +2603,26 @@ class Wiki:
         """
         if event is None:
             event = LinkStaleEvent(message, **kwargs)
+        return self.on_notice(event, logging_level=logging_level)
+
+    def on_link_folder_missing(
+        self: Wiki,
+        message: Optional[str] = None,
+        *,
+        logging_level: int = logging.WARNING,
+        event: Optional[LinkFolderMissingEvent] = None,
+        **kwargs: Any,
+    ) -> Event:
+        """Handle a missing-link-folder notice event.
+
+        Constructs a ``LinkFolderMissingEvent`` from ``message`` and the
+        payload kwargs (the entry as written) unless a pre-built
+        ``event`` is passed through, then delegates to ``on_notice``.
+        Override in subclasses to intercept this notice kind alone;
+        override ``on_notice`` to intercept every notice.
+        """
+        if event is None:
+            event = LinkFolderMissingEvent(message, **kwargs)
         return self.on_notice(event, logging_level=logging_level)
 
     def on_notice(
@@ -5388,6 +5514,20 @@ class LinkStaleEvent(Event):
         return result
 
 
+class LinkFolderMissingEvent(Event):
+    """Emitted when lint finds a ``links.external`` entry naming no folder."""
+
+    folder: str
+
+    @property
+    def description(self: LinkFolderMissingEvent) -> str:
+        """Return the missing-link-folder note line."""
+        return (
+            f'links.external entry {self.folder!r} names no folder on this'
+            ' machine; links into it are not checked'
+        )
+
+
 # plan-phase dispatch: event class -> per-kind hook name (kept in lockstep
 # with the events above; the CLI's _UPDATE_CATEGORIES keys on the same classes)
 _NOTICE_HOOKS = {
@@ -5415,6 +5555,7 @@ _NOTICE_HOOKS = {
     ContentEmptyEvent: 'on_content_empty',
     CrlfNoticeEvent: 'on_crlf_notice',
     LinkStaleEvent: 'on_link_stale',
+    LinkFolderMissingEvent: 'on_link_folder_missing',
 }
 
 

--- a/wiki/skills/wiki/SKILL.md
+++ b/wiki/skills/wiki/SKILL.md
@@ -60,7 +60,7 @@ rather than authoring or auditing page by page yourself:
   sub-agent, then run `wiki update` once to stitch the new pages into the
   indexes. Update adds and repairs index link rows and frontmatter only — it
   never linkifies mentions in page prose, so author `[[...]]` cross-links by
-  hand.
+  hand, root-relative inside the wiki.
 - **Drive sweeps with a dynamic workflow.** When auditing, relinking, or
   restructuring an existing wiki, pipeline its pages through a workflow so each
   is read, revised, and verified on its own — slow pages never block fast ones.
@@ -137,9 +137,42 @@ rather than authoring or auditing page by page yourself:
   block whose repair would leave a strict reader worse off (an accepted block
   rejected, or authored lines folded into a quoted value), which it leaves
   untouched.
-- **Wikilinks stay inside the wiki.** A wikilink (`[[...]]`) must target another
-  page in the same wiki. Files outside the wiki (source files, configs, another
-  wiki's pages) can be referenced by name or in backticks, but never linked.
+- **Wikilinks stay inside the wiki unless a folder is allowlisted.** A wikilink
+  (`[[...]]`) has two spellings, one rule each: a prefix-free target
+  (`[[core/design]]`) is relative to the wiki root and must name something
+  inside it; a target starting with `./` or `../` (or carrying a `.` or `..`
+  segment anywhere) is relative to the page's folder, as Obsidian and markdown
+  read it, and must leave the wiki — one `..` per folder of depth, so the same
+  external file is spelled differently from different pages
+  (`[[../math/lemmas]]` from a root-level page, `[[../../math/lemmas]]` from
+  `nodes/verify.md`). Such a link is live only under a folder the wiki
+  allowlists in `links.external` in `.wiki/settings.json`: a list of folder
+  paths relative to the wiki root (not the page), each climbing out of it with
+  leading `..`, e.g. `{"links": {"external": ["../src", "../math"]}}`. List the
+  narrowest folder holding the targets, and a folder, never a file. Under an
+  allowlisted folder the target is live when the file, its `.md` page, or the
+  folder exists; a target inside another wiki (a folder holding
+  `.wiki/settings.json`) follows that wiki's own settings, so a folder it
+  indexes fails lint exactly as at home
+  (`Link [[../math/g2]] targets a folder, not a page (use [[../math/g2/_index]])`).
+  Link a file or the `_index` page, never a bare folder — stricter link checkers
+  reject a bare folder link too. A prefixed link that lands inside the wiki
+  fails lint (`points inside the wiki through './' or '../'`), naming the
+  prefix-free spelling, or the page-relative spelling of the outside file the
+  same text reaches when read from the wiki root
+  (`(use [[../../src/main.py]] for the file outside the wiki)`); a link to a
+  real file outside every allowlisted folder draws the note
+  `points outside the wiki (add '../docs' to links.external in .wiki/settings.json to allow it)`.
+  Link when the reader should open the file; a passing mention, or anything
+  outside every allowlisted folder, goes in backticks. The allowlist is a lint
+  rule alone: `wiki read` never serves an external target (use
+  `wiki read --path <its root>` for another wiki, `cat` for a file), generated
+  index rows never carry one, and `wiki map` never shows an external folder.
+  Obsidian cannot see outside the vault, so an external link shows unresolved
+  there — do not click it: Obsidian creates the missing target at that path, as
+  folders outside the vault. `wiki match '\[\[\.\.?/' --lines` lists every link
+  opening with `./` or `../` (code samples included; the `wiki lint` findings
+  are the authoritative list).
 - **Lint's output contract.** `wiki lint` prints issues to stdout and soft notes
   to stderr; exit 1 means exactly "issues found" (0 clean, 2 a command error) —
   notes never gate. A script must branch on the exit code or read
@@ -148,12 +181,23 @@ rather than authoring or auditing page by page yourself:
   fields beside the prose `text`), never classify findings by scraping the prose
   streams: a stderr note is not a blocking issue.
 - **Stale wikilinks are soft notes.** A `[[...]]` in index or page prose whose
-  target no longer exists draws a stderr note from `wiki lint` without failing
-  the run. Broken links in the generated index link block — the rows
-  `wiki update` maintains — are hard issues until the next update prunes them
-  (each removal announced, with the cause named when the target is merely
-  excluded rather than deleted), as is a prose wikilink naming a folder rather
-  than the folder's index page: link `[[folder/_index]]`, never `[[folder]]`.
+  target no longer exists — inside the wiki or under a `links.external` folder —
+  draws a stderr note from `wiki lint` without failing the run; when the same
+  text read from the wiki root names a real allowlisted file (a link written
+  root-relative or absolute), the note suggests its page-relative spelling. A
+  prose link to a real file outside every allowlisted folder is the
+  `points outside the wiki` note naming the entry to add; a `links.external`
+  entry naming no folder on this machine draws one note per run
+  (`links.external entry '../src' names no folder on this machine; links into it are not checked`)
+  and the links into it draw no notes — an environment condition, so leave them
+  alone. Broken links in the generated index link block — the rows `wiki update`
+  maintains — are hard issues until the next update prunes them (each removal
+  announced, with the cause named when the target is merely excluded rather than
+  deleted), as is a prose wikilink naming a folder rather than the folder's
+  index page — in this wiki or in another wiki a `links.external` folder admits:
+  link `[[folder/_index]]`, never `[[folder]]` — and a `./` or `../` prose link
+  that lands inside the wiki (`points inside the wiki through './' or '../'`),
+  which names the prefix-free spelling to write instead.
 - **Descriptions end in a period.** `wiki lint` fails a `desc` (or an authored
   link description) that lacks a trailing period; the seeded `...` placeholder
   only draws a soft note. Author the desc in the child page's frontmatter —

--- a/wiki/skills/wiki/SKILL.md
+++ b/wiki/skills/wiki/SKILL.md
@@ -158,21 +158,24 @@ rather than authoring or auditing page by page yourself:
   Link a file or the `_index` page, never a bare folder — stricter link checkers
   reject a bare folder link too. A prefixed link that lands inside the wiki
   fails lint (`points inside the wiki through './' or '../'`), naming the
-  prefix-free spelling, or the page-relative spelling of the outside file the
-  same text reaches when read from the wiki root
-  (`(use [[../../src/main.py]] for the file outside the wiki)`); a link to a
+  prefix-free spelling (of the page-relative reading when something exists
+  there, else of the same text read from the wiki root; the root itself is
+  `_index`), or the page-relative spelling of the outside file the same text
+  reaches when read from the wiki root
+  (`(use [[../../src/main.py]] for the path outside the wiki)`); a link to a
   real file outside every allowlisted folder draws the note
-  `points outside the wiki (add '../docs' to links.external in .wiki/settings.json to allow it)`.
-  Link when the reader should open the file; a passing mention, or anything
-  outside every allowlisted folder, goes in backticks. The allowlist is a lint
-  rule alone: `wiki read` never serves an external target (use
-  `wiki read --path <its root>` for another wiki, `cat` for a file), generated
-  index rows never carry one, and `wiki map` never shows an external folder.
-  Obsidian cannot see outside the vault, so an external link shows unresolved
-  there — do not click it: Obsidian creates the missing target at that path, as
-  folders outside the vault. `wiki match '\[\[\.\.?/' --lines` lists every link
-  opening with `./` or `../` (code samples included; the `wiki lint` findings
-  are the authoritative list).
+  `points outside the wiki (add '../docs' to links.external in .wiki/settings.json to allow it)`
+  (for a folder holding an `_index.md`, adding
+  `, and link [[../docs/_index]] if a wiki indexes the folder`). Link when the
+  reader should open the file; a passing mention, or anything outside every
+  allowlisted folder, goes in backticks. The allowlist is a lint rule alone:
+  `wiki read` never serves an external target (use `wiki read --path <its root>`
+  for another wiki, `cat` for a file), generated index rows never carry one, and
+  `wiki map` never shows an external folder. Obsidian cannot see outside the
+  vault, so an external link shows unresolved there — do not click it: Obsidian
+  creates the missing target at that path, as folders outside the vault.
+  `wiki match '\[\[\.\.?/' --lines` lists every link opening with `./` or `../`
+  (code samples included; the `wiki lint` findings are the authoritative list).
 - **Lint's output contract.** `wiki lint` prints issues to stdout and soft notes
   to stderr; exit 1 means exactly "issues found" (0 clean, 2 a command error) —
   notes never gate. A script must branch on the exit code or read
@@ -184,8 +187,9 @@ rather than authoring or auditing page by page yourself:
   target no longer exists — inside the wiki or under a `links.external` folder —
   draws a stderr note from `wiki lint` without failing the run; when the same
   text read from the wiki root names a real allowlisted file (a link written
-  root-relative or absolute), the note suggests its page-relative spelling. A
-  prose link to a real file outside every allowlisted folder is the
+  root-relative or absolute), the note suggests its page-relative spelling, and
+  a target missing only by a trailing slash the same path without it. A prose
+  link to a real file outside every allowlisted folder is the
   `points outside the wiki` note naming the entry to add; a `links.external`
   entry naming no folder on this machine draws one note per run
   (`links.external entry '../src' names no folder on this machine; links into it are not checked`)


### PR DESCRIPTION
## Summary

Wikilinks may now leave the wiki into folders the wiki allowlists in `.wiki/settings.json`:

```json
{"links": {"external": ["../src", "../math"]}}
```

Entries are folder paths relative to the wiki root, each climbing out of it with leading `..` (an ancestor such as `..` is allowed; the filesystem root, a path inside the wiki, and a symlink alias of it are refused at load time).

- **Two link bases, one rule each.** A prefix-free target (`[[core/design]]`) is read from the wiki root and must name something inside it. A `./` or `../` target is read from the page's folder, as Obsidian and markdown read it, and must leave the wiki. A prefixed link that lands inside the wiki is a new hard issue, `relative_link`, naming the prefix-free spelling (and, when the same text read from the wiki root reaches a real file under an allowlisted folder, that file's page-relative spelling too).
- **Verdicts outside the wiki.** Under a present allowlisted folder a target is live when the file, its `.md` page, or the folder exists, and a soft `Stale link` note otherwise. A real file outside every entry draws a note naming the entry to add (`link_outside`). An entry naming no folder on this machine draws one note per run and the links into it go unchecked (`link_folder_missing`).
- **Other wikis.** A target inside another wiki (a `.wiki/settings.json` marker anywhere up the chain, the home and config home excepted) is judged by that wiki's own settings: a page by stem is live, a folder it indexes is the `directory_link` issue naming its `_index` page, a folder its `exclude.patterns` or gitignore keeps out is live. The read is a JSON parse; none of that wiki's code runs. A malformed or unreadable settings file there fails lint naming that wiki.
- **The allowlist is a lint rule alone.** `read`, `map`, `match`, `search`, `update`, and `new` stay confined to the root, and generated index rows never carry an external target.
- **Probe hardening.** Every link-target probe goes through `os.path`, so a target the filesystem cannot stat (unreadable, overlong, NUL-carrying) reads as missing on Python 3.11 to 3.13 as well, where `pathlib` re-raises those errors.

Docs, the skill, and the changelog describe the two bases, the allowlist grammar, the verdicts, and the Obsidian caveat (Obsidian cannot see outside the vault, so an external link shows unresolved; clicking it creates the target).

## Decisions

Recorded in the plan at `scratch/plans/2026-09-02T00:17:28Z-wiki_external_link_allowlist.md`: a missing allowlisted target is a soft note; an absent entry is one run-level note; a link into a non-allowlisted folder names the entry to add only when something real is there; ancestor entries are allowed; the read/map/match/search surfaces stay confined; another wiki's folders follow that wiki's own settings; the raw-file suggestion applies inside the wiki too; fractal seeding is deferred; the patterns wiki only rewords three sentences; `./` and `../` links must leave the wiki and are read from the page's folder.

## Testing

- Python 3.14: full suite, 2762 passed (`uv run --no-sync pytest`).
- Python 3.13 (manual environment; CI runs 3.14 only): core suite, 2482 passed, with two pre-existing read-only search tests deselected (`test_search_heals_a_readonly_index_family`, `test_search_raises_once_for_a_readonly_cache_dir`) that fail on `dev` as well and are unrelated to this change.
- Python 3.11 and 3.12 (manual environments): the link, lint, and wiki test modules, 352 passed each.
- `sphinx-build -W` and `pre-commit run --all-files` are clean.
- Review loop: three rounds of independent review and stress testing with real wikis in temp dirs on all four interpreters (link-grammar fuzzing, fix adoption as a property, settings fuzzing, a two-wiki git repository end to end, hostile filesystems, guest-wiki configurations, CLI contracts, scale, idempotence), every finding re-verified by reproduction before it was acted on; a patterns-wiki audit closed the loop.

## Hardening from the review loop

The last commit carries the loop's findings:

- Every probe on link-derived text goes through `os.path`, and the guest-wiki marker walk resolves through `os.path.realpath`: `Path.resolve()` raises on a symlink loop under Python 3.11 and 3.12, and pathlib on 3.12+ spells out every ancestor of a path, so `(path, *path.parents)` and `is_relative_to` were quadratic in a target's depth. Containment is now a path-components compare and the walk starts at the deepest existing folder, so an unclosed link swallowing a 5000-line page lints in 0.2 s (the dev build takes 13.5 s on the same fixture).
- The `.wiki` folder is probed before the home and config-home exemptions, and the exemptions before the marker's readability, so an unreadable `~/.wiki` still counts as no wiki; an unreadable marker inside a visible `.wiki` fails lint naming the wiki (`cannot read .wiki/settings.json (Permission denied)`), never with an absolute path.
- A wikilink target is read without surrounding spaces and tabs, so `[[ page ]]` links `page`; a target carrying `[` (`[[[page]]`) is junk no name can carry and stays the stale note it always was, quoted as written, so a typo before `../` no longer turns into a depth-dependent hard issue.
- Every `(use [[...]])` suggestion lints clean when adopted: the root names `_index` (minted or not), an indexed folder names `_index` before its index is minted, a miss from the page's folder falls back to the text read from the root, a trailing-slash miss is steered at any depth, a guest-indexed folder is spelled by its `_index` page, the outside note for a folder holding an `_index.md` adds the index spelling, and no note names an entry the policy would refuse (a symlink alias of the wiki, the filesystem root, a folder name carrying a backslash).
- A guest whose settings will not read fails only a link whose own verdict needs that wiki; a suggestion never fails the run. `_settings` wraps every parse failure as `Malformed JSON in .wiki/settings.json`.

## Follow-ups (not in this PR)

- A CI leg for Python 3.11 to 3.13; the probe fix is verified manually on 3.13 here.
- The patterns wiki's three reworded sentences are edited in the `patterns` repo but not committed there.
- Seeding `links.external` from fractal, and aligning collatz `reflint` with the page-relative base.
- The core root predicate (`_is_link_wiki_root`) mirrors the CLI's `_is_wiki_root`; moving both onto a shared helper in `wiki/util/` is a separate refactor. The CLI's copy still compares `Path.resolve()`, so a looped `HOME` fails every command on 3.11 and 3.12 (pre-existing).
- Pre-existing and unchanged: an absolute target that lands inside the wiki lints live; the link scan's line-number count is quadratic in a page's link count; a mode-000 folder inside the wiki crashes the walk; a FIFO named `.gitignore` hangs `git check-ignore`.
